### PR TITLE
feat: update the comments regarding resource sort orders in CRP/RP controller and work generator

### DIFF
--- a/pkg/controllers/workgenerator/envelope.go
+++ b/pkg/controllers/workgenerator/envelope.go
@@ -147,6 +147,16 @@ func extractManifestsFromEnvelopeCR(envelopeReader fleetv1beta1.EnvelopeReader) 
 	}
 
 	// Do a stable sort of the extracted manifests to ensure consistent, deterministic ordering.
+	//
+	// Note (chenyu1): the sort order here does not affect the order in which resources
+	// are applied on a selected member cluster (the work applier will handle the resources
+	// in batch with its own grouping logic). KubeFleet sorts resources here solely
+	// for consistency (deterministic processing) reasons (i.e., if the set of the
+	// resources remain the same, work objects will not be updated).
+	//
+	// Important (chenyu1): changing the sort order here may induce side effects in
+	// existing KubeFleet deployments, as it might trigger update ops on work objects.
+	// Do not update the sort order unless absolutely necessary.
 	sort.Slice(manifests, func(i, j int) bool {
 		obj1 := manifests[i].Raw
 		obj2 := manifests[j].Raw


### PR DESCRIPTION
### Description of your changes

This PR updates the comments (and applies some minor changes) on the resource sorting logic in the CRP/RP controller and the work generator.

The PR is a follow-up to #234.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

N/A


### Special notes for your reviewer

