### PR TITLE
test: fix drain E2E flakiness

### DIFF
--- a/test/e2e/drain_tool_test.go
+++ b/test/e2e/drain_tool_test.go
@@ -203,7 +203,7 @@ var _ = Describe("Drain cluster blocked - ClusterResourcePlacementDisruptionBudg
 	})
 })
 
-var _ = Describe("Drain is allowed on one cluster, blocked on others - ClusterResourcePlacementDisruptionBudget blocks evictions on some clusters", Ordered, Serial, func() {
+var _ = FDescribe("Drain is allowed on one cluster, blocked on others - ClusterResourcePlacementDisruptionBudget blocks evictions on some clusters", Ordered, Serial, func() {
 	crpName := fmt.Sprintf(crpNameTemplate, GinkgoParallelProcess())
 	var drainEvictions []placementv1beta1.ClusterResourcePlacementEviction
 	var drainClusters, noDrainClusters []*framework.Cluster
@@ -273,6 +273,26 @@ var _ = Describe("Drain is allowed on one cluster, blocked on others - ClusterRe
 				&testutilseviction.IsValidEviction{IsValid: true, Msg: condition.EvictionValidMessage},
 				&testutilseviction.IsExecutedEviction{IsExecuted: true, Msg: fmt.Sprintf(condition.EvictionAllowedPDBSpecifiedMessageFmt, 3, 3)})
 			Eventually(crpEvictionStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update cluster resource placement eviction status as expected")
+		}
+	})
+
+	It("should ensure no resources exist on drained clusters", func() {
+		for _, cluster := range drainClusters {
+			resourceRemovedActual := workNamespaceRemovedFromClusterActual(cluster)
+			Eventually(resourceRemovedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to check if resources doesn't exist on member cluster")
+		}
+	})
+
+	It("should update cluster resource placement status as expected", func() {
+		crpStatusUpdatedActual := crpStatusUpdatedActual(workResourceIdentifiers(), noDrainClusterNames, nil, "0")
+		Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update cluster resource placement status as expected")
+		Consistently(crpStatusUpdatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to update cluster resource placement status as expected")
+	})
+
+	It("should still place resources on the selected clusters which were not drained", func() {
+		for _, cluster := range noDrainClusters {
+			resourcePlacedActual := workNamespaceAndConfigMapPlacedOnClusterActual(cluster)
+			Eventually(resourcePlacedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to place resources on the selected clusters")
 		}
 	})
 

--- a/test/e2e/drain_tool_test.go
+++ b/test/e2e/drain_tool_test.go
@@ -203,7 +203,7 @@ var _ = Describe("Drain cluster blocked - ClusterResourcePlacementDisruptionBudg
 	})
 })
 
-var _ = FDescribe("Drain is allowed on one cluster, blocked on others - ClusterResourcePlacementDisruptionBudget blocks evictions on some clusters", Ordered, Serial, func() {
+var _ = Describe("Drain is allowed on one cluster, blocked on others - ClusterResourcePlacementDisruptionBudget blocks evictions on some clusters", Ordered, Serial, func() {
 	crpName := fmt.Sprintf(crpNameTemplate, GinkgoParallelProcess())
 	var drainEvictions []placementv1beta1.ClusterResourcePlacementEviction
 	var drainClusters, noDrainClusters []*framework.Cluster


### PR DESCRIPTION
### Description of your changes

Fixes: https://github.com/kubefleet-dev/kubefleet/actions/runs/14786831911/job/41516637200?pr=47

The flakiness occurs because we don't wait for the ClusterResourceBinding to be deleted. TotalPlacements are supposed to be 2 since we already execute a drain

![image](https://github.com/user-attachments/assets/8e870d3d-184d-4d06-b033-a69248202c83)

Added logic to ensure no resources exists on drained cluster and also check CRP status

Fixes #

I have:

- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
