### PR TITLE
test: set up the binding watcher integration tests to wait for cache sync

### DIFF
--- a/pkg/controllers/bindingwatcher/suite_test.go
+++ b/pkg/controllers/bindingwatcher/suite_test.go
@@ -122,6 +122,10 @@ var _ = BeforeSuite(func() {
 		err = mgr.Start(ctx)
 		Expect(err).Should(Succeed(), "failed to run manager")
 	}()
+
+	// Note (chenyu1): for the binding watcher integration tests, must wait for the cache to sync
+	// before moving onto the test stage, otherwise some events might not be catched.
+	mgr.GetCache().WaitForCacheSync(ctx)
 })
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION
### Description of your changes

This PR addresses a source of flakiness in the binding watcher where the cache might fail to get sync'd in time after the test cases begin to run, which might lead to missing events.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

N/A

### Special notes for your reviewer

Kudos to Wantong for the inputs 🙏
