### PR TITLE
fix: fix msi client used by refresh-token to not reuse tcp connection

### DIFF
--- a/pkg/authtoken/providers/azure/azure_msi.go
+++ b/pkg/authtoken/providers/azure/azure_msi.go
@@ -18,6 +18,7 @@ package azure
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
@@ -50,7 +51,25 @@ func New(clientID, scope string) authtoken.Provider {
 // FetchToken gets a new token to make request to the associated fleet' hub cluster.
 func (a *AuthTokenProvider) FetchToken(ctx context.Context) (authtoken.AuthToken, error) {
 	token := authtoken.AuthToken{}
-	opts := &azidentity.ManagedIdentityCredentialOptions{ID: azidentity.ClientID(a.ClientID)}
+	opts := &azidentity.ManagedIdentityCredentialOptions{
+		// We may race at startup with a sidecar which inserts an iptables rule
+		// to intercept IMDS calls.  If we get here before such an iptables rule
+		// is inserted, we will inadvertently connect to real IMDS, which won't
+		// be able to service our request.  IMDS does not set 'Connection:
+		// close' on 400 errors.  Default Go HTTP client behavior will keep the
+		// underlying TCP connection open for re-use, unaffected by iptables,
+		// causing all further requests to continue to be sent to real IMDS and
+		// fail.  Use a separate HTTP client for IMDS calls, where connection
+		// re-use is disabled.
+		ClientOptions: azcore.ClientOptions{
+			Transport: &http.Client{
+				Transport: &http.Transport{
+					DisableKeepAlives: true,
+				},
+			},
+		},
+		ID: azidentity.ClientID(a.ClientID),
+	}
 
 	klog.V(2).InfoS("FetchToken", "client ID", a.ClientID)
 	credential, err := azidentity.NewManagedIdentityCredential(opts)


### PR DESCRIPTION
### Description of your changes

Fix msi client used by refresh-token to not reuse tcp connection to prevent race condition where a tcp connection is established and continues being used before a side car inserts an iptables rule to intercepts the calls.

Fixes #

I have:

- [ ] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
