### PR TITLE
test: reduce the join/leave e2e test flakiness

### DIFF
--- a/test/e2e/join_and_leave_test.go
+++ b/test/e2e/join_and_leave_test.go
@@ -235,7 +235,7 @@ var _ = Describe("Test member cluster join and leave flow", Ordered, Serial, fun
 
 		It("should update CRP status to applied to all clusters again automatically after rejoining", func() {
 			crpStatusUpdatedActual := customizedCRPStatusUpdatedActual(crpName, wantSelectedResources, allMemberClusterNames, nil, "0", true)
-			Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update CRP status as expected")
+			Eventually(crpStatusUpdatedActual, workloadEventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update CRP status as expected")
 		})
 	})
 


### PR DESCRIPTION
### Description of your changes

https://github.com/kubefleet-dev/kubefleet/actions/runs/15669145044/job/44137377529
10s is too short to deploy a deployment.

```
• [FAILED] [60.388 seconds]
Test member cluster join and leave flow Test cluster join and leave flow with CRP not deleted [It] should update CRP status to applied to all clusters again automatically after rejoining [Serial]
/home/runner/work/kubefleet/kubefleet/test/e2e/join_and_leave_test.go:236

  Timeline >>
  [FAILED] in [It] - /home/runner/work/kubefleet/kubefleet/test/e2e/join_and_leave_test.go:238 @ 06/16/25 01:13:20.05
  STEP: deleting placement crp-1 and related resources @ 06/16/25 01:13:20.05
  [FAILED] in [AfterAll] - /home/runner/work/kubefleet/kubefleet/test/e2e/utils_test.go:939 @ 06/16/25 01:14:10.436
  << Timeline

  [FAILED] Timed out after 10.001s.
Failed to update CRP status as expected
  Expected success, but got an error:
      <*errors.errorString | 0xc001057300>: 
      CRP status diff (-got, +want):   v1beta1.PlacementStatus{
        	SelectedResources:     Inverse(cmpopts.SortSlices, []v1beta1.ResourceIdentifier{{Version: "v1", Kind: "ConfigMap", Name: "test-configmap", Namespace: "application-1", ...}, {Version: "v1", Kind: "Namespace", Name: "application-1"}, {Group: "placement.kubernetes-fleet.io", Version: "v1beta1", Kind: "ClusterResourceEnvelope", Name: "test-cluster-resource-envelope", ...}, {Group: "placement.kubernetes-fleet.io", Version: "v1beta1", Kind: "ResourceEnvelope", Name: "test-resource-envelope", ...}}),
        	ObservedResourceIndex: "0",
        	PlacementStatuses: []v1beta1.ResourcePlacementStatus(Inverse(cmpopts.SortSlices, []v1beta1.ResourcePlacementStatus{
        		{ClusterName: "kind-cluster-1", ObservedResourceIndex: "0", Conditions: Inverse(cmpopts.SortSlices, []v1.Condition{{Type: "Applied", Status: "True", ObservedGeneration: 1, Reason: "AllWorkHaveBeenApplied", ...}, {Type: "Available", Status: "True", ObservedGeneration: 1, Reason: "AllWorkAreAvailable", ...}, {Type: "Overridden", Status: "True", ObservedGeneration: 1, Reason: "NoOverrideSpecified", ...}, {Type: "RolloutStarted", Status: "True", ObservedGeneration: 1, Reason: "RolloutStarted", ...}, ...})},
        		{ClusterName: "kind-cluster-2", ObservedResourceIndex: "0", Conditions: Inverse(cmpopts.SortSlices, []v1.Condition{{Type: "Applied", Status: "True", ObservedGeneration: 1, Reason: "AllWorkHaveBeenApplied", ...}, {Type: "Available", Status: "True", ObservedGeneration: 1, Reason: "AllWorkAreAvailable", ...}, {Type: "Overridden", Status: "True", ObservedGeneration: 1, Reason: "NoOverrideSpecified", ...}, {Type: "RolloutStarted", Status: "True", ObservedGeneration: 1, Reason: "RolloutStarted", ...}, ...})},
        		{
        			... // 5 identical fields
        			DriftedPlacements: nil,
        			DiffedPlacements:  nil,
        			Conditions: []v1.Condition(Inverse(cmpopts.SortSlices, []v1.Condition{
        				{
        					Type:               "Applied",
      - 					Status:             "False",
      + 					Status:             "True",
        					ObservedGeneration: 1,
        					... // 1 ignored field
      - 					Reason: "ApplyInProgress",
      + 					Reason: "AllWorkHaveBeenApplied",
        					... // 1 ignored field
        				},
      + 				{
      + 					Type:               "Available",
      + 					Status:             "True",
      + 					ObservedGeneration: 1,
      + 					Reason:             "AllWorkAreAvailable",
      + 				},
```

Fixes #

I have:

- [ ] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
