### PR TITLE
feat: add support for degraded diff drift calculation

### DIFF
--- a/apis/cluster/v1beta1/zz_generated.deepcopy.go
+++ b/apis/cluster/v1beta1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )

--- a/apis/placement/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/placement/v1alpha1/zz_generated.deepcopy.go
@@ -22,7 +22,7 @@ package v1alpha1
 
 import (
 	"github.com/kubefleet-dev/kubefleet/apis/placement/v1beta1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )

--- a/apis/placement/v1beta1/zz_generated.deepcopy.go
+++ b/apis/placement/v1beta1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -22,7 +22,7 @@ package v1alpha1
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/pkg/controllers/workapplier/apply.go
+++ b/pkg/controllers/workapplier/apply.go
@@ -320,8 +320,12 @@ func (r *Reconciler) serverSideApply(
 		Resource(*gvr).Namespace(manifestObj.GetNamespace()).
 		Apply(ctx, manifestObj.GetName(), manifestObj, applyOpts)
 	if err != nil {
-		wrappedErr := controller.NewAPIServerError(false, err)
-		return nil, fmt.Errorf("failed to apply the manifest object: %w", wrappedErr)
+		// Note (chenyu1): the current implementation of NewAPIServerError flattens the passed-in error,
+		// effectively dropping the error hierarchy. This can be an issue if the caller of the function
+		// needs to identify a specific error in the hierarchy; to avoid this, this method will not return
+		// any error wrapped by NewAPIServerError.
+		_ = controller.NewAPIServerError(false, err)
+		return nil, fmt.Errorf("failed to apply the manifest object: an error is returned by the API server: %w", err)
 	}
 	return appliedObj, nil
 }

--- a/pkg/controllers/workapplier/controller.go
+++ b/pkg/controllers/workapplier/controller.go
@@ -276,6 +276,7 @@ const (
 	ApplyOrReportDiffResTypeNotTakenOver                   ManifestProcessingApplyOrReportDiffResultType = "NotTakenOver"
 	ApplyOrReportDiffResTypeFailedToRunDriftDetection      ManifestProcessingApplyOrReportDiffResultType = "FailedToRunDriftDetection"
 	ApplyOrReportDiffResTypeFoundDrifts                    ManifestProcessingApplyOrReportDiffResultType = "FoundDrifts"
+	ApplyOrReportDiffResTypeFoundDriftsInDegradedMode      ManifestProcessingApplyOrReportDiffResultType = "FoundDriftsInDegradedMode"
 	// Note that the reason string below uses the same value as kept in the old work applier.
 	ApplyOrReportDiffResTypeFailedToApply ManifestProcessingApplyOrReportDiffResultType = "ManifestApplyFailed"
 
@@ -297,15 +298,17 @@ const (
 	ApplyOrReportDiffResTypeFailedToReportDiff ManifestProcessingApplyOrReportDiffResultType = "FailedToReportDiff"
 
 	// The result type for successful diff reportings.
-	ApplyOrReportDiffResTypeFoundDiff   ManifestProcessingApplyOrReportDiffResultType = "FoundDiff"
-	ApplyOrReportDiffResTypeNoDiffFound ManifestProcessingApplyOrReportDiffResultType = "NoDiffFound"
+	ApplyOrReportDiffResTypeFoundDiff               ManifestProcessingApplyOrReportDiffResultType = "FoundDiff"
+	ApplyOrReportDiffResTypeFoundDiffInDegradedMode ManifestProcessingApplyOrReportDiffResultType = "FoundDiffInDegradedMode"
+	ApplyOrReportDiffResTypeNoDiffFound             ManifestProcessingApplyOrReportDiffResultType = "NoDiffFound"
 )
 
 const (
 	// The descriptions for different diff reporting result types.
-	ApplyOrReportDiffResTypeFailedToReportDiffDescription = "Failed to report the diff between the hub cluster and the member cluster (error = %s)"
-	ApplyOrReportDiffResTypeNoDiffFoundDescription        = "No diff has been found between the hub cluster and the member cluster"
-	ApplyOrReportDiffResTypeFoundDiffDescription          = "Diff has been found between the hub cluster and the member cluster"
+	ApplyOrReportDiffResTypeFailedToReportDiffDescription      = "Failed to report the diff between the hub cluster and the member cluster (error = %s)"
+	ApplyOrReportDiffResTypeNoDiffFoundDescription             = "No diff has been found between the hub cluster and the member cluster"
+	ApplyOrReportDiffResTypeFoundDiffDescription               = "Diff has been found between the hub cluster and the member cluster"
+	ApplyOrReportDiffResTypeFoundDiffInDegradedModeDescription = "Diff has been found in degraded mode: cannot perform partial comparison as the member cluster API server rejected the manifest object (object is invalid)"
 )
 
 var (
@@ -319,6 +322,7 @@ var (
 		ApplyOrReportDiffResTypeNotTakenOver,
 		ApplyOrReportDiffResTypeFailedToRunDriftDetection,
 		ApplyOrReportDiffResTypeFoundDrifts,
+		ApplyOrReportDiffResTypeFoundDriftsInDegradedMode,
 		ApplyOrReportDiffResTypeFailedToApply,
 		ApplyOrReportDiffResTypeAppliedWithFailedDriftDetection,
 		ApplyOrReportDiffResTypeApplied,

--- a/pkg/controllers/workapplier/controller_integration_test.go
+++ b/pkg/controllers/workapplier/controller_integration_test.go
@@ -27,6 +27,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -276,6 +277,60 @@ func regularDeploymentObjectAppliedActual(nsName, deployName string, appliedWork
 		}
 		if diff := cmp.Diff(rebuiltGotDeploy, wantDeploy); diff != "" {
 			return fmt.Errorf("deployment diff (-got +want):\n%s", diff)
+		}
+		return nil
+	}
+}
+
+func regularJobObjectAppliedActual(nsName, jobName string, appliedWorkOwnerRef *metav1.OwnerReference) func() error {
+	return func() error {
+		// Retrieve the Job object.
+		gotJob := &batchv1.Job{}
+		if err := memberClient.Get(ctx, client.ObjectKey{Namespace: nsName, Name: jobName}, gotJob); err != nil {
+			return fmt.Errorf("failed to retrieve the Job object: %w", err)
+		}
+
+		// Check that the Job object has been created as expected.
+
+		// To ignore default values automatically, here the test suite rebuilds the objects.
+		wantJob := job.DeepCopy()
+		wantJob.TypeMeta = metav1.TypeMeta{}
+		wantJob.Namespace = nsName
+		wantJob.Name = jobName
+		wantJob.OwnerReferences = []metav1.OwnerReference{
+			*appliedWorkOwnerRef,
+		}
+
+		rebuiltGotJob := &batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:       gotJob.Namespace,
+				Name:            gotJob.Name,
+				OwnerReferences: gotJob.OwnerReferences,
+			},
+			Spec: batchv1.JobSpec{
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"app": gotJob.Spec.Template.ObjectMeta.Labels["app"],
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:    gotJob.Spec.Template.Spec.Containers[0].Name,
+								Image:   gotJob.Spec.Template.Spec.Containers[0].Image,
+								Command: gotJob.Spec.Template.Spec.Containers[0].Command,
+							},
+						},
+						RestartPolicy: gotJob.Spec.Template.Spec.RestartPolicy,
+					},
+				},
+				Parallelism: gotJob.Spec.Parallelism,
+				Completions: gotJob.Spec.Completions,
+			},
+		}
+		if diff := cmp.Diff(rebuiltGotJob, wantJob); diff != "" {
+			return fmt.Errorf("job diff (-got +want):\n%s", diff)
 		}
 		return nil
 	}
