### PR TITLE
fix: enable fetching of all history in the upgrade compatibility check (cont'd)

### DIFF
--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -90,6 +90,10 @@ jobs:
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
+        with:
+          # Fetch the history of all branches and tags.
+          # This is needed for the test suite to switch between releases.
+          fetch-depth: 0
               
       - name: Set up Ginkgo CLI
         run: |
@@ -128,6 +132,10 @@ jobs:
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
+        with:
+          # Fetch the history of all branches and tags.
+          # This is needed for the test suite to switch between releases.
+          fetch-depth: 0
               
       - name: Set up Ginkgo CLI
         run: |


### PR DESCRIPTION
### Description of your changes

This PR enables fetching of all history in the upgrade compatibility check.

(The prev. PR misses two test suites)

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

N/A

### Special notes for your reviewer


