### PR TITLE
fix: replace the SKU size for testing in the property provider UTs/ITs

### DIFF
--- a/pkg/propertyprovider/azure/suite_test.go
+++ b/pkg/propertyprovider/azure/suite_test.go
@@ -46,7 +46,7 @@ const (
 
 	aksNodeSKU1 = "Standard_B4ms"
 	aksNodeSKU2 = "Standard_A4_v2"
-	aksNodeSKU3 = "Standard_DS2_v2"
+	aksNodeSKU3 = "Standard_F4s"
 )
 
 var (


### PR DESCRIPTION
### Description of your changes

This PR replaces a SKU size for testing in the property provider UTs/ITs as the old SKU size is no longer available in the given region.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- [x] Unit tests
- [x] Integration tests

### Special notes for your reviewer


