### PR TITLE
interface: support multiple resourceSnapshot versions across clusters

### DIFF
--- a/apis/placement/v1beta1/clusterresourceplacement_types.go
+++ b/apis/placement/v1beta1/clusterresourceplacement_types.go
@@ -822,6 +822,9 @@ type ClusterResourcePlacementStatus struct {
 	// One resource snapshot can contain multiple clusterResourceSnapshots CRs in order to store large amount of resources.
 	// To get clusterResourceSnapshot of a given resource index, use the following command:
 	// `kubectl get ClusterResourceSnapshot --selector=kubernetes-fleet.io/resource-index=$ObservedResourceIndex `
+	// During rollout, clusters may run different versions of the resource snapshot concurrently.
+	// In this case, ObservedResourceIndex represents the index of the latest resource snapshot installed across all clusters.
+	// Note that this may differ from the index of the latest resource snapshot available in the hub cluster depending on the rollout strategy.
 	// ObservedResourceIndex is the resource index that the conditions in the ClusterResourcePlacementStatus observe.
 	// For example, a condition of `ClusterResourcePlacementWorkSynchronized` type
 	// is observing the synchronization status of the resource snapshot with the resource index $ObservedResourceIndex.
@@ -953,6 +956,13 @@ type ResourcePlacementStatus struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:MaxItems=100
 	DiffedPlacements []DiffedResourcePlacement `json:"diffedPlacements,omitempty"`
+
+	// ObservedResourceIndex is the index of the resource snapshot that is currently rolled out on the given cluster.
+	// During rollout, depending on the rollout strategy, clusters may observe different resource indices.
+	// ObservedResourceIndex is the resource snapshot index observed by the conditions in the ResourcePlacementStatus.
+	// This field is only meaningful if the `ClusterName` is not empty.
+	// +kubebuilder:validation:Optional
+	ObservedResourceIndex string `json:"observedResourceIndex,omitempty"`
 
 	// Conditions is an array of current observed conditions for ResourcePlacementStatus.
 	// +kubebuilder:validation:Optional

--- a/apis/placement/v1beta1/clusterresourceplacement_types.go
+++ b/apis/placement/v1beta1/clusterresourceplacement_types.go
@@ -958,7 +958,7 @@ type ResourcePlacementStatus struct {
 	DiffedPlacements []DiffedResourcePlacement `json:"diffedPlacements,omitempty"`
 
 	// ObservedResourceIndex is the index of the resource snapshot that is currently being rolled out to the given cluster.
-	// During rollout, depending on the rollout strategy, clusters may observe different resource indices.
+	// During rollout, depending on the rollout strategy, clusters may observe different resource snapshot indices.
 	// ObservedResourceIndex is the resource snapshot index observed by the conditions in the ResourcePlacementStatus.
 	// This field is only meaningful if the `ClusterName` is not empty.
 	// +kubebuilder:validation:Optional

--- a/apis/placement/v1beta1/clusterresourceplacement_types.go
+++ b/apis/placement/v1beta1/clusterresourceplacement_types.go
@@ -913,6 +913,11 @@ type ResourcePlacementStatus struct {
 	// +kubebuilder:validation:Optional
 	ClusterName string `json:"clusterName,omitempty"`
 
+	// ObservedResourceIndex is the index of the resource snapshot that is currently being rolled out to the given cluster.
+	// This field is only meaningful if the `ClusterName` is not empty.
+	// +kubebuilder:validation:Optional
+	ObservedResourceIndex string `json:"observedResourceIndex,omitempty"`
+
 	// ApplicableResourceOverrides contains a list of applicable ResourceOverride snapshots associated with the selected
 	// resources.
 	//
@@ -959,11 +964,6 @@ type ResourcePlacementStatus struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:MaxItems=100
 	DiffedPlacements []DiffedResourcePlacement `json:"diffedPlacements,omitempty"`
-
-	// ObservedResourceIndex is the index of the resource snapshot that is currently being rolled out to the given cluster.
-	// This field is only meaningful if the `ClusterName` is not empty.
-	// +kubebuilder:validation:Optional
-	ObservedResourceIndex string `json:"observedResourceIndex,omitempty"`
 
 	// Conditions is an array of current observed conditions on the cluster.
 	// Each condition corresponds to the resource snapshot at the index specified by `ObservedResourceIndex`.

--- a/config/crd/bases/placement.kubernetes-fleet.io_clusterresourceplacements.yaml
+++ b/config/crd/bases/placement.kubernetes-fleet.io_clusterresourceplacements.yaml
@@ -2044,6 +2044,9 @@ spec:
                   One resource snapshot can contain multiple clusterResourceSnapshots CRs in order to store large amount of resources.
                   To get clusterResourceSnapshot of a given resource index, use the following command:
                   `kubectl get ClusterResourceSnapshot --selector=kubernetes-fleet.io/resource-index=$ObservedResourceIndex `
+                  During rollout, clusters may run different versions of the resource snapshot concurrently.
+                  In this case, ObservedResourceIndex represents the index of the latest resource snapshot installed across all clusters.
+                  Note that this may differ from the index of the latest resource snapshot available in the hub cluster depending on the rollout strategy.
                   ObservedResourceIndex is the resource index that the conditions in the ClusterResourcePlacementStatus observe.
                   For example, a condition of `ClusterResourcePlacementWorkSynchronized` type
                   is observing the synchronization status of the resource snapshot with the resource index $ObservedResourceIndex.
@@ -2500,6 +2503,13 @@ spec:
                         type: object
                       maxItems: 100
                       type: array
+                    observedResourceIndex:
+                      description: |-
+                        ObservedResourceIndex is the index of the resource snapshot that is currently rolled out on the given cluster.
+                        During rollout, depending on the rollout strategy, clusters may observe different resource indices.
+                        ObservedResourceIndex is the resource snapshot index observed by the conditions in the ResourcePlacementStatus.
+                        This field is only meaningful if the `ClusterName` is not empty.
+                      type: string
                   type: object
                 type: array
               selectedResources:

--- a/config/crd/bases/placement.kubernetes-fleet.io_clusterresourceplacements.yaml
+++ b/config/crd/bases/placement.kubernetes-fleet.io_clusterresourceplacements.yaml
@@ -1976,8 +1976,13 @@ spec:
             description: The observed status of ClusterResourcePlacement.
             properties:
               conditions:
-                description: Conditions is an array of current observed conditions
-                  for ClusterResourcePlacement.
+                description: |-
+                  Conditions is an array of current observed conditions for ClusterResourcePlacement.
+                  All conditions except `ClusterResourcePlacementScheduled` correspond to the resource snapshot at the index specified by `ObservedResourceIndex`.
+                  For example, a condition of `ClusterResourcePlacementWorkSynchronized` type
+                  is observing the synchronization status of the resource snapshot with index `ObservedResourceIndex`.
+                  If the rollout strategy type is `External`, and `ObservedResourceIndex` is unset due to clusters reporting different resource indices,
+                  conditions except `ClusterResourcePlacementScheduled` will be empty or set to Unknown.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -2043,12 +2048,10 @@ spec:
                   Each snapshot has a different resource index.
                   One resource snapshot can contain multiple clusterResourceSnapshots CRs in order to store large amount of resources.
                   To get clusterResourceSnapshot of a given resource index, use the following command:
-                  `kubectl get ClusterResourceSnapshot --selector=kubernetes-fleet.io/resource-index=$ObservedResourceIndex `
-                  ObservedResourceIndex is the resource index that the conditions in the ClusterResourcePlacementStatus observe.
-                  For example, a condition of `ClusterResourcePlacementWorkSynchronized` type
-                  is observing the synchronization status of the resource snapshot with the resource index $ObservedResourceIndex.
+                  `kubectl get ClusterResourceSnapshot --selector=kubernetes-fleet.io/resource-index=$ObservedResourceIndex`
                   If the rollout strategy type is `RollingUpdate`, `ObservedResourceIndex` is the default-latest resource snapshot index.
-                  If the rollout strategy type is `External`, rollout and version control are managed by an external controller, and this field remains empty.
+                  If the rollout strategy type is `External`, rollout and version control are managed by an external controller,
+                  and this field is not empty only if all targeted clusters observe the same resource index in `PlacementStatuses`.
                 type: string
               placementStatuses:
                 description: |-
@@ -2099,8 +2102,10 @@ spec:
                         If it is not empty, its value should be unique cross all placement decisions for the Placement.
                       type: string
                     conditions:
-                      description: Conditions is an array of current observed conditions
-                        for ResourcePlacementStatus.
+                      description: |-
+                        Conditions is an array of current observed conditions on the cluster.
+                        Each condition corresponds to the resource snapshot at the index specified by `ObservedResourceIndex`.
+                        For example, the condition of type `RolloutStarted` is observing the rollout status of the resource snapshot with index `ObservedResourceIndex`.
                       items:
                         description: Condition contains details for one aspect of
                           the current state of this API Resource.
@@ -2505,8 +2510,6 @@ spec:
                     observedResourceIndex:
                       description: |-
                         ObservedResourceIndex is the index of the resource snapshot that is currently being rolled out to the given cluster.
-                        During rollout, depending on the rollout strategy, clusters may observe different resource snapshot indices.
-                        ObservedResourceIndex is the resource snapshot index observed by the conditions in the ResourcePlacementStatus.
                         This field is only meaningful if the `ClusterName` is not empty.
                       type: string
                   type: object

--- a/config/crd/bases/placement.kubernetes-fleet.io_clusterresourceplacements.yaml
+++ b/config/crd/bases/placement.kubernetes-fleet.io_clusterresourceplacements.yaml
@@ -2505,7 +2505,7 @@ spec:
                     observedResourceIndex:
                       description: |-
                         ObservedResourceIndex is the index of the resource snapshot that is currently being rolled out to the given cluster.
-                        During rollout, depending on the rollout strategy, clusters may observe different resource indices.
+                        During rollout, depending on the rollout strategy, clusters may observe different resource snapshot indices.
                         ObservedResourceIndex is the resource snapshot index observed by the conditions in the ResourcePlacementStatus.
                         This field is only meaningful if the `ClusterName` is not empty.
                       type: string

--- a/config/crd/bases/placement.kubernetes-fleet.io_clusterresourceplacements.yaml
+++ b/config/crd/bases/placement.kubernetes-fleet.io_clusterresourceplacements.yaml
@@ -2044,17 +2044,16 @@ spec:
                   One resource snapshot can contain multiple clusterResourceSnapshots CRs in order to store large amount of resources.
                   To get clusterResourceSnapshot of a given resource index, use the following command:
                   `kubectl get ClusterResourceSnapshot --selector=kubernetes-fleet.io/resource-index=$ObservedResourceIndex `
-                  During rollout, clusters may run different versions of the resource snapshot concurrently.
-                  In this case, ObservedResourceIndex represents the index of the latest resource snapshot installed across all clusters.
-                  Note that this may differ from the index of the latest resource snapshot available in the hub cluster depending on the rollout strategy.
                   ObservedResourceIndex is the resource index that the conditions in the ClusterResourcePlacementStatus observe.
                   For example, a condition of `ClusterResourcePlacementWorkSynchronized` type
                   is observing the synchronization status of the resource snapshot with the resource index $ObservedResourceIndex.
+                  If the rollout strategy type is `RollingUpdate`, `ObservedResourceIndex` is the default-latest resource snapshot index.
+                  If the rollout strategy type is `External`, rollout and version control are managed by an external controller, and this field remains empty.
                 type: string
               placementStatuses:
                 description: |-
                   PlacementStatuses contains a list of placement status on the clusters that are selected by PlacementPolicy.
-                  Each selected cluster according to the latest resource placement is guaranteed to have a corresponding placementStatuses.
+                  Each selected cluster according to the observed resource placement is guaranteed to have a corresponding placementStatuses.
                   In the pickN case, there are N placement statuses where N = NumberOfClusters; Or in the pickFixed case, there are
                   N placement statuses where N = ClusterNames.
                   In these cases, some of them may not have assigned clusters when we cannot fill the required number of clusters.
@@ -2505,7 +2504,7 @@ spec:
                       type: array
                     observedResourceIndex:
                       description: |-
-                        ObservedResourceIndex is the index of the resource snapshot that is currently rolled out on the given cluster.
+                        ObservedResourceIndex is the index of the resource snapshot that is currently being rolled out to the given cluster.
                         During rollout, depending on the rollout strategy, clusters may observe different resource indices.
                         ObservedResourceIndex is the resource snapshot index observed by the conditions in the ResourcePlacementStatus.
                         This field is only meaningful if the `ClusterName` is not empty.
@@ -2513,8 +2512,9 @@ spec:
                   type: object
                 type: array
               selectedResources:
-                description: SelectedResources contains a list of resources selected
-                  by ResourceSelectors.
+                description: |-
+                  SelectedResources contains a list of resources selected by ResourceSelectors.
+                  This field is only meaningful if the `ObservedResourceIndex` is not empty.
                 items:
                   description: ResourceIdentifier identifies one Kubernetes resource.
                   properties:


### PR DESCRIPTION
### Description of your changes

This PR is the interface update to support showing multiple resourceSnapshot versions across targeted clusters on CRP.

Current behavior:
In current CRP status, there's `crp.status.ObservedResourceIndex` that is always set to the index of the latest resourceSnapshot currently exists on the hub cluster as current rollingUpdate rollout strategy only supports rolling to the latest resourceSnapshot version. The `crp.status.Conditions` (CRP status as a whole) as well as `crp.status.placementStatuses` (each targeted member clsuter status) are both based on this index.

This has several cons:
1. With staged update run enabled, users are able to specify the resourceSnapshot version to rollout. When the version is not the latest, CRP status always shows as "RolloutNotStarted", because resourceSnapshot version does not match.
2. During the rollout process, either with updateRun or rollingUpdate, different clusters may observe different resourceSnapshot versions, e.g. when rolling is waiting for resource to be available or just gets stuck due to some failure, current CRP always shows as "RolloutNotStarted", which does not accurately reflect the status. An example with manifestNotAvailable yet:
```
status:
  conditions:
  - lastTransitionTime: "2025-04-25T21:07:55Z"
    message: found all cluster needed as specified by the scheduling policy, found
      2 cluster(s)
    observedGeneration: 2
    reason: SchedulingPolicyFulfilled
    status: "True"
    type: ClusterResourcePlacementScheduled
  - lastTransitionTime: "2025-04-25T22:17:12Z"
    message: The rollout is being blocked by the rollout strategy in 1 cluster(s)
    observedGeneration: 2
    reason: RolloutNotStartedYet
    status: "False"
    type: ClusterResourcePlacementRolloutStarted
  observedResourceIndex: "3"
  placementStatuses:
  - clusterName: member1
    conditions:
    - lastTransitionTime: "2025-04-25T21:07:55Z"
      message: 'Successfully scheduled resources for placement in "member1" (affinity
        score: 0, topology spread score: 0): picked by scheduling policy'
      observedGeneration: 2
      reason: Scheduled
      status: "True"
      type: Scheduled
    - lastTransitionTime: "2025-04-25T22:17:12Z"
      message: Detected the new changes on the resources and started the rollout process
      observedGeneration: 2
      reason: RolloutStarted
      status: "True"
      type: RolloutStarted
    - lastTransitionTime: "2025-04-25T22:17:12Z"
      message: No override rules are configured for the selected resources
      observedGeneration: 2
      reason: NoOverrideSpecified
      status: "True"
      type: Overridden
    - lastTransitionTime: "2025-04-25T22:17:12Z"
      message: All of the works are synchronized to the latest
      observedGeneration: 2
      reason: AllWorkSynced
      status: "True"
      type: WorkSynchronized
    - lastTransitionTime: "2025-04-25T22:17:13Z"
      message: All corresponding work objects are applied
      observedGeneration: 2
      reason: AllWorkHaveBeenApplied
      status: "True"
      type: Applied
    - lastTransitionTime: "2025-04-25T22:17:13Z"
      message: Work object example-placement-work is not yet available
      observedGeneration: 2
      reason: NotAllWorkAreAvailable
      status: "False"
      type: Available
    failedPlacements:
    - condition:
        lastTransitionTime: "2025-04-25T22:17:13Z"
        message: Manifest is not yet available; Fleet will check again later
        reason: ManifestNotAvailableYet
        status: "False"
        type: Available
      kind: Service
      name: nginx
      namespace: test-namespace
      version: v1
  - clusterName: member2
    conditions:
    - lastTransitionTime: "2025-04-25T21:07:55Z"
      message: 'Successfully scheduled resources for placement in "member2" (affinity
        score: 0, topology spread score: 0): picked by scheduling policy'
      observedGeneration: 2
      reason: Scheduled
      status: "True"
      type: Scheduled
    - lastTransitionTime: "2025-04-25T22:17:12Z"
      message: The rollout is being blocked by the rollout strategy
      observedGeneration: 2
      reason: RolloutNotStartedYet
      status: "False"
      type: RolloutStarted
```
In above example, rollout does happen to member1, it's just waiting for the resource to become available. But in the CRP condition, it still shows "RolloutNotStarted". And in member2, we actually loses more information that it currently is still running on the earlier version.

#### Proposed API
The proposed solution is to modify the definition of `crp.status.ObservedResourceIndex` from the index of latest resourceSnapshot observed on hub cluster to the index of the latest resourceSnapshot observed across all targeted memberclusters. For example, when the currently latest index is 4 on hub cluster but 2, 2, 3 on member clusters respectively, current `crp.statusObservedResourceIndex` is 4, but will be 3 with the proposed changed. This does not break existing rollingUpdate strategy as all member clusters will be updated to 4 eventually and crp will reach the final terminate state. And with updateRun or other external rollout strategy, users can find it more accurate to reflect the current CRP status: CRP now shows the version that user rolls out, not the default-latest version.

There are two options to handle per-cluster status:
1. Each cluster still reports its status based on `crp.status.ObservedResourceIndex`. This aligns with current API.
2. Add an `ObservedResourceIndex` inside per-cluster placement status. And each cluster's status is based on this version. For example, when current version on each cluster is 2, 3, 3 respectively, the first cluster shows RolloutNotStarted or RolloutUnknown as it's not being updated to version 3 yet, while with this new option, it's RolloutStarted and observedResourceIndex is 2. This somehow breaks current API but it displays more accurate status.

With the proposed solution, we can easily support different rollout strategy, show cluster status more accurately, and can support rollout back in the future.

#### Revised Apr 28:

When rollout strategy type is set to `External`, rollout is managed by an external controller and crp is not aware of the actual rollout plan/target. In this case, setting `ObservedResourceIndex` and `RolloutStarted/Applied/Available` conditions in the crp whole status does not make sense and can cause confusion. In this case, we only demonstrate the per-cluster observedResourceIndex and conditions in `crp.statusResoucePlacementStatuses` array. CRP condition will only show `Scheduled` and `RolloutStarted Unknown`.

<b>
#### Revised Apr 29:

Per offline discussion, we have decided that:

* Per-cluster resourcePlacement status:
  For both `RollingUpdate` and `External` rollout strategies, `ObservedResourceIndex` and conditions including `RolloutStarted/Overridden/WorkSynchronized/Applied/Available` should reflect the current observed resource index of the member cluster and be consistent with the corresponding `clusterResourceBinding` status.
* CRP status:
  CRP status serves as an aggregate of the per-cluster resourcePlacement status.
  * For `RollingUpdate` strategy:
     `ObservedResourceIndex` is the default-latest resourceSnapshot index and the conditions are based on it.
  * For `External` strategy:
    `ObservedResourceIndex` is not empty only if all the member clusters observe the same resource index.
    When `ObservedResourceIndex` is empty, all conditions except `Scheduled` should be in `Unknown` state.
    When `ObservedResourceIndex` is not empty, conditions show the aggregation of the clusters' status:
    * If any one of the cluster is `Unknown`, aggregated state is `Unknown`.
    * Else if any one of the cluster is `False`, aggregated state is `False`.
    * If all the clusters are `True`, aggregated state is `True`.
 </b>

<!--

Briefly describe what this pull request does. We love pull requests that have a clear purpose. If yours fix an issue,
please uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
