### PR TITLE
interface: add placementScope in override API

### DIFF
--- a/apis/placement/v1alpha1/override_types.go
+++ b/apis/placement/v1alpha1/override_types.go
@@ -68,12 +68,32 @@ type ClusterResourceOverrideSpec struct {
 	Policy *OverridePolicy `json:"policy"`
 }
 
+// ResourceScope defines the scope of placement reference.
+type ResourceScope string
+
+const (
+	// ClusterScoped indicates placement is cluster-scoped.
+	ClusterScoped ResourceScope = "Cluster"
+
+	// NamespaceScoped indicates placement is namespace-scoped.
+	NamespaceScoped ResourceScope = "Namespaced"
+)
+
 // PlacementRef is the reference to a placement.
 // For now, we only support ClusterResourcePlacement.
 type PlacementRef struct {
 	// Name is the reference to the name of placement.
 	// +required
 	Name string `json:"name"`
+
+	// Scope defines the scope of the placement.
+	// A clusterResourceOverride can only reference a clusterResourcePlacement (cluster-scoped),
+	// and a resourceOverride can reference either a clusterResourcePlacement or resourcePlacement (namespaced).
+	// The referenced resourcePlacement must be in the same namespace as the resourceOverride.
+	// +kubebuilder:validation:Enum=Cluster;Namespaced
+	// +kubebuilder:default=Cluster
+	// +optional
+	Scope ResourceScope `json:"scope,omitempty"`
 }
 
 // OverridePolicy defines how to override the selected resources on the target clusters.

--- a/apis/placement/v1beta1/override_types.go
+++ b/apis/placement/v1beta1/override_types.go
@@ -67,12 +67,32 @@ type ClusterResourceOverrideSpec struct {
 	Policy *OverridePolicy `json:"policy"`
 }
 
+// ResourceScope defines the scope of placement reference.
+type ResourceScope string
+
+const (
+	// ClusterScoped indicates placement is cluster-scoped.
+	ClusterScoped ResourceScope = "Cluster"
+
+	// NamespaceScoped indicates placement is namespace-scoped.
+	NamespaceScoped ResourceScope = "Namespaced"
+)
+
 // PlacementRef is the reference to a placement.
 // For now, we only support ClusterResourcePlacement.
 type PlacementRef struct {
 	// Name is the reference to the name of placement.
 	// +required
 	Name string `json:"name"`
+
+	// Scope defines the scope of the placement.
+	// A clusterResourceOverride can only reference a clusterResourcePlacement (cluster-scoped),
+	// and a resourceOverride can reference either a clusterResourcePlacement or resourcePlacement (namespaced).
+	// The referenced resourcePlacement must be in the same namespace as the resourceOverride.
+	// +kubebuilder:validation:Enum=Cluster;Namespaced
+	// +kubebuilder:default=Cluster
+	// +optional
+	Scope ResourceScope `json:"scope,omitempty"`
 }
 
 // OverridePolicy defines how to override the selected resources on the target clusters.

--- a/config/crd/bases/placement.kubernetes-fleet.io_clusterresourceoverrides.yaml
+++ b/config/crd/bases/placement.kubernetes-fleet.io_clusterresourceoverrides.yaml
@@ -489,6 +489,17 @@ spec:
                   name:
                     description: Name is the reference to the name of placement.
                     type: string
+                  scope:
+                    default: Cluster
+                    description: |-
+                      Scope defines the scope of the placement.
+                      A clusterResourceOverride can only reference a clusterResourcePlacement (cluster-scoped),
+                      and a resourceOverride can reference either a clusterResourcePlacement or resourcePlacement (namespaced).
+                      The referenced resourcePlacement must be in the same namespace as the resourceOverride.
+                    enum:
+                    - Cluster
+                    - Namespaced
+                    type: string
                 required:
                 - name
                 type: object
@@ -838,6 +849,17 @@ spec:
                 properties:
                   name:
                     description: Name is the reference to the name of placement.
+                    type: string
+                  scope:
+                    default: Cluster
+                    description: |-
+                      Scope defines the scope of the placement.
+                      A clusterResourceOverride can only reference a clusterResourcePlacement (cluster-scoped),
+                      and a resourceOverride can reference either a clusterResourcePlacement or resourcePlacement (namespaced).
+                      The referenced resourcePlacement must be in the same namespace as the resourceOverride.
+                    enum:
+                    - Cluster
+                    - Namespaced
                     type: string
                 required:
                 - name

--- a/config/crd/bases/placement.kubernetes-fleet.io_clusterresourceoverridesnapshots.yaml
+++ b/config/crd/bases/placement.kubernetes-fleet.io_clusterresourceoverridesnapshots.yaml
@@ -521,6 +521,17 @@ spec:
                       name:
                         description: Name is the reference to the name of placement.
                         type: string
