### PR TITLE
feat: use helm apply order to sort selected resources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 )
 
 require (
-	dario.cat/mergo v1.0.0 // indirect
+	dario.cat/mergo v1.0.1 // indirect
 	github.com/Azure/azure-kusto-go v0.16.1 // indirect
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0 // indirect
@@ -104,6 +104,7 @@ require (
 	github.com/prometheus/common v0.55.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/samber/lo v1.38.1 // indirect
+	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
-dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
+dario.cat/mergo v1.0.1 h1:Ra4+bf83h2ztPIQYNP99R6m+Y7KfnARDfID+a+vLl4s=
+dario.cat/mergo v1.0.1/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 github.com/Azure/azure-kusto-go v0.16.1 h1:vCBWcQghmC1qIErUUgVNWHxGhZVStu1U/hki6iBA14k=
 github.com/Azure/azure-kusto-go v0.16.1/go.mod h1:9F2zvXH8B6eWzgI1S4k1ZXAIufnBZ1bv1cW1kB1n3D0=
 github.com/Azure/azure-sdk-for-go v68.0.0+incompatible h1:fcYLmCpyNYRnvJbPerq7U0hS+6+I79yEDJBqVNcqUzU=
@@ -219,8 +219,8 @@ github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWN
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/samber/lo v1.38.1 h1:j2XEAqXKb09Am4ebOg31SpvzUTTs6EN3VfgeLUhPdXM=
 github.com/samber/lo v1.38.1/go.mod h1:+m/ZKRl6ClXCE2Lgf3MsQlWfh4bn1bz6CXEOxnEXnEA=
-github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
-github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
+github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
+github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
 github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=

--- a/pkg/controllers/clusterresourceplacement/resource_selector.go
+++ b/pkg/controllers/clusterresourceplacement/resource_selector.go
@@ -41,6 +41,7 @@ import (
 
 // ApplyOrder is the order in which resources should be applied.
 // Those occurring earlier in the list get applied before those occurring later in the list.
+// Source: https://github.com/helm/helm/blob/31e22b9866af91e1a0ea2ad381798f6c5eec7f4f/pkg/release/util/kind_sorter.go#L31.
 var ApplyOrder = []string{
 	"PriorityClass",
 	"Namespace",
@@ -51,20 +52,15 @@ var ApplyOrder = []string{
 	"PodDisruptionBudget",
 	"ServiceAccount",
 	"Secret",
-	"SecretList",
 	"ConfigMap",
 	"StorageClass",
 	"PersistentVolume",
 	"PersistentVolumeClaim",
 	"CustomResourceDefinition",
 	"ClusterRole",
-	"ClusterRoleList",
 	"ClusterRoleBinding",
-	"ClusterRoleBindingList",
 	"Role",
-	"RoleList",
 	"RoleBinding",
-	"RoleBindingList",
 	"Service",
 	"DaemonSet",
 	"Pod",

--- a/pkg/controllers/clusterresourceplacement/resource_selector.go
+++ b/pkg/controllers/clusterresourceplacement/resource_selector.go
@@ -185,7 +185,7 @@ func sortResources(resources []*unstructured.Unstructured) {
 		second, bok := ordering[k2]
 		// if both kinds are unknown.
 		if !aok && !bok {
-			return sortByGVK(obj1, obj2, false)
+			return lessByGVK(obj1, obj2, false)
 		}
 		// unknown kind is last.
 		if !aok {
@@ -196,14 +196,14 @@ func sortResources(resources []*unstructured.Unstructured) {
 		}
 		// same kind.
 		if first == second {
-			return sortByGVK(obj1, obj2, true)
+			return lessByGVK(obj1, obj2, true)
 		}
 		// different known kinds, sort based on order index.
 		return first < second
 	})
 }
 
-func sortByGVK(obj1, obj2 *unstructured.Unstructured, ignoreKind bool) bool {
+func lessByGVK(obj1, obj2 *unstructured.Unstructured, ignoreKind bool) bool {
 	var gvk1, gvk2 string
 	if !ignoreKind {
 		gvk1 = obj1.GetObjectKind().GroupVersionKind().String()

--- a/pkg/controllers/clusterresourceplacement/resource_selector.go
+++ b/pkg/controllers/clusterresourceplacement/resource_selector.go
@@ -191,7 +191,7 @@ func sortResources(resources []*unstructured.Unstructured) {
 		if !aok && !bok {
 			return cmpObjectsIgnoreKind(obj1, obj2)
 		}
-		// unknown kind is last
+		// unknown kind is last.
 		if !aok {
 			return false
 		}
@@ -215,7 +215,7 @@ func cmpObjectsIgnoreKind(obj1, obj2 *unstructured.Unstructured) bool {
 	if gvComp == 0 {
 		// same gv, compare namespace/name, no duplication exists
 		return strings.Compare(fmt.Sprintf("%s/%s", obj1.GetNamespace(), obj1.GetName()),
-			fmt.Sprintf("%s/%s", obj2.GetNamespace(), obj2.GetName())) > 0
+			fmt.Sprintf("%s/%s", obj2.GetNamespace(), obj2.GetName())) < 0
 	}
 	return gvComp < 0
 }

--- a/pkg/controllers/clusterresourceplacement/resource_selector.go
+++ b/pkg/controllers/clusterresourceplacement/resource_selector.go
@@ -176,19 +176,17 @@ func sortResources(resources []*unstructured.Unstructured, applyOrderMap map[str
 
 		first, aok := applyOrderMap[k1]
 		second, bok := applyOrderMap[k2]
+		switch {
 		// if both kinds are unknown.
-		if !aok && !bok {
+		case !aok && !bok:
 			return lessByGVK(obj1, obj2, false)
-		}
-		// unknown kind is last.
-		if !aok {
+		// unknown kind should be last.
+		case !aok:
 			return false
-		}
-		if !bok {
+		case !bok:
 			return true
-		}
 		// same kind.
-		if first == second {
+		case first == second:
 			return lessByGVK(obj1, obj2, true)
 		}
 		// different known kinds, sort based on order index.

--- a/pkg/controllers/clusterresourceplacement/resource_selector.go
+++ b/pkg/controllers/clusterresourceplacement/resource_selector.go
@@ -48,7 +48,6 @@ var ApplyOrder = []string{
 	"NetworkPolicy",
 	"ResourceQuota",
 	"LimitRange",
-	"PodSecurityPolicy",
 	"PodDisruptionBudget",
 	"ServiceAccount",
 	"Secret",

--- a/pkg/controllers/clusterresourceplacement/resource_selector.go
+++ b/pkg/controllers/clusterresourceplacement/resource_selector.go
@@ -39,43 +39,46 @@ import (
 	"github.com/kubefleet-dev/kubefleet/pkg/utils/controller"
 )
 
-// ApplyOrder is the order in which resources should be applied.
-// Those occurring earlier in the list get applied before those occurring later in the list.
-// Source: https://github.com/helm/helm/blob/31e22b9866af91e1a0ea2ad381798f6c5eec7f4f/pkg/release/util/kind_sorter.go#L31.
-var ApplyOrder = []string{
-	"PriorityClass",
-	"Namespace",
-	"NetworkPolicy",
-	"ResourceQuota",
-	"LimitRange",
-	"PodDisruptionBudget",
-	"ServiceAccount",
-	"Secret",
-	"ConfigMap",
-	"StorageClass",
-	"PersistentVolume",
-	"PersistentVolumeClaim",
-	"CustomResourceDefinition",
-	"ClusterRole",
-	"ClusterRoleBinding",
-	"Role",
-	"RoleBinding",
-	"Service",
-	"DaemonSet",
-	"Pod",
-	"ReplicationController",
-	"ReplicaSet",
-	"Deployment",
-	"HorizontalPodAutoscaler",
-	"StatefulSet",
-	"Job",
-	"CronJob",
-	"IngressClass",
-	"Ingress",
-	"APIService",
-	"MutatingWebhookConfiguration",
-	"ValidatingWebhookConfiguration",
-}
+var (
+	// ApplyOrder is the order in which resources should be applied.
+	// Those occurring earlier in the list get applied before those occurring later in the list.
+	// Source: https://github.com/helm/helm/blob/31e22b9866af91e1a0ea2ad381798f6c5eec7f4f/pkg/release/util/kind_sorter.go#L31.
+	applyOrder = []string{
+		"PriorityClass",
+		"Namespace",
+		"NetworkPolicy",
+		"ResourceQuota",
+		"LimitRange",
+		"PodDisruptionBudget",
+		"ServiceAccount",
+		"Secret",
+		"ConfigMap",
+		"StorageClass",
+		"PersistentVolume",
+		"PersistentVolumeClaim",
+		"CustomResourceDefinition",
+		"ClusterRole",
+		"ClusterRoleBinding",
+		"Role",
+		"RoleBinding",
+		"Service",
+		"DaemonSet",
+		"Pod",
+		"ReplicationController",
+		"ReplicaSet",
+		"Deployment",
+		"HorizontalPodAutoscaler",
+		"StatefulSet",
+		"Job",
+		"CronJob",
+		"IngressClass",
+		"Ingress",
+		"APIService",
+		"MutatingWebhookConfiguration",
+		"ValidatingWebhookConfiguration",
+	}
+	applyOrderMap = buildApplyOrderMap()
+)
 
 // selectResources selects the resources according to the placement resourceSelectors.
 // It also generates an array of manifests obj based on the selected resources.
@@ -162,12 +165,12 @@ func (r *Reconciler) gatherSelectedResource(placement string, selectors []fleetv
 	}
 	// sort the resources in strict order so that we will get the stable list of manifest so that
 	// the generated work object doesn't change between reconcile loops.
-	sortResources(resources, buildApplyOrderMap())
+	sortResources(resources)
 
 	return resources, nil
 }
 
-func sortResources(resources []*unstructured.Unstructured, applyOrderMap map[string]int) {
+func sortResources(resources []*unstructured.Unstructured) {
 	sort.Slice(resources, func(i, j int) bool {
 		obj1 := resources[i]
 		obj2 := resources[j]
@@ -212,8 +215,8 @@ func lessByGVK(obj1, obj2 *unstructured.Unstructured, ignoreKind bool) bool {
 }
 
 func buildApplyOrderMap() map[string]int {
-	ordering := make(map[string]int, len(ApplyOrder))
-	for v, k := range ApplyOrder {
+	ordering := make(map[string]int, len(applyOrder))
+	for v, k := range applyOrder {
 		ordering[k] = v
 	}
 	return ordering

--- a/pkg/controllers/clusterresourceplacement/resource_selector_test.go
+++ b/pkg/controllers/clusterresourceplacement/resource_selector_test.go
@@ -1267,7 +1267,7 @@ func TestSortResource(t *testing.T) {
 			"apiVersion": "test.kubernetes-fleet.io/v1beta1",
 			"kind":       "AnotherTestResource",
 			"metadata": map[string]interface{}{
-				"name":      "another-test-resource1",
+				"name":      "another-test-resource",
 				"namespace": "test",
 			},
 		},
@@ -1289,14 +1289,6 @@ func TestSortResource(t *testing.T) {
 			resources: []*unstructured.Unstructured{ingressClass, clusterRole, clusterRoleBinindg, configMap, cronJob, crd1, daemonSet, deployment, testResource1, ingress, job, limitRange, namespace1, networkPolicy, pv, pvc, pod, pdb, replicaSet, replicationController, resourceQuota, role, roleBinding, secret1, service, serviceAccount, statefulSet, storageClass, apiService, hpa, priorityClass, validatingWebhookConfiguration, mutatingWebhookConfiguration},
 			want:      []*unstructured.Unstructured{priorityClass, namespace1, networkPolicy, resourceQuota, limitRange, pdb, serviceAccount, secret1, configMap, storageClass, pv, pvc, crd1, clusterRole, clusterRoleBinindg, role, roleBinding, service, daemonSet, pod, replicationController, replicaSet, deployment, hpa, statefulSet, job, cronJob, ingressClass, ingress, apiService, mutatingWebhookConfiguration, validatingWebhookConfiguration, testResource1},
 		},
-		"should handle multiple unknown resources, same kinds": {
-			resources: []*unstructured.Unstructured{testResource2, testResource1},
-			want:      []*unstructured.Unstructured{testResource1, testResource2},
-		},
-		"should handle multiple unknown resources, different kinds": {
-			resources: []*unstructured.Unstructured{testResource1, anotherTestResource},
-			want:      []*unstructured.Unstructured{anotherTestResource, testResource1},
-		},
 		"should handle multiple known resources, different kinds": {
 			resources: []*unstructured.Unstructured{crd2, crd1, secret2, namespace2, namespace1, secret1},
 			want:      []*unstructured.Unstructured{namespace1, namespace2, secret1, secret2, crd1, crd2},
@@ -1305,16 +1297,24 @@ func TestSortResource(t *testing.T) {
 			resources: []*unstructured.Unstructured{v1beta1Deployment, deployment, limitRange},
 			want:      []*unstructured.Unstructured{limitRange, deployment, v1beta1Deployment},
 		},
+		"should handle multiple unknown resources, same kinds": {
+			resources: []*unstructured.Unstructured{testResource2, testResource1},
+			want:      []*unstructured.Unstructured{testResource1, testResource2},
+		},
+		"should handle multiple unknown resources, different kinds": {
+			resources: []*unstructured.Unstructured{testResource1, anotherTestResource},
+			want:      []*unstructured.Unstructured{anotherTestResource, testResource1},
+		},
 		"should handle multiple unknown resources, same kinds with different versions": {
-			resources: []*unstructured.Unstructured{testResource2, v1beta1AnotherTestResource, anotherTestResource},
-			want:      []*unstructured.Unstructured{anotherTestResource, v1beta1AnotherTestResource, testResource2},
+			resources: []*unstructured.Unstructured{v1beta1AnotherTestResource, anotherTestResource},
+			want:      []*unstructured.Unstructured{anotherTestResource, v1beta1AnotherTestResource},
 		},
 	}
 
 	for testName, tt := range tests {
 		t.Run(testName, func(t *testing.T) {
 			// run many times to make sure it's stable
-			for i := 0; i < 1; i++ {
+			for i := 0; i < 10; i++ {
 				sortResources(tt.resources)
 				// Check that the returned resources match the expected resources
 				diff := cmp.Diff(tt.want, tt.resources)

--- a/pkg/controllers/clusterresourceplacement/resource_selector_test.go
+++ b/pkg/controllers/clusterresourceplacement/resource_selector_test.go
@@ -808,6 +808,41 @@ func createResourceContentForTest(t *testing.T, obj interface{}) *fleetv1beta1.R
 }
 
 func TestSortResource(t *testing.T) {
+	// Create the ingressClass object
+	ingressClass := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "networking/v1",
+			"kind":       "IngressClass",
+			"metadata": map[string]interface{}{
+				"name": "test",
+			},
+		},
+	}
+
+	// Create the Ingress object
+	ingress := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "networking/v1",
+			"kind":       "Ingress",
+			"metadata": map[string]interface{}{
+				"name":      "test-ingress",
+				"namespace": "test",
+			},
+		},
+	}
+
+	// Create the NetworkPolicy object
+	networkPolicy := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "networking/v1",
+			"kind":       "NetworkPolicy",
+			"metadata": map[string]interface{}{
+				"name":      "test-networkpolicy",
+				"namespace": "test",
+			},
+		},
+	}
+
 	// Create the first Namespace object
 	namespace1 := &unstructured.Unstructured{
 		Object: map[string]interface{}{
@@ -830,7 +865,91 @@ func TestSortResource(t *testing.T) {
 		},
 	}
 
-	// Create the Deployment object
+	// Create the LimitRange object
+	limitRange := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "LimitRange",
+			"metadata": map[string]interface{}{
+				"name":      "test-limitrange",
+				"namespace": "test",
+			},
+		},
+	}
+
+	// Create the pod object.
+	pod := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]interface{}{
+				"name":      "test-pod",
+				"namespace": "test",
+			},
+		},
+	}
+
+	// Create the ReplicationController object.
+	replicationController := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ReplicationController",
+			"metadata": map[string]interface{}{
+				"name":      "test-replicationcontroller",
+				"namespace": "test",
+			},
+		},
+	}
+
+	// Create the ResourceQuota object.
+	resourceQuota := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ResourceQuota",
+			"metadata": map[string]interface{}{
+				"name":      "test-resourcequota",
+				"namespace": "test",
+			},
+		},
+	}
+
+	// Create the Service object.
+	service := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Service",
+			"metadata": map[string]interface{}{
+				"name":      "test-service",
+				"namespace": "test",
+			},
+		},
+	}
+
+	// Create the ServiceAccount object.
+	serviceAccount := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ServiceAccount",
+			"metadata": map[string]interface{}{
+				"name":      "test-serviceaccount",
+				"namespace": "test",
+			},
+		},
+	}
+
+	// Create the PodDisruptionBudget object.
+	pdb := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "policy/v1",
+			"kind":       "PodDisruptionBudget",
+			"metadata": map[string]interface{}{
+				"name":      "test-pdb",
+				"namespace": "test",
+			},
+		},
+	}
+
+	// Create the Deployment object.
 	deployment := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": "apps/v1",
@@ -842,7 +961,110 @@ func TestSortResource(t *testing.T) {
 		},
 	}
 
