### PR TITLE
test: fix flaky capacity-based scheduling e2e

### DIFF
--- a/test/e2e/scheduler_watchers_test.go
+++ b/test/e2e/scheduler_watchers_test.go
@@ -20,6 +20,7 @@ package e2e
 
 import (
 	"fmt"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -1381,7 +1382,9 @@ var _ = Describe("responding to specific member cluster changes", func() {
 		It("should pick the new cluster", func() {
 			targetClusterNames := []string{memberCluster3WestProdName}
 			crpStatusUpdatedActual := crpStatusUpdatedActual(workResourceIdentifiers(), targetClusterNames, nil, "0")
-			Eventually(crpStatusUpdatedActual, workloadEventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update CRP status as expected")
+			// CRP should be scheduled only after member-agent reports the newly added capacity.
+			// Set the timeout to be a bit longer than the member cluster heartbeat period.
+			Eventually(crpStatusUpdatedActual, eventuallyDuration+time.Second*memberClusterHeartbeatPeriodSeconds, eventuallyInterval).Should(Succeed(), "Failed to update CRP status as expected")
 			Consistently(crpStatusUpdatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to update CRP status as expected")
 		})
 

--- a/test/e2e/setup_test.go
+++ b/test/e2e/setup_test.go
@@ -80,6 +80,8 @@ const (
 	azurePropertyProviderEnvVarValue    = "azure"
 	fleetClusterResourceIDAnnotationKey = "fleet.azure.com/cluster-resource-id"
 	fleetLocationAnnotationKey          = "fleet.azure.com/location"
+
+	memberClusterHeartbeatPeriodSeconds = 60
 )
 
 const (

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -81,7 +81,7 @@ func createMemberCluster(name, svcAccountName string, labels, annotations map[st
 				Kind:      "ServiceAccount",
 				Namespace: fleetSystemNS,
 			},
-			HeartbeatPeriodSeconds: 60,
+			HeartbeatPeriodSeconds: memberClusterHeartbeatPeriodSeconds,
 		},
 	}
 	Expect(hubClient.Create(ctx, mcObj)).To(Succeed(), "Failed to create member cluster object %s", name)


### PR DESCRIPTION
### Description of your changes
Local repro failed due to resources not fully applied yet (schedule fulfilled): 

The new node was added at 08:24:58:
```
I0630 08:24:58.547585       1 controllers/node.go:44] "Reconciliation starts for node objects in the Azure property provider" node="test-node"
```

Member-agent reports member cluster status every 60s, and it only reported the newly added capacity at 08:25:43 (45s after the node was added):
```
I0630 08:24:43.463797       1 v1beta1/member_controller.go:447] "Property provider cluster property collection completed" internalMemberCluster="fleet-member-kind-cluster-3/kind-cluster-3"
I0630 08:25:43.661744       1 v1beta1/member_controller.go:447] "Property provider cluster property collection completed" internalMemberCluster="fleet-member-kind-cluster-3/kind-cluster-3"
```
 
Test timed out but we can see the scheduled condition is set to true at 08:25:43 right after member agent reported new capacity:
```
{ClusterResourcePlacementScheduled True 1 2025-06-30 08:25:43 +0000 UTC SchedulingPolicyFulfilled found all cluster needed as specified by the scheduling policy, found 1 cluster(s)}
```
 It seems the scheduler bahaves correctly. It's just that our current timeout (45s) is not long enough. Set it as member cluster heartbeat report period + 10s to give it some buffer.

<!--

Briefly describe what this pull request does. We love pull requests that have a clear purpose. If yours fix an issue,
please uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
