### PR TITLE
fix: fix updateRun error msg when a binding does not have expected state

### DIFF
--- a/pkg/controllers/updaterun/execution.go
+++ b/pkg/controllers/updaterun/execution.go
@@ -176,7 +176,8 @@ func (r *Reconciler) executeUpdatingStage(
 			// This issue mostly happens when there are concurrent updateRuns referencing the same clusterResourcePlacement but releasing different versions.
 			// After the 1st updateRun updates the binding, and before the controller re-checks the binding status, the 2nd updateRun updates the same binding, and thus the 1st updateRun is preempted and observes the binding not matching the desired state.
 			preemptedErr := controller.NewUserError(fmt.Errorf("the clusterResourceBinding of the updating cluster `%s` in the stage `%s` is not up-to-date with the desired status, "+
-				"please check the status of binding `%s` and see if there is a concurrent updateRun referencing the same clusterResourcePlacement and updating the same cluster", clusterStatus.ClusterName, updatingStageStatus.StageName, klog.KObj(binding)))
+				"please check the status of binding `%s` and see if there is a concurrent updateRun referencing the same clusterResourcePlacement and updating the same cluster",
+				clusterStatus.ClusterName, updatingStageStatus.StageName, klog.KObj(binding)))
 			klog.ErrorS(preemptedErr, "The binding has been changed during updating",
 				"binding spec insync", inSync, "binding state", binding.Spec.State,
 				"binding RolloutStarted", rolloutStarted, "binding", klog.KObj(binding), "clusterStagedUpdateRun", updateRunRef)

--- a/pkg/controllers/updaterun/execution.go
+++ b/pkg/controllers/updaterun/execution.go
@@ -170,12 +170,16 @@ func (r *Reconciler) executeUpdatingStage(
 		}
 
 		// Now the cluster has to be updating, the binding should point to the right resource snapshot and the binding should be bound.
-		if insync, rolloutStarted := isBindingSyncedWithClusterStatus(resourceSnapshotName, updateRun, binding, clusterStatus), condition.IsConditionStatusTrue(meta.FindStatusCondition(binding.Status.Conditions, string(placementv1beta1.ResourceBindingRolloutStarted)), binding.Generation); !insync || binding.Spec.State != placementv1beta1.BindingStateBound || !rolloutStarted {
+		insync := isBindingSyncedWithClusterStatus(resourceSnapshotName, updateRun, binding, clusterStatus)
+		rolloutStarted := condition.IsConditionStatusTrue(meta.FindStatusCondition(binding.Status.Conditions, string(placementv1beta1.ResourceBindingRolloutStarted)), binding.Generation)
+		if !insync || !rolloutStarted || binding.Spec.State != placementv1beta1.BindingStateBound {
 			// This issue mostly happens when there are concurrent updateRuns referencing the same clusterResourcePlacement but releasing different versions.
 			// After the 1st updateRun updates the binding, and before the controller re-checks the binding status, the 2nd updateRun updates the same binding, and thus the 1st updateRun is preempted and observes the binding not matching the desired state.
 			preemptedErr := controller.NewUserError(fmt.Errorf("the clusterResourceBinding of the updating cluster `%s` in the stage `%s` is not up-to-date with the desired status, "+
-				"please check the binding status and see if there is a concurrent updateRun referencing the same clusterResourcePlacement and updating the same binding", clusterStatus.ClusterName, updatingStageStatus.StageName))
-			klog.ErrorS(preemptedErr, "The binding has been changed during updating", "binding spec insync", insync, "binding state", binding.Spec.State, "binding RolloutStarted", rolloutStarted, "binding", klog.KObj(binding), "clusterStagedUpdateRun", updateRunRef)
+				"please check the status of binding `%s` and see if there is a concurrent updateRun referencing the same clusterResourcePlacement and updating the same binding", clusterStatus.ClusterName, updatingStageStatus.StageName, klog.KObj(binding)))
+			klog.ErrorS(preemptedErr, "The binding has been changed during updating",
+				"binding spec insync", insync, "binding state", binding.Spec.State,
+				"binding RolloutStarted", rolloutStarted, "binding", klog.KObj(binding), "clusterStagedUpdateRun", updateRunRef)
 			markClusterUpdatingFailed(clusterStatus, updateRun.Generation, preemptedErr.Error())
 			return 0, fmt.Errorf("%w: %s", errStagedUpdatedAborted, preemptedErr.Error())
 		}