-	// Create the first CustomResourceDefinition object
+	// Create the DaemonSet object.
+	daemonSet := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "DaemonSet",
+			"metadata": map[string]interface{}{
+				"name":      "test-daemonset",
+				"namespace": "test",
+			},
+		},
+	}
+
+	// Create the ReplicaSet object.
+	replicaSet := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "ReplicaSet",
+			"metadata": map[string]interface{}{
+				"name":      "test-replicaset",
+				"namespace": "test",
+			},
+		},
+	}
+
+	// Create the StatefulSet object.
+	statefulSet := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "StatefulSet",
+			"metadata": map[string]interface{}{
+				"name":      "test-statefulset",
+				"namespace": "test",
+			},
+		},
+	}
+
+	// Create the StorageClass object.
+	storageClass := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "storage.k8s.io/v1",
+			"kind":       "StorageClass",
+			"metadata": map[string]interface{}{
+				"name": "test-storageclass",
+			},
+		},
+	}
+
+	// Create the APIService object.
+	apiService := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apiregistration.k8s.io/v1",
+			"kind":       "APIService",
+			"metadata": map[string]interface{}{
+				"name": "test-apiservice",
+			},
+		},
+	}
+
+	// Create the HorizontalPodAutoscaler object.
+	hpa := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "autoscaling/v1",
+			"kind":       "HorizontalPodAutoscaler",
+			"metadata": map[string]interface{}{
+				"name":      "test-hpa",
+				"namespace": "test",
+			},
+		},
+	}
+
+	// Create the PriorityClass object.
+	priorityClass := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "scheduling.k8s.io/v1",
+			"kind":       "PriorityClass",
+			"metadata": map[string]interface{}{
+				"name": "test-priorityclass",
+			},
+		},
+	}
+
+	// Create the ValidatingWebhookConfiguration object.
+	validatingWebhookConfiguration := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "admissionregistration.k8s.io/v1",
+			"kind":       "ValidatingWebhookConfiguration",
+			"metadata": map[string]interface{}{
+				"name": "test-validatingwebhookconfiguration",
+			},
+		},
+	}
+
+	// Create the MutatingWebhookConfiguration object.
+	mutatingWebhookConfiguration := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "admissionregistration.k8s.io/v1",
+			"kind":       "MutatingWebhookConfiguration",
+			"metadata": map[string]interface{}{
+				"name": "test-mutatingwebhookconfiguration",
+			},
+		},
+	}
+
+	// Create the first CustomResourceDefinition object.
 	crd1 := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": "apiextensions.k8s.io/v1",
