### PR TITLE
fix: address a naming error in the envelope related E2E tests

### DIFF
--- a/test/e2e/enveloped_object_placement_test.go
+++ b/test/e2e/enveloped_object_placement_test.go
@@ -795,7 +795,7 @@ func createWrappedResourcesForEnvelopTest() {
 	// Create ResourceEnvelope with ResourceQuota inside
 	quotaBytes, err := json.Marshal(testResourceQuota)
 	Expect(err).Should(Succeed())
-	testResourceEnvelope.Data["resourceQuota1.yaml"] = runtime.RawExtension{Raw: quotaBytes}
+	testResourceEnvelope.Data["resourceQuota.yaml"] = runtime.RawExtension{Raw: quotaBytes}
 	deploymentBytes, err := json.Marshal(testDeployment)
 	Expect(err).Should(Succeed())
 	testResourceEnvelope.Data["deployment.yaml"] = runtime.RawExtension{Raw: deploymentBytes}


### PR DESCRIPTION
### Description of your changes

This PR fixes a naming error in the envelope related E2E tests.

(the key, `resourceQuota1.yaml`, is never used).

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

N/A

### Special notes for your reviewer

Needed for PR #230.
