### PR TITLE
util: display eviction status in logs

### DIFF
--- a/pkg/controllers/clusterresourceplacementeviction/controller.go
+++ b/pkg/controllers/clusterresourceplacementeviction/controller.go
@@ -168,7 +168,7 @@ func (r *Reconciler) updateEvictionStatus(ctx context.Context, eviction *placeme
 		klog.ErrorS(err, "Failed to update eviction status", "clusterResourcePlacementEviction", evictionRef)
 		return controller.NewUpdateIgnoreConflictError(err)
 	}
-	klog.V(2).InfoS("Updated the status of a eviction", "clusterResourcePlacementEviction", evictionRef)
+	klog.V(2).InfoS("Updated the status of a eviction", "clusterResourcePlacementEviction", evictionRef, "status", eviction.Status)
 	return nil
 }
 


### PR DESCRIPTION
### Description of your changes

Example logs:

$ kubectl logs hub-agent-59b749d9bf-gm5dm -n fleet-system | grep "Updated the status of a eviction"
I0501 00:08:19.912290       1 clusterresourceplacementeviction/controller.go:171] "Updated the status of a eviction" clusterResourcePlacementEviction="test-eviction" status={"conditions":[{"type":"Valid","status":"True","observedGeneration":1,"lastTransitionTime":"2025-05-01T00:08:19Z","reason":"ClusterResourcePlacementEvictionValid","message":"Eviction is valid"},{"type":"Executed","status":"True","observedGeneration":1,"lastTransitionTime":"2025-05-01T00:08:19Z","reason":"ClusterResourcePlacementEvictionExecuted","message":"Eviction is allowed, no ClusterResourcePlacementDisruptionBudget specified"}]}

Fixes #

I have:

- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