@@ -853,7 +1075,7 @@ func TestSortResource(t *testing.T) {
 		},
 	}
 
-	// Create the second CustomResourceDefinition object
+	// Create the second CustomResourceDefinition object.
 	crd2 := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": "apiextensions.k8s.io/v1",
@@ -864,7 +1086,7 @@ func TestSortResource(t *testing.T) {
 		},
 	}
 
-	// Create the ClusterRole object
+	// Create the ClusterRole object.
 	clusterRole := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": "rbac.authorization.k8s.io/v1",
@@ -875,31 +1097,66 @@ func TestSortResource(t *testing.T) {
 		},
 	}
 
-	// Create the Secret object
-	secret := &unstructured.Unstructured{
+	// Create the ClusterRoleBinding object.
+	clusterRoleBinindg := &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": "v1",
-			"kind":       "Secret",
+			"apiVersion": "rbac.authorization.k8s.io/v1",
+			"kind":       "ClusterRoleBinding",
 			"metadata": map[string]interface{}{
-				"name":      "test-secret",
+				"name": "test-clusterrolebinding",
+			},
+		},
+	}
+
+	// Create the Role object.
+	role := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "rbac.authorization.k8s.io/v1",
+			"kind":       "Role",
+			"metadata": map[string]interface{}{
+				"name":      "test-role",
 				"namespace": "test",
 			},
 		},
 	}
 
