### PR TITLE
test: fix override api integration test flakiness

### DIFF
--- a/test/apis/placement/v1beta1/api_validation_integration_test.go
+++ b/test/apis/placement/v1beta1/api_validation_integration_test.go
@@ -1174,18 +1174,18 @@ var _ = Describe("Test placement v1beta1 API validation", func() {
 			})
 
 			It("should deny update of ClusterResourceOverride placement name", func() {
-				Expect(hubClient.Get(ctx, types.NamespacedName{Name: croName}, &cro)).Should(Succeed())
-				cro.Spec.Placement.Name = "different-placement"
-				err := hubClient.Update(ctx, &cro)
+				updatedCRO := cro.DeepCopy()
+				updatedCRO.Spec.Placement.Name = "different-placement"
+				err := hubClient.Update(ctx, updatedCRO)
 				var statusErr *k8sErrors.StatusError
 				Expect(errors.As(err, &statusErr)).To(BeTrue(), fmt.Sprintf("Update ClusterResourceOverride call produced error %s. Error type wanted is %s.", reflect.TypeOf(err), reflect.TypeOf(&k8sErrors.StatusError{})))
 				Expect(statusErr.ErrStatus.Message).Should(MatchRegexp("The placement field is immutable"))
 			})
 
 			It("should deny update of ClusterResourceOverride placement scope", func() {
-				Expect(hubClient.Get(ctx, types.NamespacedName{Name: croName}, &cro)).Should(Succeed())
-				cro.Spec.Placement.Scope = placementv1beta1.NamespaceScoped
-				err := hubClient.Update(ctx, &cro)
+				updatedCRO := cro.DeepCopy()
+				updatedCRO.Spec.Placement.Scope = placementv1beta1.NamespaceScoped
+				err := hubClient.Update(ctx, updatedCRO)
 				var statusErr *k8sErrors.StatusError
 				Expect(errors.As(err, &statusErr)).To(BeTrue(), fmt.Sprintf("Update ClusterResourceOverride call produced error %s. Error type wanted is %s.", reflect.TypeOf(err), reflect.TypeOf(&k8sErrors.StatusError{})))
 				Expect(statusErr.ErrStatus.Message).Should(ContainSubstring("placement reference cannot be Namespaced scope"))
@@ -1211,9 +1211,9 @@ var _ = Describe("Test placement v1beta1 API validation", func() {
 			})
 
 			It("should deny update of ClusterResourceOverride placement from non-nil to nil", func() {
-				Expect(hubClient.Get(ctx, types.NamespacedName{Name: croName}, &cro)).Should(Succeed())
-				cro.Spec.Placement = nil
-				err := hubClient.Update(ctx, &cro)
+				updatedCRO := cro.DeepCopy()
+				updatedCRO.Spec.Placement = nil
+				err := hubClient.Update(ctx, updatedCRO)
 				var statusErr *k8sErrors.StatusError
 				Expect(errors.As(err, &statusErr)).To(BeTrue(), fmt.Sprintf("Update ClusterResourceOverride call produced error %s. Error type wanted is %s.", reflect.TypeOf(err), reflect.TypeOf(&k8sErrors.StatusError{})))
 				Expect(statusErr.ErrStatus.Message).Should(MatchRegexp("The placement field is immutable"))
@@ -1294,9 +1294,9 @@ var _ = Describe("Test placement v1beta1 API validation", func() {
 			})
 
 			It("should deny update of ResourceOverride placement name", func() {
-				Expect(hubClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: roName}, &ro)).Should(Succeed())
-				ro.Spec.Placement.Name = "different-placement"
-				err := hubClient.Update(ctx, &ro)
+				updatedRO := ro.DeepCopy()
+				updatedRO.Spec.Placement.Name = "different-placement"
+				err := hubClient.Update(ctx, updatedRO)
 				var statusErr *k8sErrors.StatusError
 				Expect(errors.As(err, &statusErr)).To(BeTrue(), fmt.Sprintf("Update ResourceOverride call produced error %s. Error type wanted is %s.", reflect.TypeOf(err), reflect.TypeOf(&k8sErrors.StatusError{})))
 				Expect(statusErr.ErrStatus.Message).Should(MatchRegexp("The placement field is immutable"))
@@ -1323,18 +1323,18 @@ var _ = Describe("Test placement v1beta1 API validation", func() {
 			})
 
 			It("should deny update of ResourceOverride placement from non-nil to nil", func() {
-				Expect(hubClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: roName}, &ro)).Should(Succeed())
-				ro.Spec.Placement = nil
-				err := hubClient.Update(ctx, &ro)
+				updatedRO := ro.DeepCopy()
+				updatedRO.Spec.Placement = nil
+				err := hubClient.Update(ctx, updatedRO)
 				var statusErr *k8sErrors.StatusError
 				Expect(errors.As(err, &statusErr)).To(BeTrue(), fmt.Sprintf("Update ResourceOverride call produced error %s. Error type wanted is %s.", reflect.TypeOf(err), reflect.TypeOf(&k8sErrors.StatusError{})))
 				Expect(statusErr.ErrStatus.Message).Should(MatchRegexp("The placement field is immutable"))
 			})
 
 			It("should deny update of ResourceOverride placement from cluster-scoped to namespace-scoped", func() {
-				Expect(hubClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: roName}, &ro)).Should(Succeed())
-				ro.Spec.Placement.Scope = placementv1beta1.NamespaceScoped
-				err := hubClient.Update(ctx, &ro)
+				updatedRO := ro.DeepCopy()
+				updatedRO.Spec.Placement.Scope = placementv1beta1.NamespaceScoped
+				err := hubClient.Update(ctx, updatedRO)
 				var statusErr *k8sErrors.StatusError
 				Expect(errors.As(err, &statusErr)).To(BeTrue(), fmt.Sprintf("Update ResourceOverride call produced error %s. Error type wanted is %s.", reflect.TypeOf(err), reflect.TypeOf(&k8sErrors.StatusError{})))
 				Expect(statusErr.ErrStatus.Message).Should(MatchRegexp("The placement field is immutable"))


### PR DESCRIPTION
### Description of your changes
The PR fixes the integration test flakiness: https://github.com/kubefleet-dev/kubefleet/actions/runs/17082725288/job/48440323804?pr=202

Get CRO/RO failed due to cache inconsistency. Instead of retrieving the CRO/RO again, we directly use the CRO/RO returned from the `create()` function.
<!--

Briefly describe what this pull request does. We love pull requests that have a clear purpose. If yours fix an issue,
please uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
