### PR TITLE
fix: fix the override e2e flakiness by waiting for the override snapshot to appear

### DIFF
--- a/test/e2e/placement_cro_test.go
+++ b/test/e2e/placement_cro_test.go
@@ -37,6 +37,7 @@ import (
 var _ = Context("creating clusterResourceOverride (selecting all clusters) to override all resources under the namespace", Ordered, func() {
 	crpName := fmt.Sprintf(crpNameTemplate, GinkgoParallelProcess())
 	croName := fmt.Sprintf(croNameTemplate, GinkgoParallelProcess())
+	croSnapShotName := fmt.Sprintf(placementv1alpha1.OverrideSnapshotNameFmt, croName, 0)
 
 	BeforeAll(func() {
 		By("creating work resources")
@@ -69,21 +70,14 @@ var _ = Context("creating clusterResourceOverride (selecting all clusters) to ov
 		}
 		By(fmt.Sprintf("creating clusterResourceOverride %s", croName))
 		Expect(hubClient.Create(ctx, cro)).To(Succeed(), "Failed to create clusterResourceOverride %s", croName)
+		//this is to make sure the cro snapshot is created before the CRP
+		Eventually(func() error {
+			croSnap := &placementv1alpha1.ClusterResourceOverrideSnapshot{}
+			return hubClient.Get(ctx, types.NamespacedName{Name: croSnapShotName}, croSnap)
+		}, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update ro as expected", crpName)
 
 		// Create the CRP.
-		crp := &placementv1beta1.ClusterResourcePlacement{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: crpName,
-				// Add a custom finalizer; this would allow us to better observe
-				// the behavior of the controllers.
-				Finalizers: []string{customDeletionBlockerFinalizer},
-			},
-			Spec: placementv1beta1.ClusterResourcePlacementSpec{
-				ResourceSelectors: workResourceSelector(),
-			},
-		}
-		By(fmt.Sprintf("creating placement %s", crpName))
-		Expect(hubClient.Create(ctx, crp)).To(Succeed(), "Failed to create CRP %s", crpName)
+		createCRP(crpName)
 	})
 
 	AfterAll(func() {
@@ -95,7 +89,7 @@ var _ = Context("creating clusterResourceOverride (selecting all clusters) to ov
 	})
 
 	It("should update CRP status as expected", func() {
-		wantCRONames := []string{fmt.Sprintf(placementv1alpha1.OverrideSnapshotNameFmt, croName, 0)}
+		wantCRONames := []string{croSnapShotName}
 		crpStatusUpdatedActual := crpStatusWithOverrideUpdatedActual(workResourceIdentifiers(), allMemberClusterNames, "0", wantCRONames, nil)
 		Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update CRP %s status as expected", crpName)
 	})
@@ -213,6 +207,7 @@ var _ = Context("creating clusterResourceOverride (selecting all clusters) to ov
 var _ = Context("creating clusterResourceOverride with multiple jsonPatchOverrides", Ordered, func() {
 	crpName := fmt.Sprintf(crpNameTemplate, GinkgoParallelProcess())
 	croName := fmt.Sprintf(croNameTemplate, GinkgoParallelProcess())
+	croSnapShotName := fmt.Sprintf(placementv1alpha1.OverrideSnapshotNameFmt, croName, 0)
 
 	BeforeAll(func() {
 		By("creating work resources")
@@ -251,20 +246,14 @@ var _ = Context("creating clusterResourceOverride with multiple jsonPatchOverrid
 		By(fmt.Sprintf("creating clusterResourceOverride %s", croName))
 		Expect(hubClient.Create(ctx, cro)).To(Succeed(), "Failed to create clusterResourceOverride %s", croName)
 
+		//this is to make sure the cro snapshot is created before the CRP
+		Eventually(func() error {
+			croSnap := &placementv1alpha1.ClusterResourceOverrideSnapshot{}
+			return hubClient.Get(ctx, types.NamespacedName{Name: croSnapShotName}, croSnap)
+		}, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update ro as expected", crpName)
+
 		// Create the CRP.
-		crp := &placementv1beta1.ClusterResourcePlacement{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: crpName,
-				// Add a custom finalizer; this would allow us to better observe
-				// the behavior of the controllers.
-				Finalizers: []string{customDeletionBlockerFinalizer},
-			},
-			Spec: placementv1beta1.ClusterResourcePlacementSpec{
-				ResourceSelectors: workResourceSelector(),
-			},
-		}
-		By(fmt.Sprintf("creating placement %s", crpName))
-		Expect(hubClient.Create(ctx, crp)).To(Succeed(), "Failed to create CRP %s", crpName)
+		createCRP(crpName)
 	})
 
 	AfterAll(func() {
@@ -276,7 +265,7 @@ var _ = Context("creating clusterResourceOverride with multiple jsonPatchOverrid
 	})
 
 	It("should update CRP status as expected", func() {
-		wantCRONames := []string{fmt.Sprintf(placementv1alpha1.OverrideSnapshotNameFmt, croName, 0)}
+		wantCRONames := []string{croSnapShotName}
 		crpStatusUpdatedActual := crpStatusWithOverrideUpdatedActual(workResourceIdentifiers(), allMemberClusterNames, "0", wantCRONames, nil)
 		Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update CRP %s status as expected", crpName)
 	})
@@ -312,6 +301,7 @@ var _ = Context("creating clusterResourceOverride with multiple jsonPatchOverrid
 var _ = Context("creating clusterResourceOverride with different rules for each cluster", Ordered, func() {
 	crpName := fmt.Sprintf(crpNameTemplate, GinkgoParallelProcess())
 	croName := fmt.Sprintf(croNameTemplate, GinkgoParallelProcess())
+	croSnapShotName := fmt.Sprintf(placementv1alpha1.OverrideSnapshotNameFmt, croName, 0)
 
 	BeforeAll(func() {
 		By("creating work resources")
@@ -387,20 +377,14 @@ var _ = Context("creating clusterResourceOverride with different rules for each 
 		By(fmt.Sprintf("creating clusterResourceOverride %s", croName))
 		Expect(hubClient.Create(ctx, cro)).To(Succeed(), "Failed to create clusterResourceOverride %s", croName)
 
+		//this is to make sure the cro snapshot is created before the CRP
+		Eventually(func() error {
+			croSnap := &placementv1alpha1.ClusterResourceOverrideSnapshot{}
+			return hubClient.Get(ctx, types.NamespacedName{Name: croSnapShotName}, croSnap)
+		}, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update ro as expected", crpName)
+
 		// Create the CRP.
-		crp := &placementv1beta1.ClusterResourcePlacement{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: crpName,
-				// Add a custom finalizer; this would allow us to better observe
-				// the behavior of the controllers.
-				Finalizers: []string{customDeletionBlockerFinalizer},
-			},
-			Spec: placementv1beta1.ClusterResourcePlacementSpec{
-				ResourceSelectors: workResourceSelector(),
-			},
-		}
-		By(fmt.Sprintf("creating placement %s", crpName))
-		Expect(hubClient.Create(ctx, crp)).To(Succeed(), "Failed to create CRP %s", crpName)
+		createCRP(crpName)
 	})
 
 	AfterAll(func() {
@@ -412,7 +396,7 @@ var _ = Context("creating clusterResourceOverride with different rules for each 
 	})
 
 	It("should update CRP status as expected", func() {
-		wantCRONames := []string{fmt.Sprintf(placementv1alpha1.OverrideSnapshotNameFmt, croName, 0)}
+		wantCRONames := []string{croSnapShotName}
 		crpStatusUpdatedActual := crpStatusWithOverrideUpdatedActual(workResourceIdentifiers(), allMemberClusterNames, "0", wantCRONames, nil)
 		Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update CRP %s status as expected", crpName)
 	})
@@ -429,7 +413,7 @@ var _ = Context("creating clusterResourceOverride with different rules for each 
 	})
 })
 
-var _ = Context("creating clusterResourceOverride with different rules for each cluster", Ordered, func() {
+var _ = Context("creating clusterResourceOverride with different rules for each cluster that is attached to a CRP", Ordered, func() {
 	crpName := fmt.Sprintf(crpNameTemplate, GinkgoParallelProcess())
 	croName := fmt.Sprintf(croNameTemplate, GinkgoParallelProcess())
 
@@ -507,6 +491,7 @@ var _ = Context("creating clusterResourceOverride with different rules for each 
 var _ = Context("creating clusterResourceOverride with incorrect path", Ordered, func() {
 	crpName := fmt.Sprintf(crpNameTemplate, GinkgoParallelProcess())
 	croName := fmt.Sprintf(croNameTemplate, GinkgoParallelProcess())
+	croSnapShotName := fmt.Sprintf(placementv1alpha1.OverrideSnapshotNameFmt, croName, 0)
 
 	BeforeAll(func() {
 		By("creating work resources")
@@ -540,20 +525,14 @@ var _ = Context("creating clusterResourceOverride with incorrect path", Ordered,
 		By(fmt.Sprintf("creating clusterResourceOverride %s", croName))
 		Expect(hubClient.Create(ctx, cro)).To(Succeed(), "Failed to create clusterResourceOverride %s", croName)
 
+		//this is to make sure the cro snapshot is created before the CRP
+		Eventually(func() error {
+			croSnap := &placementv1alpha1.ClusterResourceOverrideSnapshot{}
+			return hubClient.Get(ctx, types.NamespacedName{Name: croSnapShotName}, croSnap)
+		}, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update ro as expected", crpName)
+
 		// Create the CRP.
-		crp := &placementv1beta1.ClusterResourcePlacement{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: crpName,
-				// Add a custom finalizer; this would allow us to better observe
-				// the behavior of the controllers.
-				Finalizers: []string{customDeletionBlockerFinalizer},
-			},
-			Spec: placementv1beta1.ClusterResourcePlacementSpec{
-				ResourceSelectors: workResourceSelector(),
-			},
-		}
-		By(fmt.Sprintf("creating placement %s", crpName))
-		Expect(hubClient.Create(ctx, crp)).To(Succeed(), "Failed to create CRP %s", crpName)
+		createCRP(crpName)
 	})
 
 	AfterAll(func() {
@@ -565,7 +544,7 @@ var _ = Context("creating clusterResourceOverride with incorrect path", Ordered,
 	})
 
 	It("should update CRP status as expected", func() {
-		wantCRONames := []string{fmt.Sprintf(placementv1alpha1.OverrideSnapshotNameFmt, croName, 0)}
+		wantCRONames := []string{croSnapShotName}
 		crpStatusUpdatedActual := crpStatusWithOverrideUpdatedFailedActual(workResourceIdentifiers(), allMemberClusterNames, "0", wantCRONames, nil)
 		Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update CRP %s status as expected", crpName)
 	})
@@ -577,6 +556,7 @@ var _ = Context("creating clusterResourceOverride with incorrect path", Ordered,
 var _ = Context("creating clusterResourceOverride with and resource becomes invalid after override", Ordered, func() {
 	crpName := fmt.Sprintf(crpNameTemplate, GinkgoParallelProcess())
 	croName := fmt.Sprintf(croNameTemplate, GinkgoParallelProcess())
+	croSnapShotName := fmt.Sprintf(placementv1alpha1.OverrideSnapshotNameFmt, croName, 0)
 
 	BeforeAll(func() {
 		By("creating work resources")
@@ -610,20 +590,14 @@ var _ = Context("creating clusterResourceOverride with and resource becomes inva
 		By(fmt.Sprintf("creating clusterResourceOverride %s", croName))
 		Expect(hubClient.Create(ctx, cro)).To(Succeed(), "Failed to create clusterResourceOverride %s", croName)
 
+		//this is to make sure the cro snapshot is created before the CRP
+		Eventually(func() error {
+			croSnap := &placementv1alpha1.ClusterResourceOverrideSnapshot{}
+			return hubClient.Get(ctx, types.NamespacedName{Name: croSnapShotName}, croSnap)
+		}, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update ro as expected", crpName)
+
 		// Create the CRP.
-		crp := &placementv1beta1.ClusterResourcePlacement{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: crpName,
-				// Add a custom finalizer; this would allow us to better observe
-				// the behavior of the controllers.
-				Finalizers: []string{customDeletionBlockerFinalizer},
-			},
-			Spec: placementv1beta1.ClusterResourcePlacementSpec{
-				ResourceSelectors: workResourceSelector(),
-			},
-		}
-		By(fmt.Sprintf("creating placement %s", crpName))
-		Expect(hubClient.Create(ctx, crp)).To(Succeed(), "Failed to create CRP %s", crpName)
+		createCRP(crpName)
 	})
 
 	AfterAll(func() {
@@ -635,7 +609,7 @@ var _ = Context("creating clusterResourceOverride with and resource becomes inva
 	})
 
 	It("should update CRP status as expected", func() {
-		wantCRONames := []string{fmt.Sprintf(placementv1alpha1.OverrideSnapshotNameFmt, croName, 0)}
+		wantCRONames := []string{croSnapShotName}
 		crpStatusUpdatedActual := crpStatusWithWorkSynchronizedUpdatedFailedActual(workResourceIdentifiers(), allMemberClusterNames, "0", wantCRONames, nil)
 		Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update CRP %s status as expected", crpName)
 	})
@@ -658,6 +632,9 @@ var _ = Context("creating clusterResourceOverride with delete rules for one clus
 				Name: croName,
 			},
 			Spec: placementv1alpha1.ClusterResourceOverrideSpec{
+				Placement: &placementv1alpha1.PlacementRef{
+					Name: crpName, // assigned CRP name
+				},
 				ClusterResourceSelectors: workResourceSelector(),
 				Policy: &placementv1alpha1.OverridePolicy{
 					OverrideRules: []placementv1alpha1.OverrideRule{
@@ -700,19 +677,7 @@ var _ = Context("creating clusterResourceOverride with delete rules for one clus
 		Expect(hubClient.Create(ctx, cro)).To(Succeed(), "Failed to create clusterResourceOverride %s", croName)
 
 		// Create the CRP.
-		crp := &placementv1beta1.ClusterResourcePlacement{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: crpName,
-				// Add a custom finalizer; this would allow us to better observe
-				// the behavior of the controllers.
-				Finalizers: []string{customDeletionBlockerFinalizer},
-			},
-			Spec: placementv1beta1.ClusterResourcePlacementSpec{
-				ResourceSelectors: workResourceSelector(),
-			},
-		}
-		By(fmt.Sprintf("creating placement %s", crpName))
-		Expect(hubClient.Create(ctx, crp)).To(Succeed(), "Failed to create CRP %s", crpName)
+		createCRP(crpName)
 	})
 
 	AfterAll(func() {

--- a/test/e2e/placement_ro_test.go
+++ b/test/e2e/placement_ro_test.go
@@ -875,7 +875,7 @@ var _ = Context("creating resourceOverride with delete configMap", Ordered, func
 	})
 })
 
-var _ = FContext("creating resourceOverride with a templated rules with cluster label key replacement", Ordered, func() {
+var _ = Context("creating resourceOverride with a templated rules with cluster label key replacement", Ordered, func() {
 	crpName := fmt.Sprintf(crpNameTemplate, GinkgoParallelProcess())
 	roName := fmt.Sprintf(roNameTemplate, GinkgoParallelProcess())
 	roNamespace := fmt.Sprintf(workNamespaceNameTemplate, GinkgoParallelProcess())
@@ -1001,19 +1001,13 @@ var _ = FContext("creating resourceOverride with a templated rules with cluster 
 				},
 				{
 					Type:               string(placementv1beta1.ClusterResourcePlacementRolloutStartedConditionType),
-					Status:             metav1.ConditionTrue,
-					Reason:             condition.RolloutStartedReason,
-					ObservedGeneration: crp.Generation,
-				},
-				{
-					Type:               string(placementv1beta1.ClusterResourcePlacementOverriddenConditionType),
 					Status:             metav1.ConditionFalse,
-					Reason:             condition.OverriddenFailedReason,
+					Reason:             condition.RolloutNotStartedYetReason,
 					ObservedGeneration: crp.Generation,
 				},
 			}
 			if diff := cmp.Diff(crp.Status.Conditions, wantCondition, crpStatusCmpOptions...); diff != "" {
-				return fmt.Errorf("CRP status diff (-got, +want): %s", diff)
+				return fmt.Errorf("CRP condition diff (-got, +want): %s", diff)
 			}
 			return nil
 		}, eventuallyDuration, eventuallyInterval).Should(Succeed(), "CRP %s failed to show the override failed and stuck in rollout", crpName)

--- a/test/e2e/placement_ro_test.go
+++ b/test/e2e/placement_ro_test.go
@@ -18,6 +18,7 @@ package e2e
 import (
 	"fmt"
 
+	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -28,6 +29,8 @@ import (
 
 	placementv1alpha1 "github.com/kubefleet-dev/kubefleet/apis/placement/v1alpha1"
 	placementv1beta1 "github.com/kubefleet-dev/kubefleet/apis/placement/v1beta1"
+	scheduler "github.com/kubefleet-dev/kubefleet/pkg/scheduler/framework"
+	"github.com/kubefleet-dev/kubefleet/pkg/utils/condition"
 )
 
 // Note that this container will run in parallel with other containers.
@@ -200,12 +203,12 @@ var _ = Context("creating resourceOverride with multiple jsonPatchOverrides to o
 	crpName := fmt.Sprintf(crpNameTemplate, GinkgoParallelProcess())
 	roName := fmt.Sprintf(roNameTemplate, GinkgoParallelProcess())
 	roNamespace := fmt.Sprintf(workNamespaceNameTemplate, GinkgoParallelProcess())
+	roSnapShotName := fmt.Sprintf(placementv1alpha1.OverrideSnapshotNameFmt, roName, 0)
 
 	BeforeAll(func() {
 		By("creating work resources")
 		createWorkResources()
 
-		// Create the ro before crp so that the observed resource index is predictable.
 		ro := &placementv1alpha1.ResourceOverride{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      roName,
@@ -238,6 +241,11 @@ var _ = Context("creating resourceOverride with multiple jsonPatchOverrides to o
 		}
 		By(fmt.Sprintf("creating resourceOverride %s", roName))
 		Expect(hubClient.Create(ctx, ro)).To(Succeed(), "Failed to create resourceOverride %s", roName)
+		// wait until the snapshot is created so that the observed resource index is predictable.
+		Eventually(func() error {
+			roSnap := &placementv1alpha1.ResourceOverrideSnapshot{}
+			return hubClient.Get(ctx, types.NamespacedName{Name: roSnapShotName, Namespace: roNamespace}, roSnap)
+		}, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update ro as expected", crpName)
 
 		// Create the CRP.
 		createCRP(crpName)
@@ -253,7 +261,7 @@ var _ = Context("creating resourceOverride with multiple jsonPatchOverrides to o
 
 	It("should update CRP status as expected", func() {
 		wantRONames := []placementv1beta1.NamespacedName{
-			{Namespace: roNamespace, Name: fmt.Sprintf(placementv1alpha1.OverrideSnapshotNameFmt, roName, 0)},
+			{Namespace: roNamespace, Name: roSnapShotName},
 		}
 		crpStatusUpdatedActual := crpStatusWithOverrideUpdatedActual(workResourceIdentifiers(), allMemberClusterNames, "0", nil, wantRONames)
 		Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update CRP %s status as expected", crpName)
@@ -407,6 +415,8 @@ var _ = Context("creating resourceOverride and clusterResourceOverride, resource
 	croName := fmt.Sprintf(croNameTemplate, GinkgoParallelProcess())
 	roName := fmt.Sprintf(roNameTemplate, GinkgoParallelProcess())
 	roNamespace := fmt.Sprintf(workNamespaceNameTemplate, GinkgoParallelProcess())
+	roSnapShotName := fmt.Sprintf(placementv1alpha1.OverrideSnapshotNameFmt, roName, 0)
+	croSnapShotName := fmt.Sprintf(placementv1alpha1.OverrideSnapshotNameFmt, croName, 0)
 
 	BeforeAll(func() {
 		By("creating work resources")
@@ -437,7 +447,6 @@ var _ = Context("creating resourceOverride and clusterResourceOverride, resource
 		}
 		By(fmt.Sprintf("creating clusterResourceOverride %s", croName))
 		Expect(hubClient.Create(ctx, cro)).To(Succeed(), "Failed to create clusterResourceOverride %s", croName)
-		// Create the ro before crp so that the observed resource index is predictable.
 		ro := &placementv1alpha1.ResourceOverride{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      roName,
@@ -465,6 +474,15 @@ var _ = Context("creating resourceOverride and clusterResourceOverride, resource
 		}
 		By(fmt.Sprintf("creating resourceOverride %s", roName))
 		Expect(hubClient.Create(ctx, ro)).To(Succeed(), "Failed to create resourceOverride %s", roName)
+		// wait until the snapshot is created so that the observed resource index is predictable.
+		Eventually(func() error {
+			roSnap := &placementv1alpha1.ResourceOverrideSnapshot{}
+			return hubClient.Get(ctx, types.NamespacedName{Name: roSnapShotName, Namespace: roNamespace}, roSnap)
+		}, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update ro as expected", crpName)
+		Eventually(func() error {
+			croSnap := &placementv1alpha1.ClusterResourceOverrideSnapshot{}
+			return hubClient.Get(ctx, types.NamespacedName{Name: croSnapShotName}, croSnap)
+		}, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update ro as expected", crpName)
 
 		// Create the CRP.
 		createCRP(crpName)
@@ -483,9 +501,9 @@ var _ = Context("creating resourceOverride and clusterResourceOverride, resource
 
 	It("should update CRP status as expected", func() {
 		wantRONames := []placementv1beta1.NamespacedName{
-			{Namespace: roNamespace, Name: fmt.Sprintf(placementv1alpha1.OverrideSnapshotNameFmt, roName, 0)},
+			{Namespace: roNamespace, Name: roSnapShotName},
 		}
-		wantCRONames := []string{fmt.Sprintf(placementv1alpha1.OverrideSnapshotNameFmt, croName, 0)}
+		wantCRONames := []string{croSnapShotName}
 		crpStatusUpdatedActual := crpStatusWithOverrideUpdatedActual(workResourceIdentifiers(), allMemberClusterNames, "0", wantCRONames, wantRONames)
 		Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update CRP %s status as expected", crpName)
 	})
@@ -511,6 +529,7 @@ var _ = Context("creating resourceOverride with incorrect path", Ordered, func()
 	crpName := fmt.Sprintf(crpNameTemplate, GinkgoParallelProcess())
 	roName := fmt.Sprintf(croNameTemplate, GinkgoParallelProcess())
 	roNamespace := fmt.Sprintf(workNamespaceNameTemplate, GinkgoParallelProcess())
+	roSnapShotName := fmt.Sprintf(placementv1alpha1.OverrideSnapshotNameFmt, roName, 0)
 
 	BeforeAll(func() {
 		By("creating work resources")
@@ -546,8 +565,13 @@ var _ = Context("creating resourceOverride with incorrect path", Ordered, func()
 		}
 		By(fmt.Sprintf("creating the bad resourceOverride %s", roName))
 		Expect(hubClient.Create(ctx, ro)).To(Succeed(), "Failed to create resourceOverride %s", roName)
+		// wait until the snapshot is created so that failed override won't block the rollout
+		Eventually(func() error {
+			roSnap := &placementv1alpha1.ResourceOverrideSnapshot{}
+			return hubClient.Get(ctx, types.NamespacedName{Name: roSnapShotName, Namespace: roNamespace}, roSnap)
+		}, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update ro as expected", crpName)
 
-		// Create the CRP later so that failed override won't block the rollout
+		// Create the CRP later
 		createCRP(crpName)
 	})
 
@@ -561,7 +585,7 @@ var _ = Context("creating resourceOverride with incorrect path", Ordered, func()
 
 	It("should update CRP status as failed to override", func() {
 		wantRONames := []placementv1beta1.NamespacedName{
-			{Namespace: roNamespace, Name: fmt.Sprintf(placementv1alpha1.OverrideSnapshotNameFmt, roName, 0)},
+			{Namespace: roNamespace, Name: roSnapShotName},
 		}
 		crpStatusUpdatedActual := crpStatusWithOverrideUpdatedFailedActual(workResourceIdentifiers(), allMemberClusterNames, "0", nil, wantRONames)
 		Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update CRP %s status as expected", crpName)
@@ -638,6 +662,7 @@ var _ = Context("creating resourceOverride with a templated rules with cluster n
 	crpName := fmt.Sprintf(crpNameTemplate, GinkgoParallelProcess())
 	roName := fmt.Sprintf(roNameTemplate, GinkgoParallelProcess())
 	roNamespace := fmt.Sprintf(workNamespaceNameTemplate, GinkgoParallelProcess())
+	roSnapShotName := fmt.Sprintf(placementv1alpha1.OverrideSnapshotNameFmt, roName, 0)
 
 	BeforeAll(func() {
 		By("creating work resources")
@@ -687,6 +712,10 @@ var _ = Context("creating resourceOverride with a templated rules with cluster n
 		}
 		By(fmt.Sprintf("creating resourceOverride %s", roName))
 		Expect(hubClient.Create(ctx, ro)).To(Succeed(), "Failed to create resourceOverride %s", roName)
+		Eventually(func() error {
+			roSnap := &placementv1alpha1.ResourceOverrideSnapshot{}
+			return hubClient.Get(ctx, types.NamespacedName{Name: roSnapShotName, Namespace: roNamespace}, roSnap)
+		}, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update ro as expected", crpName)
 
 		// Create the CRP.
 		createCRP(crpName)
@@ -702,7 +731,7 @@ var _ = Context("creating resourceOverride with a templated rules with cluster n
 
 	It("should update CRP status as expected", func() {
 		wantRONames := []placementv1beta1.NamespacedName{
-			{Namespace: roNamespace, Name: fmt.Sprintf(placementv1alpha1.OverrideSnapshotNameFmt, roName, 0)},
+			{Namespace: roNamespace, Name: roSnapShotName},
 		}
 		crpStatusUpdatedActual := crpStatusWithOverrideUpdatedActual(workResourceIdentifiers(), allMemberClusterNames, "0", nil, wantRONames)
 		Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update CRP %s status as expected", crpName)
@@ -732,6 +761,7 @@ var _ = Context("creating resourceOverride with delete configMap", Ordered, func
 	crpName := fmt.Sprintf(crpNameTemplate, GinkgoParallelProcess())
 	roName := fmt.Sprintf(roNameTemplate, GinkgoParallelProcess())
 	roNamespace := fmt.Sprintf(workNamespaceNameTemplate, GinkgoParallelProcess())
+	roSnapShotName := fmt.Sprintf(placementv1alpha1.OverrideSnapshotNameFmt, roName, 0)
 
 	BeforeAll(func() {
 		By("creating work resources")
@@ -783,6 +813,10 @@ var _ = Context("creating resourceOverride with delete configMap", Ordered, func
 		}
 		By(fmt.Sprintf("creating resourceOverride %s", roName))
 		Expect(hubClient.Create(ctx, ro)).To(Succeed(), "Failed to create resourceOverride %s", roName)
+		Eventually(func() error {
+			roSnap := &placementv1alpha1.ResourceOverrideSnapshot{}
+			return hubClient.Get(ctx, types.NamespacedName{Name: roSnapShotName, Namespace: roNamespace}, roSnap)
+		}, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update ro as expected", crpName)
 
 		// Create the CRP.
 		createCRP(crpName)
@@ -798,7 +832,7 @@ var _ = Context("creating resourceOverride with delete configMap", Ordered, func
 
 	It("should update CRP status as expected", func() {
 		wantRONames := []placementv1beta1.NamespacedName{
-			{Namespace: roNamespace, Name: fmt.Sprintf(placementv1alpha1.OverrideSnapshotNameFmt, roName, 0)},
+			{Namespace: roNamespace, Name: roSnapShotName},
 		}
 		crpStatusUpdatedActual := crpStatusWithOverrideUpdatedActual(workResourceIdentifiers(), allMemberClusterNames, "0", nil, wantRONames)
 		Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update CRP %s status as expected", crpName)
@@ -841,7 +875,7 @@ var _ = Context("creating resourceOverride with delete configMap", Ordered, func
 	})
 })
 
-var _ = Context("creating resourceOverride with a templated rules with cluster label key replacement", Ordered, func() {
+var _ = FContext("creating resourceOverride with a templated rules with cluster label key replacement", Ordered, func() {
 	crpName := fmt.Sprintf(crpNameTemplate, GinkgoParallelProcess())
 	roName := fmt.Sprintf(roNameTemplate, GinkgoParallelProcess())
 	roNamespace := fmt.Sprintf(workNamespaceNameTemplate, GinkgoParallelProcess())
@@ -953,7 +987,36 @@ var _ = Context("creating resourceOverride with a templated rules with cluster l
 		}, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update resourceOverride %s with non-existent label key", roName)
 
 		By("Verify the CRP status should have one cluster failed to override while the rest stuck in rollout")
-		// TODO: need to construct the expected status
+		Eventually(func() error {
+			crp := &placementv1beta1.ClusterResourcePlacement{}
+			if err := hubClient.Get(ctx, types.NamespacedName{Name: crpName}, crp); err != nil {
+				return err
+			}
+			wantCondition := []metav1.Condition{
+				{
+					Type:               string(placementv1beta1.ClusterResourcePlacementScheduledConditionType),
+					Status:             metav1.ConditionTrue,
+					Reason:             scheduler.FullyScheduledReason,
+					ObservedGeneration: crp.Generation,
+				},
+				{
+					Type:               string(placementv1beta1.ClusterResourcePlacementRolloutStartedConditionType),
+					Status:             metav1.ConditionTrue,
+					Reason:             condition.RolloutStartedReason,
+					ObservedGeneration: crp.Generation,
+				},
+				{
+					Type:               string(placementv1beta1.ClusterResourcePlacementOverriddenConditionType),
+					Status:             metav1.ConditionFalse,
+					Reason:             condition.OverriddenFailedReason,
+					ObservedGeneration: crp.Generation,
+				},
+			}
+			if diff := cmp.Diff(crp.Status.Conditions, wantCondition, crpStatusCmpOptions...); diff != "" {
+				return fmt.Errorf("CRP status diff (-got, +want): %s", diff)
+			}
+			return nil
+		}, eventuallyDuration, eventuallyInterval).Should(Succeed(), "CRP %s failed to show the override failed and stuck in rollout", crpName)
 
 		By("Verify the configMap remains unchanged")
 		cmName := fmt.Sprintf(appConfigMapNameTemplate, GinkgoParallelProcess())
@@ -979,6 +1042,7 @@ var _ = Context("creating resourceOverride with non-exist label", Ordered, func(
 	crpName := fmt.Sprintf(crpNameTemplate, GinkgoParallelProcess())
 	roName := fmt.Sprintf(croNameTemplate, GinkgoParallelProcess())
 	roNamespace := fmt.Sprintf(workNamespaceNameTemplate, GinkgoParallelProcess())
+	roSnapShotName := fmt.Sprintf(placementv1alpha1.OverrideSnapshotNameFmt, roName, 0)
 
 	BeforeAll(func() {
 		By("creating work resources")
@@ -1034,6 +1098,10 @@ var _ = Context("creating resourceOverride with non-exist label", Ordered, func(
 		}
 		By(fmt.Sprintf("creating the bad resourceOverride %s", roName))
 		Expect(hubClient.Create(ctx, ro)).To(Succeed(), "Failed to create resourceOverride %s", roName)
+		Eventually(func() error {
+			roSnap := &placementv1alpha1.ResourceOverrideSnapshot{}
+			return hubClient.Get(ctx, types.NamespacedName{Name: roSnapShotName, Namespace: roNamespace}, roSnap)
+		}, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update ro as expected", crpName)
 
 		// Create the CRP later so that failed override won't block the rollout
 		createCRP(crpName)
@@ -1049,7 +1117,7 @@ var _ = Context("creating resourceOverride with non-exist label", Ordered, func(
 
 	It("should update CRP status as failed to override", func() {
 		wantRONames := []placementv1beta1.NamespacedName{
-			{Namespace: roNamespace, Name: fmt.Sprintf(placementv1alpha1.OverrideSnapshotNameFmt, roName, 0)},
+			{Namespace: roNamespace, Name: roSnapShotName},
 		}
 		crpStatusUpdatedActual := crpStatusWithOverrideUpdatedFailedActual(workResourceIdentifiers(), allMemberClusterNames, "0", nil, wantRONames)
 		Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update CRP %s status as expected", crpName)


### PR DESCRIPTION
### Description of your changes

Need to wait for the snapshot appear before creating the CRP otherwise, it's a race between override and rollout controller 

Fixes #

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