-	// Create the Secret object
+	// Create the RoleBinding object.
+	roleBinding := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "rbac.authorization.k8s.io/v1",
+			"kind":       "RoleBinding",
+			"metadata": map[string]interface{}{
+				"name":      "test-rolebinding",
+				"namespace": "test",
+			},
+		},
+	}
+
+	// Create the Secret object.
+	secret1 := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"metadata": map[string]interface{}{
+				"name":      "test-secret1",
+				"namespace": "test",
+			},
+		},
+	}
+
+	// Create the Secret object.
 	secret2 := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": "v1",
 			"kind":       "Secret",
 			"metadata": map[string]interface{}{
-				"name":      "test-secret-2",
+				"name":      "test-secret2",
 				"namespace": "test",
 			},
 		},
 	}
 
-	// Create the ConfigMap object
+	// Create the ConfigMap object.
 	configMap := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": "v1",
@@ -911,7 +1168,42 @@ func TestSortResource(t *testing.T) {
 		},
 	}
 
-	// Create the PersistentVolumeClaim object
+	// Create the CronJob object.
+	cronJob := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "batch/v1",
+			"kind":       "CronJob",
+			"metadata": map[string]interface{}{
+				"name":      "test-cronjob",
+				"namespace": "test",
+			},
+		},
+	}
+
+	// Create the Job object.
+	job := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "batch/v1",
+			"kind":       "Job",
+			"metadata": map[string]interface{}{
+				"name":      "test-job",
+				"namespace": "test",
+			},
+		},
+	}
+
+	// Create the PersistentVolume object.
+	pv := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "PersistentVolume",
+			"metadata": map[string]interface{}{
+				"name": "test-pv",
+			},
+		},
+	}
+
+	// Create the PersistentVolumeClaim object.
 	pvc := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": "v1",