@@ -624,6 +679,22 @@ func regularDeployNotRemovedActual(nsName, deployName string) func() error {
 		}
 		if err := memberClient.Get(ctx, client.ObjectKey{Namespace: nsName, Name: deployName}, deploy); err != nil {
 			return fmt.Errorf("failed to retrieve the Deployment object: %w", err)
+		}
+		return nil
+	}
+}
+
+func regularJobNotRemovedActual(nsName, jobName string) func() error {
+	return func() error {
+		// Retrieve the Job object.
+		job := &batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: nsName,
+				Name:      jobName,
+			},
+		}
+		if err := memberClient.Get(ctx, client.ObjectKey{Namespace: nsName, Name: jobName}, job); err != nil {
+			return fmt.Errorf("failed to retrieve the Job object: %w", err)
 		}
 		return nil
 	}
@@ -3676,6 +3747,403 @@ var _ = Describe("drift detection and takeover", func() {
 		})
 	})
 
+	// Note (chenyu1): this test case is built upon the mutable scheduling directives
+	// feature that is enabled in Kubernetes since version 1.27. This feature is designed
+	// specifically for cloud-native queue implementations, which allow them to
+	// fine-tune how Job pods are scheduled by modifying certain scheduling-related
+	// fields when the Job is just created in the suspended state. Without this feature
+	// we wouldn't be able to introduce drifts to Job objects once they are created.
+	Context("detect drifts (apply if no drift, drift occurred, partial comparison, degraded mode)", Ordered, func() {
+		workName := fmt.Sprintf(workNameTemplate, utils.RandStr())
+		// The environment prepared by the envtest package does not support namespace
+		// deletion; each test case would use a new namespace.
+		nsName := fmt.Sprintf(nsNameTemplate, utils.RandStr())
+
+		var appliedWorkOwnerRef *metav1.OwnerReference
+		var regularNS *corev1.Namespace
+		var regularJob *batchv1.Job
+
+		BeforeAll(func() {
+			// Prepare a NS object.
+			regularNS = ns.DeepCopy()
+			regularNS.Name = nsName
+			regularNSJSON := marshalK8sObjJSON(regularNS)
+
+			// Prepare a Job object.
+			regularJob = job.DeepCopy()
+			regularJob.Namespace = nsName
+			regularJob.Name = jobName
+			regularJob.Spec.Suspend = ptr.To(true)
+			regularJob.Spec.Template.Labels[dummyLabelKey] = dummyLabelValue1
+			regularJobJSON := marshalK8sObjJSON(regularJob)
+
+			// Create a new Work object with all the manifest JSONs and proper apply strategy.
+			applyStrategy := &fleetv1beta1.ApplyStrategy{
+				ComparisonOption: fleetv1beta1.ComparisonOptionTypePartialComparison,
+				WhenToApply:      fleetv1beta1.WhenToApplyTypeIfNotDrifted,
+				WhenToTakeOver:   fleetv1beta1.WhenToTakeOverTypeAlways,
+			}
+			createWorkObject(workName, applyStrategy, regularNSJSON, regularJobJSON)
+		})
+
+		It("should add cleanup finalizer to the Work object", func() {
+			finalizerAddedActual := workFinalizerAddedActual(workName)
+			Eventually(finalizerAddedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to add cleanup finalizer to the Work object")
+		})
+
+		It("should prepare an AppliedWork object", func() {
+			appliedWorkCreatedActual := appliedWorkCreatedActual(workName)
+			Eventually(appliedWorkCreatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to prepare an AppliedWork object")
+
+			appliedWorkOwnerRef = prepareAppliedWorkOwnerRef(workName)
+		})
+
+		It("should update the Work object status", func() {
+			// Prepare the status information.
+			workConds := []metav1.Condition{
+				{
+					Type:   fleetv1beta1.WorkConditionTypeApplied,
+					Status: metav1.ConditionTrue,
+					Reason: condition.WorkAllManifestsAppliedReason,
+				},
+				{
+					Type:   fleetv1beta1.WorkConditionTypeAvailable,
+					Status: metav1.ConditionTrue,
+					Reason: condition.WorkNotTrackableReason,
+				},
+			}
+			manifestConds := []fleetv1beta1.ManifestCondition{
+				{
+					Identifier: fleetv1beta1.WorkResourceIdentifier{
+						Ordinal:  0,
+						Group:    "",
+						Version:  "v1",
+						Kind:     "Namespace",
+						Resource: "namespaces",
+						Name:     nsName,
+					},
+					Conditions: []metav1.Condition{
+						{
+							Type:               fleetv1beta1.WorkConditionTypeApplied,
+							Status:             metav1.ConditionTrue,
+							Reason:             string(ApplyOrReportDiffResTypeApplied),
+							ObservedGeneration: 0,
+						},
+						{
+							Type:               fleetv1beta1.WorkConditionTypeAvailable,
+							Status:             metav1.ConditionTrue,
+							Reason:             string(ManifestProcessingAvailabilityResultTypeAvailable),
+							ObservedGeneration: 0,
+						},
+					},
+				},
+				{
+					Identifier: fleetv1beta1.WorkResourceIdentifier{
+						Ordinal:   1,
+						Group:     "batch",
+						Version:   "v1",
+						Kind:      "Job",
+						Resource:  "jobs",
+						Name:      jobName,
+						Namespace: nsName,
+					},
+					Conditions: []metav1.Condition{
+						{
+							Type:               fleetv1beta1.WorkConditionTypeApplied,
+							Status:             metav1.ConditionTrue,
+							Reason:             string(ApplyOrReportDiffResTypeApplied),
+							ObservedGeneration: 1,
+						},
+						{
+							Type:               fleetv1beta1.WorkConditionTypeAvailable,
+							Status:             metav1.ConditionTrue,
+							Reason:             string(ManifestProcessingAvailabilityResultTypeNotTrackable),
+							ObservedGeneration: 1,
+						},
+					},
+				},
+			}
+
+			workStatusUpdatedActual := workStatusUpdated(workName, workConds, manifestConds, nil, nil)
+			Eventually(workStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update work status")
+		})
+
+		It("should apply all manifests", func() {
+			// Ensure that the NS object has been applied as expected.
+			regularNSObjectAppliedActual := regularNSObjectAppliedActual(nsName, appliedWorkOwnerRef)
+			Eventually(regularNSObjectAppliedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to apply the namespace object")
+
+			Expect(memberClient.Get(ctx, client.ObjectKey{Name: nsName}, regularNS)).To(Succeed(), "Failed to retrieve the NS object")
+
+			// Ensure that the Job object has been applied as expected.
+			regularJobObjectAppliedActual := regularJobObjectAppliedActual(nsName, jobName, appliedWorkOwnerRef)
+			Eventually(regularJobObjectAppliedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to apply the job object")
+
+			Expect(memberClient.Get(ctx, client.ObjectKey{Name: jobName, Namespace: nsName}, regularJob)).To(Succeed(), "Failed to retrieve the Job object")
+		})
+
+		It("should update the AppliedWork object status", func() {
+			// Prepare the status information.
+			appliedResourceMeta := []fleetv1beta1.AppliedResourceMeta{
+				{
+					WorkResourceIdentifier: fleetv1beta1.WorkResourceIdentifier{
+						Ordinal:  0,
+						Group:    "",
+						Version:  "v1",
+						Kind:     "Namespace",
+						Resource: "namespaces",
+						Name:     nsName,
+					},
+					UID: regularNS.UID,
+				},
+				{
+					WorkResourceIdentifier: fleetv1beta1.WorkResourceIdentifier{
+						Ordinal:   1,
+						Group:     "batch",
+						Version:   "v1",
+						Kind:      "Job",
+						Resource:  "jobs",
+						Name:      jobName,
+						Namespace: nsName,
+					},
+					UID: regularJob.UID,
+				},
+			}
+
+			appliedWorkStatusUpdatedActual := appliedWorkStatusUpdated(workName, appliedResourceMeta)
+			Eventually(appliedWorkStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update appliedWork status")
+		})
+
+		It("can update the job object directly on the member cluster side", func() {
+			// Update the labels in the pod template.
+			//
+			// This is only possible when the Job is just created in the suspended state.
+			Expect(memberClient.Get(ctx, client.ObjectKey{Namespace: nsName, Name: jobName}, regularJob)).To(Succeed(), "Failed to retrieve the Job object")
+
+			// Use an Eventually block to guard transient errors.
+			Eventually(func() error {
+				regularJob.Spec.Template.Labels[dummyLabelKey] = dummyLabelValue2
+				return memberClient.Update(ctx, regularJob)
+			}, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update the Job object")
+
+			// Unsuspend the Job object. This would make the pod template immutable.
+			Eventually(func() error {
+				regularJob.Spec.Suspend = ptr.To(false)
+				return memberClient.Update(ctx, regularJob)
+			}, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to unsuspend the Job object")
+		})
+
+		It("should update the Work object status", func() {
+			// Prepare the status information.
+			workConds := []metav1.Condition{
+				{
+					Type:   fleetv1beta1.WorkConditionTypeApplied,
+					Status: metav1.ConditionFalse,
+					Reason: condition.WorkNotAllManifestsAppliedReason,
+				},
+			}
+			manifestConds := []fleetv1beta1.ManifestCondition{
+				{
+					Identifier: fleetv1beta1.WorkResourceIdentifier{
+						Ordinal:  0,
+						Group:    "",
+						Version:  "v1",
+						Kind:     "Namespace",
+						Resource: "namespaces",
+						Name:     nsName,
+					},
+					Conditions: []metav1.Condition{
+						{
+							Type:               fleetv1beta1.WorkConditionTypeApplied,
+							Status:             metav1.ConditionTrue,
+							Reason:             string(ApplyOrReportDiffResTypeApplied),
+							ObservedGeneration: 0,
+						},
+						{
+							Type:               fleetv1beta1.WorkConditionTypeAvailable,
+							Status:             metav1.ConditionTrue,
+							Reason:             string(ManifestProcessingAvailabilityResultTypeAvailable),
+							ObservedGeneration: 0,
+						},
+					},
+				},
+				{
+					Identifier: fleetv1beta1.WorkResourceIdentifier{
+						Ordinal:   1,
+						Group:     "batch",
+						Version:   "v1",
+						Kind:      "Job",
+						Resource:  "jobs",
+						Name:      jobName,
+						Namespace: nsName,
+					},
+					Conditions: []metav1.Condition{
+						{
+							Type:               fleetv1beta1.WorkConditionTypeApplied,
+							Status:             metav1.ConditionFalse,
+							Reason:             string(ApplyOrReportDiffResTypeFoundDriftsInDegradedMode),
+							ObservedGeneration: regularJob.Generation,
+						},
+					},
+					DriftDetails: &fleetv1beta1.DriftDetails{
+						ObservedInMemberClusterGeneration: regularJob.Generation,
+						ObservedDrifts: []fleetv1beta1.PatchDetail{
+							{
+								Path:          "/spec/template/metadata/labels/foo",
+								ValueInMember: dummyLabelValue2,
+								ValueInHub:    dummyLabelValue1,
+							},
+						},
+					},
+				},
+			}
+
+			// Use custom status comparison logic as in this test case drift calculation is expected
+			// to run in degraded mode, which includes additional dynamic output that need to be
+			// filtered out.
+			Eventually(func() error {
+				// Retrieve the Work object.
+				work := &fleetv1beta1.Work{}
+				if err := hubClient.Get(ctx, client.ObjectKey{Name: workName, Namespace: memberReservedNSName}, work); err != nil {
+					return fmt.Errorf("failed to retrieve the Work object: %w", err)
+				}
+
+				// Prepare the expected Work object status.
+
+				// Update the conditions with the observed generation.
+				//
+				// Note that the observed generation of a manifest condition is that of an applied
+				// resource, not that of the Work object.
+				for idx := range workConds {
+					workConds[idx].ObservedGeneration = work.Generation
+				}
+				wantWorkStatus := fleetv1beta1.WorkStatus{
+					Conditions:         workConds,
+					ManifestConditions: manifestConds,
+				}
+
+				if len(work.Status.ManifestConditions) == 2 && work.Status.ManifestConditions[1].DriftDetails != nil {
+					println(fmt.Sprintf("see me:\n%+v", work.Status.ManifestConditions[1].DriftDetails.ObservedDrifts))
+				}
+				// Check that the Work object status has been updated as expected.
+				if diff := cmp.Diff(
+					work.Status, wantWorkStatus,
+					ignoreFieldConditionLTTMsg,
+					ignoreDiffDetailsObsTime, ignoreDriftDetailsObsTime,
+					cmpopts.SortSlices(lessFuncPatchDetail),
+					cmpopts.IgnoreSliceElements(func(d fleetv1beta1.PatchDetail) bool {
+						return d.Path != "/spec/template/metadata/labels/foo"
+					}),
+				); diff != "" {
+					return fmt.Errorf("work status diff (-got, +want):\n%s", diff)
+				}
+
+				// For simplicity reasons, the diff timestamps are not checked.
+				return nil
+			}, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update work status")
+		})
+
+		It("should not apply the job manifest", func() {
+			// Ensure that the changes made before have not been overwritten.
+			Consistently(func() error {
+				// Retrieve the Job object.
+				gotJob := &batchv1.Job{}
+				if err := memberClient.Get(ctx, client.ObjectKey{Namespace: nsName, Name: jobName}, gotJob); err != nil {
+					return fmt.Errorf("failed to retrieve the Job object: %w", err)
+				}
+
+				// Check that the Job object has been created as expected.
+
+				// To ignore default values automatically, here the test suite rebuilds the objects.
+				wantJob := job.DeepCopy()
+				wantJob.TypeMeta = metav1.TypeMeta{}
+				wantJob.Namespace = nsName
+				wantJob.Name = jobName
+				wantJob.OwnerReferences = []metav1.OwnerReference{
+					*appliedWorkOwnerRef,
+				}
+				wantJob.Spec.Template.Labels[dummyLabelKey] = dummyLabelValue2
+				wantJob.Spec.Suspend = ptr.To(false)
+
+				rebuiltGotJob := &batchv1.Job{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:       gotJob.Namespace,
+						Name:            gotJob.Name,
+						OwnerReferences: gotJob.OwnerReferences,
+					},
+					Spec: batchv1.JobSpec{
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{
+									"app":         gotJob.Spec.Template.ObjectMeta.Labels["app"],
+									dummyLabelKey: gotJob.Spec.Template.ObjectMeta.Labels[dummyLabelKey],
+								},
+							},
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name:    gotJob.Spec.Template.Spec.Containers[0].Name,
+										Image:   gotJob.Spec.Template.Spec.Containers[0].Image,
+										Command: gotJob.Spec.Template.Spec.Containers[0].Command,
+									},
+								},
+								RestartPolicy: gotJob.Spec.Template.Spec.RestartPolicy,
+							},
+						},
+						Suspend:     gotJob.Spec.Suspend,
+						Parallelism: gotJob.Spec.Parallelism,
+						Completions: gotJob.Spec.Completions,
+					},
+				}
+				if diff := cmp.Diff(rebuiltGotJob, wantJob); diff != "" {
+					return fmt.Errorf("job diff (-got +want):\n%s", diff)
+				}
+				return nil
+			}, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to leave the Job object alone")
+
+			Expect(memberClient.Get(ctx, client.ObjectKey{Name: jobName, Namespace: nsName}, regularJob)).To(Succeed(), "Failed to retrieve the Job object")
+		})
+
+		It("should update the AppliedWork object status", func() {
+			// Prepare the status information.
+			appliedResourceMeta := []fleetv1beta1.AppliedResourceMeta{
+				{
+					WorkResourceIdentifier: fleetv1beta1.WorkResourceIdentifier{
+						Ordinal:  0,
+						Group:    "",
+						Version:  "v1",
+						Kind:     "Namespace",
+						Resource: "namespaces",
+						Name:     nsName,
+					},
+					UID: regularNS.UID,
+				},
+			}
+
+			appliedWorkStatusUpdatedActual := appliedWorkStatusUpdated(workName, appliedResourceMeta)
+			Eventually(appliedWorkStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update appliedWork status")
+		})
+
+		AfterAll(func() {
+			// Delete the Work object and related resources.
+			deleteWorkObject(workName)
+
+			// Ensure that the Job object has been left alone.
+			jobNotRemovedActual := regularJobNotRemovedActual(nsName, jobName)
+			Consistently(jobNotRemovedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to remove the job object")
+
+			// Ensure that the AppliedWork object has been removed.
+			appliedWorkRemovedActual := appliedWorkRemovedActual(workName, nsName)
+			Eventually(appliedWorkRemovedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to remove the AppliedWork object")
+
+			workRemovedActual := workRemovedActual(workName)
+			Eventually(workRemovedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to remove the Work object")
+
+			// The environment prepared by the envtest package does not support namespace
+			// deletion; consequently this test suite would not attempt so verify its deletion.
+		})
+	})
+
 	// For simplicity reasons, this test case will only involve a NS object.
 	Context("detect drifts (apply if no drift, drift occurred, full comparison)", Ordered, func() {
 		workName := fmt.Sprintf(workNameTemplate, utils.RandStr())
@@ -5769,6 +6237,272 @@ var _ = Describe("report diff", func() {
 		AfterAll(func() {
 			// Delete the Work object and related resources.
 			deleteWorkObject(workName)
+
+			// Ensure that the AppliedWork object has been removed.
+			appliedWorkRemovedActual := appliedWorkRemovedActual(workName, nsName)
+			Eventually(appliedWorkRemovedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to remove the AppliedWork object")
+
+			workRemovedActual := workRemovedActual(workName)
+			Eventually(workRemovedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to remove the Work object")
+
+			// The environment prepared by the envtest package does not support namespace
+			// deletion; consequently this test suite would not attempt so verify its deletion.
+		})
+	})
+
+	Context("report diff only (partial comparison, degraded)", Ordered, func() {
+		workName := fmt.Sprintf(workNameTemplate, utils.RandStr())
+		// The environment prepared by the envtest package does not support namespace
+		// deletion; each test case would use a new namespace.
+		nsName := fmt.Sprintf(nsNameTemplate, utils.RandStr())
+
+		//var appliedWorkOwnerRef *metav1.OwnerReference
+		var regularNS *corev1.Namespace
+		var regularJob *batchv1.Job
+
+		BeforeAll(func() {
+			// Prepare a NS object.
+			regularNS = ns.DeepCopy()
+			regularNS.Name = nsName
+			regularNSJSON := marshalK8sObjJSON(regularNS)
+
+			// Prepare a Job object.
+			regularJob = job.DeepCopy()
+			regularJob.Namespace = nsName
+			regularJob.Name = jobName
+
+			// Create the objects first in the member cluster.
+			Expect(memberClient.Create(ctx, regularNS)).To(Succeed(), "Failed to create the NS object")
+			Expect(memberClient.Create(ctx, regularJob)).To(Succeed(), "Failed to create the Job object")
+
+			// Update the values on the hub cluster side so that diffs will be found.
+			updatedJob := job.DeepCopy()
+			updatedJob.Namespace = nsName
+			updatedJob.Name = jobName
+			// `.spec.completions` is an immutable field in Job objects.
+			updatedJob.Spec.Completions = ptr.To(int32(3))
+			// `.spec.template` is an immutable field in Job objects.
+			updatedJob.Spec.Template.Spec.Containers[0].Image = "busybox:v0.0.1"
+			updatedJSONJSON := marshalK8sObjJSON(updatedJob)
+
+			// Create a new Work object with all the manifest JSONs and proper apply strategy.
+			applyStrategy := &fleetv1beta1.ApplyStrategy{
+				ComparisonOption: fleetv1beta1.ComparisonOptionTypePartialComparison,
+				Type:             fleetv1beta1.ApplyStrategyTypeReportDiff,
+				WhenToTakeOver:   fleetv1beta1.WhenToTakeOverTypeNever,
+			}
+			createWorkObject(workName, applyStrategy, regularNSJSON, updatedJSONJSON)
+		})
+
+		It("should add cleanup finalizer to the Work object", func() {
+			finalizerAddedActual := workFinalizerAddedActual(workName)
+			Eventually(finalizerAddedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to add cleanup finalizer to the Work object")
+		})
+
+		It("should prepare an AppliedWork object", func() {
+			appliedWorkCreatedActual := appliedWorkCreatedActual(workName)
+			Eventually(appliedWorkCreatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to prepare an AppliedWork object")
+
+			appliedWorkOwnerRef = prepareAppliedWorkOwnerRef(workName)
+		})
+
+		It("should update the Work object status", func() {
+			// Prepare the status information.
+			workConds := []metav1.Condition{
+				{
+					Type:   fleetv1beta1.WorkConditionTypeDiffReported,
+					Status: metav1.ConditionFalse,
+					Reason: condition.WorkNotAllManifestsDiffReportedReason,
+				},
+			}
+			manifestConds := []fleetv1beta1.ManifestCondition{
+				{
+					Identifier: fleetv1beta1.WorkResourceIdentifier{
+						Ordinal:  0,
+						Group:    "",
+						Version:  "v1",
+						Kind:     "Namespace",
+						Resource: "namespaces",
+						Name:     nsName,
+					},
+					Conditions: []metav1.Condition{
+						{
+							Type:               fleetv1beta1.WorkConditionTypeDiffReported,
+							Status:             metav1.ConditionTrue,
+							Reason:             string(ApplyOrReportDiffResTypeNoDiffFound),
+							ObservedGeneration: 0,
+						},
+					},
+				},
+				{
+					Identifier: fleetv1beta1.WorkResourceIdentifier{
+						Ordinal:   1,
+						Group:     "batch",
+						Version:   "v1",
+						Kind:      "Job",
+						Resource:  "jobs",
+						Name:      jobName,
+						Namespace: nsName,
+					},
+					Conditions: []metav1.Condition{
+						{
+							Type:               fleetv1beta1.WorkConditionTypeDiffReported,
+							Status:             metav1.ConditionTrue,
+							Reason:             string(ApplyOrReportDiffResTypeFoundDiffInDegradedMode),
+							ObservedGeneration: 1,
+						},
+					},
+					DiffDetails: &fleetv1beta1.DiffDetails{
+						ObservedInMemberClusterGeneration: &regularJob.Generation,
+						ObservedDiffs: []fleetv1beta1.PatchDetail{
+							{
+								Path:          "/spec/completions",
+								ValueInMember: "2",
+								ValueInHub:    "3",
+							},
+							{
+								Path:          "/spec/template/spec/containers/0/image",
+								ValueInMember: "busybox",
+								ValueInHub:    "busybox:v0.0.1",
+							},
+						},
+					},
+				},
+			}
+
+			// Use custom status comparison logic as in this test case diff calculation is expected
+			// to run in degraded mode, which includes additional dynamic output that need to be
+			// filtered out.
+			Eventually(func() error {
+				// Retrieve the Work object.
+				work := &fleetv1beta1.Work{}
+				if err := hubClient.Get(ctx, client.ObjectKey{Name: workName, Namespace: memberReservedNSName}, work); err != nil {
+					return fmt.Errorf("failed to retrieve the Work object: %w", err)
+				}
+
+				// Prepare the expected Work object status.
+
+				// Update the conditions with the observed generation.
+				//
+				// Note that the observed generation of a manifest condition is that of an applied
+				// resource, not that of the Work object.
+				for idx := range workConds {
+					workConds[idx].ObservedGeneration = work.Generation
+				}
+				wantWorkStatus := fleetv1beta1.WorkStatus{
+					Conditions:         workConds,
+					ManifestConditions: manifestConds,
+				}
+
+				// Check that the Work object status has been updated as expected.
+				if diff := cmp.Diff(
+					work.Status, wantWorkStatus,
+					ignoreFieldConditionLTTMsg,
+					ignoreDiffDetailsObsTime, ignoreDriftDetailsObsTime,
+					cmpopts.SortSlices(lessFuncPatchDetail),
+					cmpopts.IgnoreSliceElements(func(d fleetv1beta1.PatchDetail) bool {
+						return d.Path != "/spec/completions" && d.Path != "/spec/template/spec/containers/0/image"
+					}),
+				); diff != "" {
+					return fmt.Errorf("work status diff (-got, +want):\n%s", diff)
+				}
+
+				// For simplicity reasons, the diff timestamps are not checked.
+				return nil
+			}, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update work status")
+		})
+
+		It("should not own the objects or apply the manifests to them", func() {
+			Consistently(func() error {
+				// Retrieve the NS object.
+				updatedNS := &corev1.Namespace{}
+				if err := memberClient.Get(ctx, client.ObjectKey{Name: nsName}, updatedNS); err != nil {
+					return fmt.Errorf("failed to retrieve the NS object: %w", err)
+				}
+
+				// Rebuild the NS object to ignore default values automatically.
+				rebuiltGotNS := &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            updatedNS.Name,
+						OwnerReferences: updatedNS.OwnerReferences,
+					},
+				}
+
+				wantNS := ns.DeepCopy()
+				wantNS.Name = nsName
+				if diff := cmp.Diff(rebuiltGotNS, wantNS, ignoreFieldTypeMetaInNamespace); diff != "" {
+					return fmt.Errorf("namespace diff (-got +want):\n%s", diff)
+				}
+				return nil
+			}, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to leave the NS object alone")
+
+			Consistently(func() error {
+				// Retrieve the Job object.
+				updatedJob := &batchv1.Job{}
+				if err := memberClient.Get(ctx, client.ObjectKey{Namespace: nsName, Name: jobName}, updatedJob); err != nil {
+					return fmt.Errorf("failed to retrieve the Job object: %w", err)
+				}
+
+				// Rebuild the Job object to ignore default values automatically.
+				if len(updatedJob.Spec.Template.Spec.Containers) != 1 {
+					return fmt.Errorf("unexpected number of containers in the Job pod template spec: %d, want 1", len(updatedJob.Spec.Template.Spec.Containers))
+				}
+				rebuiltGotJob := &batchv1.Job{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:       updatedJob.Namespace,
+						Name:            updatedJob.Name,
+						OwnerReferences: updatedJob.OwnerReferences,
+					},
+					Spec: batchv1.JobSpec{
+						Parallelism: updatedJob.Spec.Parallelism,
+						Completions: updatedJob.Spec.Completions,
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{
+									"app": updatedJob.Spec.Template.ObjectMeta.Labels["app"],
+								},
+							},
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name:    updatedJob.Spec.Template.Spec.Containers[0].Name,
+										Image:   updatedJob.Spec.Template.Spec.Containers[0].Image,
+										Command: updatedJob.Spec.Template.Spec.Containers[0].Command,
+									},
+								},
+								RestartPolicy: corev1.RestartPolicyNever,
+							},
+						},
+					},
+				}
+
+				wantJob := job.DeepCopy()
+				wantJob.TypeMeta = metav1.TypeMeta{}
+				wantJob.Namespace = nsName
+				wantJob.Name = jobName
+
+				if diff := cmp.Diff(rebuiltGotJob, wantJob); diff != "" {
+					return fmt.Errorf("job diff (-got +want):\n%s", diff)
+				}
+				return nil
+			}, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to leave the Job object alone")
+		})
+
+		It("should have no applied object reportings in the AppliedWork status", func() {
+			// Prepare the status information.
+			var appliedResourceMeta []fleetv1beta1.AppliedResourceMeta
+
+			appliedWorkStatusUpdatedActual := appliedWorkStatusUpdated(workName, appliedResourceMeta)
+			Eventually(appliedWorkStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update appliedWork status")
+		})
+
+		AfterAll(func() {
+			// Delete the Work object and related resources.
+			deleteWorkObject(workName)
+
+			// Ensure that the Job object has been left alone.
+			jobNotRemovedActual := regularJobNotRemovedActual(nsName, jobName)
+			Consistently(jobNotRemovedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to remove the job object")
 
 			// Ensure that the AppliedWork object has been removed.
 			appliedWorkRemovedActual := appliedWorkRemovedActual(workName, nsName)

--- a/pkg/controllers/workapplier/controller_test.go
+++ b/pkg/controllers/workapplier/controller_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -43,6 +44,7 @@ const (
 	workName = "work-1"
 
 	deployName      = "deploy-1"
+	jobName         = "job-1"
 	configMapName   = "configmap-1"
 	nsName          = "ns-1"
 	clusterRoleName = "clusterrole-1"
@@ -95,6 +97,42 @@ var (
 	}
 	deployUnstructured *unstructured.Unstructured
 	deployJSON         []byte
+
+	job = &batchv1.Job{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Job",
+			APIVersion: "batch/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      jobName,
+			Namespace: nsName,
+		},
+		Spec: batchv1.JobSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": "busybox",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "busybox",
+							Image: "busybox",
+							Command: []string{
+								"sh",
+								"-c",
+								"sleep 60",
+							},
+						},
+					},
+					RestartPolicy: corev1.RestartPolicyNever,
+				},
+			},
+			Parallelism: ptr.To(int32(1)),
+			Completions: ptr.To(int32(2)),
+		},
+	}
 
 	ns = &corev1.Namespace{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/controllers/workapplier/drift_detection_takeover.go
+++ b/pkg/controllers/workapplier/drift_detection_takeover.go
@@ -46,7 +46,7 @@ func (r *Reconciler) takeOverPreExistingObject(
 	manifestObj, inMemberClusterObj *unstructured.Unstructured,
 	applyStrategy *fleetv1beta1.ApplyStrategy,
 	expectedAppliedWorkOwnerRef *metav1.OwnerReference,
-) (*unstructured.Unstructured, []fleetv1beta1.PatchDetail, error) {
+) (*unstructured.Unstructured, []fleetv1beta1.PatchDetail, bool, error) {
 	inMemberClusterObjCopy := inMemberClusterObj.DeepCopy()
 	existingOwnerRefs := inMemberClusterObjCopy.GetOwnerReferences()
 
@@ -59,7 +59,7 @@ func (r *Reconciler) takeOverPreExistingObject(
 	// removing any owner reference that points to an orphaned AppliedWork object.
 	existingOwnerRefs, err := r.removeLeftBehindAppliedWorkOwnerRefs(ctx, existingOwnerRefs)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to remove left-behind AppliedWork owner references: %w", err)
+		return nil, nil, false, fmt.Errorf("failed to remove left-behind AppliedWork owner references: %w", err)
 	}
 
 	// Check this object is already owned by another object (or controller); if so, Fleet will only
@@ -69,7 +69,7 @@ func (r *Reconciler) takeOverPreExistingObject(
 		// No takeover will be performed.
 		//
 		// Note that This will be registered as an (apply) error.
-		return nil, nil, fmt.Errorf("the object is already owned by some other sources(s) and co-ownership is disallowed")
+		return nil, nil, false, fmt.Errorf("the object is already owned by some other sources(s) and co-ownership is disallowed")
 	}
 
 	// Check if the object is already owned by Fleet, but the owner is a different AppliedWork
@@ -83,19 +83,19 @@ func (r *Reconciler) takeOverPreExistingObject(
 	// user confusion. To address this corner case, Fleet would now deny placing the same object
 	// twice.
 	if isPlacedByFleetInDuplicate(existingOwnerRefs, expectedAppliedWorkOwnerRef) {
-		return nil, nil, fmt.Errorf("the object is already owned by another Fleet AppliedWork object")
+		return nil, nil, false, fmt.Errorf("the object is already owned by another Fleet AppliedWork object")
 	}
 
 	// Check if the takeover action requires additional steps (configuration difference inspection).
 	//
 	// Note that the default takeover action is AlwaysApply.
 	if applyStrategy.WhenToTakeOver == fleetv1beta1.WhenToTakeOverTypeIfNoDiff {
-		configDiffs, err := r.diffBetweenManifestAndInMemberClusterObjects(ctx, gvr, manifestObj, inMemberClusterObjCopy, applyStrategy.ComparisonOption)
+		configDiffs, diffCalculatedInDegradedMode, err := r.diffBetweenManifestAndInMemberClusterObjects(ctx, gvr, manifestObj, inMemberClusterObjCopy, applyStrategy.ComparisonOption)
 		switch {
 		case err != nil:
-			return nil, nil, fmt.Errorf("failed to calculate configuration diffs between the manifest object and the object from the member cluster: %w", err)
+			return nil, nil, false, fmt.Errorf("failed to calculate configuration diffs between the manifest object and the object from the member cluster: %w", err)
 		case len(configDiffs) > 0:
-			return nil, configDiffs, nil
+			return nil, configDiffs, diffCalculatedInDegradedMode, nil
 		}
 	}
 
@@ -107,10 +107,10 @@ func (r *Reconciler) takeOverPreExistingObject(
 		Update(ctx, inMemberClusterObjCopy, metav1.UpdateOptions{})
 	if err != nil {
 		wrappedErr := controller.NewAPIServerError(false, err)
-		return nil, nil, fmt.Errorf("failed to take over the object: %w", wrappedErr)
+		return nil, nil, false, fmt.Errorf("failed to take over the object: %w", wrappedErr)
 	}
 
-	return takenOverInMemberClusterObj, nil, nil
+	return takenOverInMemberClusterObj, nil, false, nil
 }
 
 // diffBetweenManifestAndInMemberClusterObjects calculates the differences between the manifest object
@@ -120,16 +120,17 @@ func (r *Reconciler) diffBetweenManifestAndInMemberClusterObjects(
 	gvr *schema.GroupVersionResource,
 	manifestObj, inMemberClusterObj *unstructured.Unstructured,
 	cmpOption fleetv1beta1.ComparisonOptionType,
-) ([]fleetv1beta1.PatchDetail, error) {
+) ([]fleetv1beta1.PatchDetail, bool, error) {
 	switch cmpOption {
 	case fleetv1beta1.ComparisonOptionTypePartialComparison:
 		return r.partialDiffBetweenManifestAndInMemberClusterObjects(ctx, gvr, manifestObj, inMemberClusterObj)
 	case fleetv1beta1.ComparisonOptionTypeFullComparison:
 		// For the full comparison, Fleet compares directly the JSON representations of the
 		// manifest object and the object in the member cluster.
-		return preparePatchDetails(manifestObj, inMemberClusterObj)
+		patchDetails, err := preparePatchDetails(manifestObj, inMemberClusterObj)
+		return patchDetails, false, err
 	default:
-		return nil, fmt.Errorf("an invalid comparison option is specified")
+		return nil, false, fmt.Errorf("an invalid comparison option is specified")
 	}
 }
 
@@ -141,13 +142,10 @@ func (r *Reconciler) partialDiffBetweenManifestAndInMemberClusterObjects(
 	ctx context.Context,
 	gvr *schema.GroupVersionResource,
 	manifestObj, inMemberClusterObj *unstructured.Unstructured,
-) ([]fleetv1beta1.PatchDetail, error) {
+) ([]fleetv1beta1.PatchDetail, bool, error) {
 	// Fleet calculates the partial diff between two objects by running apply ops in the dry-run
 	// mode.
 	appliedObj, err := r.applyInDryRunMode(ctx, gvr, manifestObj, inMemberClusterObj)
-	if err != nil {
-		return nil, fmt.Errorf("failed to apply the manifest in dry-run mode: %w", err)
-	}
 
 	// After the dry-run apply op, all the managed fields should have been overwritten using the
 	// values from the manifest object, while leaving all the unmanaged fields untouched. This
@@ -157,8 +155,35 @@ func (r *Reconciler) partialDiffBetweenManifestAndInMemberClusterObjects(
 	// imply that running an actual apply op would lead to unexpected changes, which signifies
 	// the presence of partial drifts (drifts in managed fields).
 
-	// Prepare the patch details.
-	return preparePatchDetails(appliedObj, inMemberClusterObj)
+	switch {
+	case err == nil:
+		// The dry-run apply op has succeeded. All managed fields should have been overwritten using the
+		// values from the manifest object, while leaving all the unmanaged fields untouched. This
+		// would allow Fleet to compare the object returned by the dry-run apply op with the object
+		// that is currently in the member cluster; if all the fields are consistent, it is safe
+		// for us to assume that there are no drifts, otherwise, any fields that are different
+		// imply that running an actual apply op would lead to unexpected changes, which signifies
+		// the presence of partial drifts (drifts in managed fields).
+		patchDetails, err := preparePatchDetails(appliedObj, inMemberClusterObj)
+		return patchDetails, false, err
+	case errors.IsInvalid(err):
+		// The dry-run apply op has failed as the manifest object provided is not valid. This could
+		// happen when the apply op involves fields that are immutable or the apply op attempts to
+		// set invalid values. This error implies that the in-cluster object has already been modified,
+		// and any change that the user supplies right now cannot be accepted.
+		//
+		// In this case, fall back to full comparison. Report that the diff is being calculated in a
+		// degraded manner.
+		//
+		// This is not considered as a diff calculation error.
+		klog.V(2).InfoS("Calculate diffs in degraded mode as the manifest object cannot be server-side applied in dry-run mode",
+			"gvr", gvr, "manifestObj", klog.KObj(manifestObj), "serverErr", err)
+		patchDetails, err := preparePatchDetails(manifestObj, inMemberClusterObj)
+		return patchDetails, true, err
+	default:
+		// An unexpected error has occurred.
+		return nil, false, fmt.Errorf("failed to apply the manifest in dry-run mode: %w", err)
+	}
 }
 
 // organizeJSONPatchIntoFleetPatchDetails organizes the JSON patch operations into Fleet patch details.

--- a/pkg/controllers/workapplier/drift_detection_takeover_test.go
+++ b/pkg/controllers/workapplier/drift_detection_takeover_test.go
@@ -98,16 +98,17 @@ func TestTakeOverPreExistingObject(t *testing.T) {
 	})
 
 	testCases := []struct {
-		name                        string
-		gvr                         *schema.GroupVersionResource
-		manifestObj                 *unstructured.Unstructured
-		inMemberClusterObj          *unstructured.Unstructured
-		workObj                     *fleetv1beta1.Work
-		applyStrategy               *fleetv1beta1.ApplyStrategy
-		expectedAppliedWorkOwnerRef *metav1.OwnerReference
-		wantErred                   bool
-		wantTakeOverObj             *unstructured.Unstructured
-		wantPatchDetails            []fleetv1beta1.PatchDetail
+		name                             string
+		gvr                              *schema.GroupVersionResource
+		manifestObj                      *unstructured.Unstructured
+		inMemberClusterObj               *unstructured.Unstructured
+		workObj                          *fleetv1beta1.Work
+		applyStrategy                    *fleetv1beta1.ApplyStrategy
+		expectedAppliedWorkOwnerRef      *metav1.OwnerReference
+		wantErred                        bool
+		wantTakeOverObj                  *unstructured.Unstructured
+		wantPatchDetails                 []fleetv1beta1.PatchDetail
+		wantDiffCalculatedInDegradedMode bool
 	}{
 		{
 			name:               "existing non-Fleet owner, co-ownership not allowed",
@@ -209,7 +210,7 @@ func TestTakeOverPreExistingObject(t *testing.T) {
 				workNameSpace:      memberReservedNSName,
 			}
 
-			takenOverObj, patchDetails, err := r.takeOverPreExistingObject(
+			takenOverObj, patchDetails, diffCalculatedInDegradedMode, err := r.takeOverPreExistingObject(
 				ctx,
 				tc.gvr,
 				tc.manifestObj, tc.inMemberClusterObj,
@@ -230,6 +231,9 @@ func TestTakeOverPreExistingObject(t *testing.T) {
 			}
 			if diff := cmp.Diff(patchDetails, tc.wantPatchDetails); diff != "" {
 				t.Errorf("patchDetails mismatches (-got, +want):\n%s", diff)
+			}
+			if diffCalculatedInDegradedMode != tc.wantDiffCalculatedInDegradedMode {
+				t.Errorf("diffCalculatedInDegradedMode = %v, want %v", diffCalculatedInDegradedMode, tc.wantDiffCalculatedInDegradedMode)
 			}
 		})
 	}

--- a/pkg/controllers/workapplier/process.go
+++ b/pkg/controllers/workapplier/process.go
@@ -198,7 +198,7 @@ func (r *Reconciler) takeOverInMemberClusterObjectIfApplicable(
 
 	// Take over the object. Note that this steps adds only the owner reference; no other
 	// fields are modified (on the object from the member cluster).
-	takenOverInMemberClusterObj, configDiffs, err := r.takeOverPreExistingObject(ctx,
+	takenOverInMemberClusterObj, configDiffs, diffCalculatedInDegradedMode, err := r.takeOverPreExistingObject(ctx,
 		bundle.gvr, bundle.manifestObj, bundle.inMemberClusterObj,
 		work.Spec.ApplyStrategy, expectedAppliedWorkOwnerRef)
 	switch {
@@ -209,6 +209,19 @@ func (r *Reconciler) takeOverInMemberClusterObjectIfApplicable(
 		klog.ErrorS(err, "Failed to take over a pre-existing object",
 			"work", klog.KObj(work), "GVR", *bundle.gvr, "manifestObj", klog.KObj(bundle.manifestObj),
 			"inMemberClusterObj", klog.KObj(bundle.inMemberClusterObj), "expectedAppliedWorkOwnerRef", *expectedAppliedWorkOwnerRef)
+		return true
+	case len(configDiffs) > 0 && diffCalculatedInDegradedMode:
+		// Takeover cannot be performed as configuration differences are found between the manifest
+		// object and the object in the member cluster in degraded mode.
+		//
+		// Note that though degraded diff calculation itself is not considered as an error, the
+		// presence of diffs is indeed an error.
+		bundle.diffs = configDiffs
+		bundle.applyOrReportDiffErr = fmt.Errorf("cannot take over object: configuration differences are found between the manifest object and the corresponding object in the member cluster in degraded mode (full comparison is performed instead of partial comparison, as the manifest object is considered to be invalid by the member cluster API server)")
+		bundle.applyOrReportDiffResTyp = ApplyOrReportDiffResTypeFailedToTakeOver
+		klog.V(2).InfoS("Cannot take over object as configuration differences are found between the manifest object and the corresponding object in the member cluster in degraded mode",
+			"work", klog.KObj(work), "GVR", *bundle.gvr, "manifestObj", klog.KObj(bundle.manifestObj),
+			"expectedAppliedWorkOwnerRef", *expectedAppliedWorkOwnerRef)
 		return true
 	case len(configDiffs) > 0:
 		// Takeover cannot be performed as configuration differences are found between the manifest
@@ -300,7 +313,7 @@ func (r *Reconciler) reportDiffOnlyIfApplicable(
 
 	// The object has been created in the member cluster; Fleet will calculate the configuration
 	// diffs between the manifest object and the object from the member cluster.
-	configDiffs, err := r.diffBetweenManifestAndInMemberClusterObjects(ctx,
+	configDiffs, diffCalculatedInDegradedMode, err := r.diffBetweenManifestAndInMemberClusterObjects(ctx,
 		bundle.gvr,
 		bundle.manifestObj, bundle.inMemberClusterObj,
 		work.Spec.ApplyStrategy.ComparisonOption)
@@ -313,6 +326,13 @@ func (r *Reconciler) reportDiffOnlyIfApplicable(
 			"Failed to calculate configuration diffs between the manifest object and the object from the member cluster",
 			"work", klog.KObj(work), "GVR", *bundle.gvr, "manifestObj", klog.KObj(bundle.manifestObj),
 			"inMemberClusterObj", klog.KObj(bundle.inMemberClusterObj), "expectedAppliedWorkOwnerRef", *expectedAppliedWorkOwnerRef)
+	case len(configDiffs) > 0 && diffCalculatedInDegradedMode:
+		// Configuration diffs are found in degraded mode.
+		bundle.diffs = configDiffs
+		bundle.applyOrReportDiffResTyp = ApplyOrReportDiffResTypeFoundDiffInDegradedMode
+		klog.V(2).InfoS("Diff report completed; configuration diffs are found in degraded mode",
+			"GVR", *bundle.gvr, "manifestObj", klog.KObj(bundle.manifestObj),
+			"work", klog.KObj(work))
 	case len(configDiffs) > 0:
 		// Configuration diffs are found.
 		bundle.diffs = configDiffs
@@ -385,7 +405,7 @@ func (r *Reconciler) performPreApplyDriftDetectionIfApplicable(
 		return false
 	default:
 		// Run the drift detection process.
-		drifts, err := r.diffBetweenManifestAndInMemberClusterObjects(ctx,
+		drifts, driftsCalculatedInDegradedMode, err := r.diffBetweenManifestAndInMemberClusterObjects(ctx,
 			bundle.gvr,
 			bundle.manifestObj, bundle.inMemberClusterObj,
 			work.Spec.ApplyStrategy.ComparisonOption)
@@ -396,6 +416,18 @@ func (r *Reconciler) performPreApplyDriftDetectionIfApplicable(
 			bundle.applyOrReportDiffResTyp = ApplyOrReportDiffResTypeFailedToRunDriftDetection
 			klog.ErrorS(err,
 				"Failed to calculate pre-apply drifts between the manifest and the object from the member cluster",
+				"work", klog.KObj(work), "GVR", *bundle.gvr, "manifestObj", klog.KObj(bundle.manifestObj),
+				"inMemberClusterObj", klog.KObj(bundle.inMemberClusterObj), "expectedAppliedWorkOwnerRef", *expectedAppliedWorkOwnerRef)
+			return true
+		case len(drifts) > 0 && driftsCalculatedInDegradedMode:
+			// Configuration drifts are found in degraded mode.
+			//
+			// Note that though degraded drift calculation itself is not considered as an error, the
+			// presence of drifts in the pre-apply drift detection step is indeed an error.
+			bundle.drifts = drifts
+			bundle.applyOrReportDiffErr = fmt.Errorf("cannot apply manifest: drifts are found between the manifest and the object from the member cluster in degraded mode (full comparison is performed instead of partial comparison, as the manifest object is considered to be invalid by the member cluster API server)")
+			bundle.applyOrReportDiffResTyp = ApplyOrReportDiffResTypeFoundDriftsInDegradedMode
+			klog.V(2).InfoS("Cannot apply manifest: drifts are found between the manifest and the object from the member cluster in degraded mode",
 				"work", klog.KObj(work), "GVR", *bundle.gvr, "manifestObj", klog.KObj(bundle.manifestObj),
 				"inMemberClusterObj", klog.KObj(bundle.inMemberClusterObj), "expectedAppliedWorkOwnerRef", *expectedAppliedWorkOwnerRef)
 			return true
@@ -456,7 +488,7 @@ func (r *Reconciler) performPostApplyDriftDetectionIfApplicable(
 		return false
 	}
 
-	drifts, err := r.diffBetweenManifestAndInMemberClusterObjects(ctx,
+	drifts, driftsCalculatedInDegradedMode, err := r.diffBetweenManifestAndInMemberClusterObjects(ctx,
 		bundle.gvr,
 		bundle.manifestObj, bundle.inMemberClusterObj,
 		work.Spec.ApplyStrategy.ComparisonOption)
@@ -472,6 +504,18 @@ func (r *Reconciler) performPostApplyDriftDetectionIfApplicable(
 			"work", klog.KObj(work), "GVR", *bundle.gvr, "manifestObj", klog.KObj(bundle.manifestObj),
 			"inMemberClusterObj", klog.KObj(bundle.inMemberClusterObj), "expectedAppliedWorkOwnerRef", *expectedAppliedWorkOwnerRef)
 		return true
+	case len(drifts) > 0 && driftsCalculatedInDegradedMode:
+		// Configuration drifts are found, but they were calculated in degraded mode.
+		//
+		// Normally this should never happen, as post apply drift detection will only run if the full
+		// comparison mode is enabled, but degraded mode only applies to partial comparison mode.
+
+		// Surface the drifts as normal, but raise an unexpected behavior flag.
+		bundle.drifts = drifts
+		klog.V(2).InfoS("Post-apply drift detection completed; drifts are found in degraded mode",
+			"manifestObj", klog.KObj(bundle.manifestObj), "GVR", *bundle.gvr, "work", klog.KObj(work))
+		// The presence of such drifts are not considered as an error.
+		return false
 	case len(drifts) > 0:
 		// Drifts are found in the post-apply drift detection process.
 		bundle.drifts = drifts

--- a/pkg/controllers/workapplier/status.go
+++ b/pkg/controllers/workapplier/status.go
@@ -429,6 +429,17 @@ func setManifestDiffReportedCondition(
 			Message:            ApplyOrReportDiffResTypeFoundDiffDescription,
 			ObservedGeneration: inMemberClusterObjGeneration,
 		}
+	case applyOrReportDiffResTyp == ApplyOrReportDiffResTypeFoundDiffInDegradedMode:
+		// Found diffs in degraded mode.
+		//
+		// This is not considered as a system error.
+		diffReportedCond = &metav1.Condition{
+			Type:               fleetv1beta1.WorkConditionTypeDiffReported,
+			Status:             metav1.ConditionTrue,
+			Reason:             string(ApplyOrReportDiffResTypeFoundDiffInDegradedMode),
+			Message:            ApplyOrReportDiffResTypeFoundDiffInDegradedModeDescription,
+			ObservedGeneration: inMemberClusterObjGeneration,
+		}
 	default:
 		// There are cases where the work applier might not be able to complete the diff reporting
 		// due to failures in the pre-processing or processing stage (e.g., the manifest cannot be decoded,

--- a/pkg/controllers/workapplier/suite_test.go
+++ b/pkg/controllers/workapplier/suite_test.go
@@ -25,6 +25,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
@@ -118,6 +119,8 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(memberCfg).ToNot(BeNil())
 
+	err = batchv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
 	err = fleetv1beta1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 	err = testv1alpha1.AddToScheme(scheme.Scheme)

--- a/test/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/test/apis/v1alpha1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 


### PR DESCRIPTION
### Description of your changes

KubeFleet currently uses server-side apply in the dry-run mode to calculate diffs/drifts in the partial comparison mode. It has been identified that there are cases where server-side apply dry-runs might fail when the supplied manifest itself is not valid (e.g., when mutable scheduling directives are used). This PR addresses this issue by enabling degraded diff/drift calculations -> the work applier will fall back to the full comparison mode if it is sure that server-side apply dry-runs will never succeed given the current manifest.

Fixes #

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- [N/A] Unit tests
- [x] Integration tests


### Special notes for your reviewer

Additional tests will be submitted in separate PRs to control the PR size.
