### PR TITLE
test: increase time in clusterresourcebinding watcher IT

### DIFF
--- a/pkg/controllers/clusterresourcebindingwatcher/watcher_integration_test.go
+++ b/pkg/controllers/clusterresourcebindingwatcher/watcher_integration_test.go
@@ -37,7 +37,7 @@ const (
 	testReason1                      = "testReason1"
 	testReason2                      = "testReason2"
 
-	eventuallyTimeout    = time.Second * 10
+	eventuallyTimeout    = time.Second * 20
 	consistentlyDuration = time.Second * 10
 	interval             = time.Millisecond * 250
 )
@@ -653,7 +653,14 @@ func validateWhenUpdateClusterResourceBindingStatusWithCondition(conditionType f
 
 	By("Checking placement controller queue")
 	eventuallyCheckPlacementControllerQueue(crb.GetLabels()[fleetv1beta1.CRPTrackingLabel])
-	fakePlacementController.ResetQueue()
+	// Reset the queue to avoid the multiple events triggered.
+	Consistently(func() error {
+		if fakePlacementController.Key() == testCRPName {
+			By("By finding the key and resetting the placement queue")
+			fakePlacementController.ResetQueue()
+		}
+		return nil
+	}, consistentlyDuration, interval).Should(Succeed(), "placementController queue should be stable empty after resetting")
 }
 
 func eventuallyCheckPlacementControllerQueue(key string) {


### PR DESCRIPTION
### Description of your changes

Test ClusterResourceBinding Watcher - update status [It] Should enqueue the clusterResourcePlacement name for reconciling, when clusterResourceBinding status changes - RolloutStarted [Serial]
/home/runner/work/kubefleet/kubefleet/pkg/controllers/clusterresourcebindingwatcher/watcher_integration_test.go:123

https://github.com/kubefleet-dev/kubefleet/actions/runs/15528629716/job/43712797542

The key cannot be found within 10s.
Increase the time to reduce the flakiness

Fixes #

I have:

- [ ] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