@@ -923,13 +1215,38 @@ func TestSortResource(t *testing.T) {
 		},
 	}
 
-	// Create the ClusterRole object
-	role := &unstructured.Unstructured{
+	// Create the test resource.
+	testResource1 := &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": "rbac.authorization.k8s.io/v1",
-			"kind":       "Role",
+			"apiVersion": "test.kubernetes-fleet.io/v1alpha1",
+			"kind":       "TestResource",
 			"metadata": map[string]interface{}{
-				"name": "test-clusterrole",
+				"name":      "test-resource1",
+				"namespace": "test",
+			},
+		},
+	}
+
+	// Create the test resource.
+	testResource2 := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "test.kubernetes-fleet.io/v1alpha1",
+			"kind":       "TestResource",
+			"metadata": map[string]interface{}{
+				"name":      "test-resource2",
+				"namespace": "test",
+			},
+		},
+	}
+
+	// Create another test resource.
+	anotherTestResource := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "test.kubernetes-fleet.io/v1alpha1",
+			"kind":       "AnotherTestResource",
+			"metadata": map[string]interface{}{
+				"name":      "another-test-resource",
+				"namespace": "test",
 			},
 		},
 	}
@@ -946,41 +1263,21 @@ func TestSortResource(t *testing.T) {
 			resources: []*unstructured.Unstructured{deployment},
 			want:      []*unstructured.Unstructured{deployment},
 		},