--- a/pkg/controllers/updaterun/execution.go
+++ b/pkg/controllers/updaterun/execution.go
@@ -170,15 +170,15 @@ func (r *Reconciler) executeUpdatingStage(
 		}
 
 		// Now the cluster has to be updating, the binding should point to the right resource snapshot and the binding should be bound.
-		insync := isBindingSyncedWithClusterStatus(resourceSnapshotName, updateRun, binding, clusterStatus)
+		inSync := isBindingSyncedWithClusterStatus(resourceSnapshotName, updateRun, binding, clusterStatus)
 		rolloutStarted := condition.IsConditionStatusTrue(meta.FindStatusCondition(binding.Status.Conditions, string(placementv1beta1.ResourceBindingRolloutStarted)), binding.Generation)
-		if !insync || !rolloutStarted || binding.Spec.State != placementv1beta1.BindingStateBound {
+		if !inSync || !rolloutStarted || binding.Spec.State != placementv1beta1.BindingStateBound {
 			// This issue mostly happens when there are concurrent updateRuns referencing the same clusterResourcePlacement but releasing different versions.
 			// After the 1st updateRun updates the binding, and before the controller re-checks the binding status, the 2nd updateRun updates the same binding, and thus the 1st updateRun is preempted and observes the binding not matching the desired state.
 			preemptedErr := controller.NewUserError(fmt.Errorf("the clusterResourceBinding of the updating cluster `%s` in the stage `%s` is not up-to-date with the desired status, "+
-				"please check the status of binding `%s` and see if there is a concurrent updateRun referencing the same clusterResourcePlacement and updating the same binding", clusterStatus.ClusterName, updatingStageStatus.StageName, klog.KObj(binding)))
+				"please check the status of binding `%s` and see if there is a concurrent updateRun referencing the same clusterResourcePlacement and updating the same cluster", clusterStatus.ClusterName, updatingStageStatus.StageName, klog.KObj(binding)))
 			klog.ErrorS(preemptedErr, "The binding has been changed during updating",
-				"binding spec insync", insync, "binding state", binding.Spec.State,
+				"binding spec insync", inSync, "binding state", binding.Spec.State,
 				"binding RolloutStarted", rolloutStarted, "binding", klog.KObj(binding), "clusterStagedUpdateRun", updateRunRef)
 			markClusterUpdatingFailed(clusterStatus, updateRun.Generation, preemptedErr.Error())
 			return 0, fmt.Errorf("%w: %s", errStagedUpdatedAborted, preemptedErr.Error())

