### PR TITLE
fix: upgrade go stdlib to 1.23.10 to address CVEs (CVE-2025-4673, CVE-2025-0913)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
     paths-ignore: [docs/**, "**.md", "**.mdx", "**.png", "**.jpg"]
 
 env:
-  GO_VERSION: '1.23.8'
+  GO_VERSION: '1.23.10'
 
 jobs:
   detect-noop:

--- a/.github/workflows/code-lint.yml
+++ b/.github/workflows/code-lint.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.23.8'
+  GO_VERSION: '1.23.10'
 
 jobs:
 

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -18,7 +18,7 @@ env:
   MEMBER_AGENT_IMAGE_NAME: member-agent
   REFRESH_TOKEN_IMAGE_NAME: refresh-token
 
-  GO_VERSION: '1.23.8'
+  GO_VERSION: '1.23.10'
 
 jobs:
   export-registry:

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -17,7 +17,7 @@ on:
     paths-ignore: [docs/**, "**.md", "**.mdx", "**.png", "**.jpg"]
 
 env:
-  GO_VERSION: '1.23.8'
+  GO_VERSION: '1.23.10'
 
 jobs:
   detect-noop:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 run:
   timeout: 15m
-  go: '1.23.8'
+  go: '1.23.10'
 
 linters-settings:
   stylecheck:

--- a/docker/hub-agent.Dockerfile
+++ b/docker/hub-agent.Dockerfile
@@ -1,5 +1,5 @@
 # Build the hubagent binary
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.23.8 AS builder
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.23.10 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/docker/member-agent.Dockerfile
+++ b/docker/member-agent.Dockerfile
@@ -1,5 +1,5 @@
 # Build the memberagent binary
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.23.8 AS builder
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.23.10 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/docker/refresh-token.Dockerfile
+++ b/docker/refresh-token.Dockerfile
@@ -1,5 +1,5 @@
 # Build the hubagent binary
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.23.8 AS builder
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.23.10 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubefleet-dev/kubefleet
 
-go 1.23.8
+go 1.23.10
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.16.0


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that have a clear purpose. If yours fix an issue,
please uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have: upgrade go stdlib to 1.23.10 to address CVEs (CVE-2025-4673, CVE-2025-0913)

- [ ] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

CVE-2025-0913: https://github.com/golang/go/commit/c2c89d95516d2a6b51aa1766ed5f76e542ab282c
CVE-2025-4673: https://github.com/golang/go/commit/b897e97c36cb62629a458bc681723ca733404e32