-		"should handle multiple namespaces": {
-			resources: []*unstructured.Unstructured{namespace1, namespace2},
-			want:      []*unstructured.Unstructured{namespace2, namespace1},
+		"should handle multiple resources of all kinds": {
+			resources: []*unstructured.Unstructured{ingressClass, clusterRole, clusterRoleBinindg, configMap, cronJob, crd1, daemonSet, deployment, testResource1, ingress, job, limitRange, namespace1, networkPolicy, pv, pvc, pod, pdb, replicaSet, replicationController, resourceQuota, role, roleBinding, secret1, service, serviceAccount, statefulSet, storageClass, apiService, hpa, priorityClass, validatingWebhookConfiguration, mutatingWebhookConfiguration},
+			want:      []*unstructured.Unstructured{priorityClass, namespace1, networkPolicy, resourceQuota, limitRange, pdb, serviceAccount, secret1, configMap, storageClass, pv, pvc, crd1, clusterRole, clusterRoleBinindg, role, roleBinding, service, daemonSet, pod, replicationController, replicaSet, deployment, hpa, statefulSet, job, cronJob, ingressClass, ingress, apiService, mutatingWebhookConfiguration, validatingWebhookConfiguration, testResource1},
 		},
-		"should gather selected resources with Namespace in front with order": {
-			resources: []*unstructured.Unstructured{deployment, namespace1, namespace2},
-			want:      []*unstructured.Unstructured{namespace2, namespace1, deployment},
+		"should handle multiple resource of unknown, same kinds": {
+			resources: []*unstructured.Unstructured{testResource2, testResource1},
+			want:      []*unstructured.Unstructured{testResource1, testResource2},
 		},
-		"should gather selected resources with CRD in front with order": {
-			resources: []*unstructured.Unstructured{clusterRole, crd1, crd2},
-			want:      []*unstructured.Unstructured{crd2, crd1, clusterRole},
+		"should handle multiple resources of unknown, different kinds": {
+			resources: []*unstructured.Unstructured{testResource1, anotherTestResource},
+			want:      []*unstructured.Unstructured{anotherTestResource, testResource1},
 		},
-		"should gather selected resources with CRD or Namespace in front  with order": {
-			resources: []*unstructured.Unstructured{deployment, namespace1, namespace2, clusterRole, crd1, crd2},
-			want:      []*unstructured.Unstructured{namespace2, namespace1, crd2, crd1, clusterRole, deployment},
-		},
-		"should gather selected resources with CRD or Namespace in front  with order, second case": {
-			resources: []*unstructured.Unstructured{crd1, crd2, deployment, namespace2, clusterRole},
-			want:      []*unstructured.Unstructured{namespace2, crd2, crd1, deployment, clusterRole},
-		},
-		"should gather selected resources with PersistentVolumeClaim in front with order": {
-			resources: []*unstructured.Unstructured{deployment, pvc, namespace1, role},
-			want:      []*unstructured.Unstructured{namespace1, pvc, deployment, role},
-		},
-		"should gather selected resources with Secret in front with order": {
-			resources: []*unstructured.Unstructured{deployment, secret, namespace1, crd1, namespace2, role},
-			want:      []*unstructured.Unstructured{namespace2, namespace1, crd1, secret, deployment, role},
-		},
-		"should gather selected resources with ConfigMap and Secret in front with order": {
-			resources: []*unstructured.Unstructured{deployment, secret, namespace1, role, configMap, secret2},
-			want:      []*unstructured.Unstructured{namespace1, configMap, secret2, secret, deployment, role},
-		},
-		"should gather selected all the resources with the right order": {
-			resources: []*unstructured.Unstructured{configMap, deployment, role, crd1, pvc, secret2, clusterRole, secret, namespace1, namespace2, crd2},
-			want:      []*unstructured.Unstructured{namespace2, namespace1, crd2, crd1, configMap, secret2, secret, pvc, deployment, clusterRole, role},
+		"should handle multiple resources of known, different kinds": {
+			resources: []*unstructured.Unstructured{crd2, crd1, secret2, namespace2, namespace1, secret1},
+			want:      []*unstructured.Unstructured{namespace1, namespace2, secret1, secret2, crd1, crd2},
 		},
 	}
 

--- a/pkg/controllers/clusterresourceplacement/resource_selector_test.go
+++ b/pkg/controllers/clusterresourceplacement/resource_selector_test.go
@@ -961,6 +961,7 @@ func TestSortResource(t *testing.T) {
 		},
 	}
 
+	// Create the v1beta1 Deployment object.
 	v1beta1Deployment := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": "apps/v1beta1",
@@ -1262,6 +1263,7 @@ func TestSortResource(t *testing.T) {
 		},
 	}
 
+	// Create v1beta1 another test resource.
 	v1beta1AnotherTestResource := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": "test.kubernetes-fleet.io/v1beta1",

--- a/pkg/controllers/clusterresourceplacement/resource_selector_test.go
+++ b/pkg/controllers/clusterresourceplacement/resource_selector_test.go
@@ -807,7 +807,7 @@ func createResourceContentForTest(t *testing.T, obj interface{}) *fleetv1beta1.R
 	}
 }
 