--- a/pkg/controllers/updaterun/execution.go
+++ b/pkg/controllers/updaterun/execution.go
@@ -171,8 +171,10 @@ func (r *Reconciler) executeUpdatingStage(
 
 		// Now the cluster has to be updating, the binding should point to the right resource snapshot and the binding should be bound.
 		if insync, rolloutStarted := isBindingSyncedWithClusterStatus(resourceSnapshotName, updateRun, binding, clusterStatus), condition.IsConditionStatusTrue(meta.FindStatusCondition(binding.Status.Conditions, string(placementv1beta1.ResourceBindingRolloutStarted)), binding.Generation); !insync || binding.Spec.State != placementv1beta1.BindingStateBound || !rolloutStarted {
-			preemptedErr := controller.NewUserError(fmt.Errorf("the clusterResourceBinding of the updating cluster `%s` in the stage `%s` is not up-to-date with the cluster status, "+
-				"please check the binding status and see if there is a concurrent updateRun updating the same binding", clusterStatus.ClusterName, updatingStageStatus.StageName))
+			// This issue mostly happens when there are concurrent updateRuns referencing the same clusterResourcePlacement but releasing different versions.
+			// After the 1st updateRun updates the binding, and before the controller re-checks the binding status, the 2nd updateRun updates the same binding, and thus the 1st updateRun is preempted and observes the binding not matching the desired state.
+			preemptedErr := controller.NewUserError(fmt.Errorf("the clusterResourceBinding of the updating cluster `%s` in the stage `%s` is not up-to-date with the desired status, "+
+				"please check the binding status and see if there is a concurrent updateRun referencing the same clusterResourcePlacement and updating the same binding", clusterStatus.ClusterName, updatingStageStatus.StageName))
 			klog.ErrorS(preemptedErr, "The binding has been changed during updating", "binding spec insync", insync, "binding state", binding.Spec.State, "binding RolloutStarted", rolloutStarted, "binding", klog.KObj(binding), "clusterStagedUpdateRun", updateRunRef)
 			markClusterUpdatingFailed(clusterStatus, updateRun.Generation, preemptedErr.Error())
 			return 0, fmt.Errorf("%w: %s", errStagedUpdatedAborted, preemptedErr.Error())

--- a/pkg/controllers/updaterun/execution.go
+++ b/pkg/controllers/updaterun/execution.go
@@ -179,8 +179,8 @@ func (r *Reconciler) executeUpdatingStage(
 				"please check the status of binding `%s` and see if there is a concurrent updateRun referencing the same clusterResourcePlacement and updating the same cluster",
 				clusterStatus.ClusterName, updatingStageStatus.StageName, klog.KObj(binding)))
 			klog.ErrorS(preemptedErr, "The binding has been changed during updating",
-				"binding spec insync", inSync, "binding state", binding.Spec.State,
-				"binding RolloutStarted", rolloutStarted, "binding", klog.KObj(binding), "clusterStagedUpdateRun", updateRunRef)
+				"bindingSpecInSync", inSync, "bindingState", binding.Spec.State,
+				"bindingRolloutStarted", rolloutStarted, "binding", klog.KObj(binding), "clusterStagedUpdateRun", updateRunRef)
 			markClusterUpdatingFailed(clusterStatus, updateRun.Generation, preemptedErr.Error())
 			return 0, fmt.Errorf("%w: %s", errStagedUpdatedAborted, preemptedErr.Error())
 		}

--- a/pkg/controllers/updaterun/execution_test.go
+++ b/pkg/controllers/updaterun/execution_test.go
@@ -26,24 +26,24 @@ import (
 	"github.com/kubefleet-dev/kubefleet/pkg/utils/condition"
 )
 
-func TestGetBindingDiffFromClusterStatus(t *testing.T) {
+func TestIsBindingSyncedWithClusterStatus(t *testing.T) {
 	tests := []struct {
 		name                 string
 		resourceSnapshotName string
 		updateRun            *placementv1beta1.ClusterStagedUpdateRun
 		binding              *placementv1beta1.ClusterResourceBinding
 		cluster              *placementv1beta1.ClusterUpdatingStatus
-		wantDiff             string
+		wantEqual            bool
 	}{
 		{
-			name:                 "getBindingDiffFromClusterStatus should return diff if binding and updateRun have different resourceSnapshot",
+			name:                 "isBindingSyncedWithClusterStatus should return false if binding and updateRun have different resourceSnapshot",
 			resourceSnapshotName: "test-1-snapshot",
 			binding: &placementv1beta1.ClusterResourceBinding{
 				Spec: placementv1beta1.ResourceBindingSpec{
 					ResourceSnapshotName: "test-2-snapshot",
 				},
 			},
-			wantDiff: "binding has different resourceSnapshotName, want: test-1-snapshot, got: test-2-snapshot",
+			wantEqual: false,
 		},
 		{
 			name:                 "isBindingSyncedWithClusterStatus should return false if binding and cluster status have different resourceOverrideSnapshot list",
@@ -75,7 +75,7 @@ func TestGetBindingDiffFromClusterStatus(t *testing.T) {
 					},
 				},
 			},
-			wantDiff: "binding has different resourceOverrideSnapshots, want: [{ro1 ns1} {ro2 ns2}], got: [{ro2 ns2} {ro1 ns1}]",
+			wantEqual: false,
 		},
 		{
 			name:                 "isBindingSyncedWithClusterStatus should return false if binding and cluster status have different clusterResourceOverrideSnapshot list",
@@ -97,7 +97,7 @@ func TestGetBindingDiffFromClusterStatus(t *testing.T) {
 				},
 				ClusterResourceOverrideSnapshots: []string{"cr1"},
 			},
-			wantDiff: "binding has different clusterResourceOverrideSnapshots, want: [cr1], got: [cr1 cr2]",
+			wantEqual: false,
 		},
 		{
 			name:                 "isBindingSyncedWithClusterStatus should return false if binding and updateRun have different applyStrategy",
@@ -129,7 +129,7 @@ func TestGetBindingDiffFromClusterStatus(t *testing.T) {
 				},
 				ClusterResourceOverrideSnapshots: []string{"cr1", "cr2"},
 			},