+                      scope:
+                        default: Cluster
+                        description: |-
+                          Scope defines the scope of the placement.
+                          A clusterResourceOverride can only reference a clusterResourcePlacement (cluster-scoped),
+                          and a resourceOverride can reference either a clusterResourcePlacement or resourcePlacement (namespaced).
+                          The referenced resourcePlacement must be in the same namespace as the resourceOverride.
+                        enum:
+                        - Cluster
+                        - Namespaced
+                        type: string
                     required:
                     - name
                     type: object
@@ -888,6 +899,17 @@ spec:
                     properties:
                       name:
                         description: Name is the reference to the name of placement.
+                        type: string
+                      scope:
+                        default: Cluster
+                        description: |-
+                          Scope defines the scope of the placement.
+                          A clusterResourceOverride can only reference a clusterResourcePlacement (cluster-scoped),
+                          and a resourceOverride can reference either a clusterResourcePlacement or resourcePlacement (namespaced).
+                          The referenced resourcePlacement must be in the same namespace as the resourceOverride.
+                        enum:
+                        - Cluster
+                        - Namespaced
                         type: string
                     required:
                     - name

--- a/config/crd/bases/placement.kubernetes-fleet.io_resourceoverrides.yaml
+++ b/config/crd/bases/placement.kubernetes-fleet.io_resourceoverrides.yaml
@@ -353,6 +353,17 @@ spec:
                   name:
                     description: Name is the reference to the name of placement.
                     type: string
+                  scope:
+                    default: Cluster
+                    description: |-
+                      Scope defines the scope of the placement.
+                      A clusterResourceOverride can only reference a clusterResourcePlacement (cluster-scoped),
+                      and a resourceOverride can reference either a clusterResourcePlacement or resourcePlacement (namespaced).
+                      The referenced resourcePlacement must be in the same namespace as the resourceOverride.
+                    enum:
+                    - Cluster
+                    - Namespaced
+                    type: string
                 required:
                 - name
                 type: object
@@ -651,6 +662,17 @@ spec:
                 properties:
                   name:
                     description: Name is the reference to the name of placement.
+                    type: string
+                  scope:
+                    default: Cluster
+                    description: |-
+                      Scope defines the scope of the placement.
+                      A clusterResourceOverride can only reference a clusterResourcePlacement (cluster-scoped),
+                      and a resourceOverride can reference either a clusterResourcePlacement or resourcePlacement (namespaced).
+                      The referenced resourcePlacement must be in the same namespace as the resourceOverride.
+                    enum:
+                    - Cluster
+                    - Namespaced
                     type: string
                 required:
                 - name

--- a/config/crd/bases/placement.kubernetes-fleet.io_resourceoverridesnapshots.yaml
+++ b/config/crd/bases/placement.kubernetes-fleet.io_resourceoverridesnapshots.yaml
@@ -385,6 +385,17 @@ spec:
                       name:
                         description: Name is the reference to the name of placement.
                         type: string
+                      scope:
+                        default: Cluster
+                        description: |-
+                          Scope defines the scope of the placement.
+                          A clusterResourceOverride can only reference a clusterResourcePlacement (cluster-scoped),
+                          and a resourceOverride can reference either a clusterResourcePlacement or resourcePlacement (namespaced).
+                          The referenced resourcePlacement must be in the same namespace as the resourceOverride.
+                        enum:
+                        - Cluster
+                        - Namespaced
+                        type: string
                     required:
                     - name
                     type: object
@@ -701,6 +712,17 @@ spec:
                     properties:
                       name:
                         description: Name is the reference to the name of placement.
+                        type: string
+                      scope:
+                        default: Cluster
+                        description: |-
+                          Scope defines the scope of the placement.
+                          A clusterResourceOverride can only reference a clusterResourcePlacement (cluster-scoped),
+                          and a resourceOverride can reference either a clusterResourcePlacement or resourcePlacement (namespaced).
+                          The referenced resourcePlacement must be in the same namespace as the resourceOverride.
+                        enum:
+                        - Cluster
+                        - Namespaced
                         type: string
                     required:
                     - name


### PR DESCRIPTION
### Description of your changes

Add scope field in placementRef in override API so that controller can differentiate if the placement referenced is clusterResourcePlacement or resourcePlacement.

API design followed CRD:
https://github.com/kubernetes/kubernetes/blob/032142c53e54e41aff516cf9515c175afeeffd32/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/types.go#L277C1-L283C2

<!--

Briefly describe what this pull request does. We love pull requests that have a clear purpose. If yours fix an issue,
please uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