-func TestSortResource(t *testing.T) {
+func TestSortResources(t *testing.T) {
 	// Create the ingressClass object
 	ingressClass := &unstructured.Unstructured{
 		Object: map[string]interface{}{
@@ -1317,7 +1317,7 @@ func TestSortResource(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			// run many times to make sure it's stable
 			for i := 0; i < 10; i++ {
-				sortResources(tt.resources)
+				sortResources(tt.resources, buildApplyOrderMap())
 				// Check that the returned resources match the expected resources
 				diff := cmp.Diff(tt.want, tt.resources)
 				if diff != "" {

--- a/pkg/controllers/clusterresourceplacement/resource_selector_test.go
+++ b/pkg/controllers/clusterresourceplacement/resource_selector_test.go
@@ -1317,7 +1317,7 @@ func TestSortResources(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			// run many times to make sure it's stable
 			for i := 0; i < 10; i++ {
-				sortResources(tt.resources, buildApplyOrderMap())
+				sortResources(tt.resources)
 				// Check that the returned resources match the expected resources
 				diff := cmp.Diff(tt.want, tt.resources)
 				if diff != "" {

--- a/pkg/controllers/workgenerator/controller.go
+++ b/pkg/controllers/workgenerator/controller.go
@@ -521,7 +521,6 @@ func (r *Reconciler) syncAllWork(ctx context.Context, resourceBinding *fleetv1be
 		if len(simpleManifests) == 0 {
 			klog.V(2).InfoS("the snapshot contains no resource to apply either because of override or enveloped resources", "snapshot", klog.KObj(snapshot))
 		}
-
 		// generate a work object for the manifests even if there is nothing to place
 		// to allow CRP to collect the status of the placement
 		// TODO (RZ): revisit to see if we need this hack

--- a/pkg/controllers/workgenerator/controller.go
+++ b/pkg/controllers/workgenerator/controller.go
@@ -521,6 +521,7 @@ func (r *Reconciler) syncAllWork(ctx context.Context, resourceBinding *fleetv1be
 		if len(simpleManifests) == 0 {
 			klog.V(2).InfoS("the snapshot contains no resource to apply either because of override or enveloped resources", "snapshot", klog.KObj(snapshot))
 		}
+
 		// generate a work object for the manifests even if there is nothing to place
 		// to allow CRP to collect the status of the placement
 		// TODO (RZ): revisit to see if we need this hack

--- a/test/e2e/placement_selecting_resources_test.go
+++ b/test/e2e/placement_selecting_resources_test.go
@@ -1390,8 +1390,8 @@ var _ = Describe("creating CRP and checking selected resources order", Ordered, 
 		// Define the expected resources in order
 		expectedResources := []placementv1beta1.ResourceIdentifier{
 			{Kind: "Namespace", Name: nsName, Version: "v1"},
-			{Kind: "ConfigMap", Name: configMap.Name, Namespace: nsName, Version: "v1"},
 			{Kind: "Secret", Name: secret.Name, Namespace: nsName, Version: "v1"},
+			{Kind: "ConfigMap", Name: configMap.Name, Namespace: nsName, Version: "v1"},
 			{Kind: "PersistentVolumeClaim", Name: pvc.Name, Namespace: nsName, Version: "v1"},
 			{Group: "rbac.authorization.k8s.io", Kind: "Role", Name: role.Name, Namespace: nsName, Version: "v1"},
 		}

--- a/test/integration/cluster_placement_test.go
+++ b/test/integration/cluster_placement_test.go
@@ -683,7 +683,7 @@ var _ = Describe("Test Cluster Resource Placement Controller", func() {
 				var uObj unstructured.Unstructured
 				err := utils.GetObjectFromRawExtension(manifest.Raw, &uObj)
 				Expect(err).Should(Succeed())
-				if uObj.GroupVersionKind().Kind == ClusterRoleKind && uObj.GroupVersionKind().Group == rbacv1.GroupName {
+				if uObj.GroupVersionKind().Kind == ClusterRoleKind && uObj.GroupVersionKind().Group == rbacv1.GroupName && uObj.GetName() == clusterRole.GetName() {
 					var selectedRole rbacv1.ClusterRole
 					err := utils.GetObjectFromRawExtension(manifest.Raw, &selectedRole)
 					Expect(err).Should(Succeed())
@@ -715,7 +715,7 @@ var _ = Describe("Test Cluster Resource Placement Controller", func() {
 				var uObj unstructured.Unstructured
 				err := utils.GetObjectFromRawExtension(manifest.Raw, &uObj)
 				Expect(err).Should(Succeed())
-				if uObj.GroupVersionKind().Kind == ClusterRoleKind && uObj.GroupVersionKind().Group == rbacv1.GroupName {
+				if uObj.GroupVersionKind().Kind == ClusterRoleKind && uObj.GroupVersionKind().Group == rbacv1.GroupName && uObj.GetName() == clusterRole.GetName() {
 					var selectedRole rbacv1.ClusterRole
 					err := utils.GetObjectFromRawExtension(manifest.Raw, &selectedRole)
 					Expect(err).Should(Succeed())


### PR DESCRIPTION
### Description of your changes

use helm install order defined https://github.com/helm/helm/blob/31e22b9866af91e1a0ea2ad381798f6c5eec7f4f/pkg/release/util/kind_sorter.go#L31 to sort manifest before creating work objects

Fixes #

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

https://kubernetes.io/blog/2021/04/06/podsecuritypolicy-deprecation-past-present-and-future/