-			wantDiff: "binding has different applyStrategy, want: &{  ClientSideApply false <nil> }, got: &{  ReportDiff false <nil> }",
+			wantEqual: false,
 		},
 		{
 			name:                 "isBindingSyncedWithClusterStatus should return true if resourceSnapshot, applyStrategy, and override lists are all deep equal",
@@ -161,14 +161,14 @@ func TestGetBindingDiffFromClusterStatus(t *testing.T) {
 				},
 				ClusterResourceOverrideSnapshots: []string{"cr1", "cr2"},
 			},
-			wantDiff: "",
+			wantEqual: true,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := getBindingDiffFromClusterStatus(test.resourceSnapshotName, test.updateRun, test.binding, test.cluster)
-			if got != test.wantDiff {
-				t.Fatalf("getBindingDiffFromClusterStatus() got diff `%s`; want diff `%s`", got, test.wantDiff)
+			got := isBindingSyncedWithClusterStatus(test.resourceSnapshotName, test.updateRun, test.binding, test.cluster)
+			if got != test.wantEqual {
+				t.Fatalf("isBindingSyncedWithClusterStatus() got %v; want %v", got, test.wantEqual)
 			}
 		})
 	}


### PR DESCRIPTION
### Description of your changes
Currently when there're 2 concurrent updateRuns for the same CRP and the same one preempts the first, the first would fail with a very long and hard-to-understand error msg:
```
- lastTransitionTime: "2025-05-13T03:45:41Z"
    message: 'cannot continue the ClusterStagedUpdateRun: unexpected behavior which
      cannot be handled by the controller: the updating cluster `member1` in the stage
      staging does not match the cluster status: &{ClusterName:member1 ResourceOverrideSnapshots:[]
      ClusterResourceOverrideSnapshots:[] Conditions:[{Type:Started Status:True ObservedGeneration:1
      LastTransitionTime:2025-05-13 03:45:26 +0000 UTC Reason:ClusterUpdatingStarted
      Message:Cluster update started}]}, binding: {State:Bound ResourceSnapshotName:example-placement-1-snapshot
      ResourceOverrideSnapshots:[] ClusterResourceOverrideSnapshots:[] SchedulingPolicySnapshotName:example-placement-0
      TargetCluster:member1 ClusterDecision:{ClusterName:member1 Selected:true ClusterScore:0xc002737d70
      Reason:Successfully scheduled resources for placement in "member1" (affinity
      score: 0, topology spread score: 0): picked by scheduling policy} ApplyStrategy:<nil>},
      condition: &Condition{Type:RolloutStarted,Status:True,ObservedGeneration:3,LastTransitionTime:2025-05-13
      03:45:38 +0000 UTC,Reason:RolloutStarted,Message:Detected the new changes on
      the resources and started the rollout process, resourceSnapshotIndex: 1, clusterStagedUpdateRun:
      example-run-1,}'
    observedGeneration: 1
    reason: UpdateRunFailed
    status: "False"
    type: Succeeded
```

This PR makes the error msg easier to understand:
```
- lastTransitionTime: "2025-05-15T22:03:26Z"
        message: 'failed to process the request due to a client error: the clusterResourceBinding
          of the updating cluster `member1` in the stage `staging` is not up-to-date
          with the desired status, please check the status of binding `example-placement-member1-043b2fcc`
          and see if there is a concurrent updateRun referencing the same clusterResourcePlacement
          and updating the same binding'
        observedGeneration: 1
        reason: ClusterUpdatingFailed
        status: "False"
        type: Succeeded
```
<!--

Briefly describe what this pull request does. We love pull requests that have a clear purpose. If yours fix an issue,
please uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
