### PR TITLE
feat: security: obscure drift/diff reportings on secret object data fields (re-submission)

### DIFF
--- a/pkg/controllers/workapplier/controller_test.go
+++ b/pkg/controllers/workapplier/controller_test.go
@@ -46,6 +46,7 @@ const (
 	deployName      = "deploy-1"
 	jobName         = "job-1"
 	configMapName   = "configmap-1"
+	secretName      = "secret-1"
 	nsName          = "ns-1"
 	clusterRoleName = "clusterrole-1"
 )
@@ -157,6 +158,20 @@ var (
 		},
 		Data: map[string]string{
 			dummyLabelKey: dummyLabelValue1,
+		},
+	}
+
+	secret = &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: nsName,
+			Name:      secretName,
+		},
+		Data: map[string][]byte{
+			dummyLabelKey: []byte(dummyLabelValue1),
 		},
 	}
 


### PR DESCRIPTION
### Description of your changes

This PR will set the work applier to obscure any drift/diff reportings on the data fields of secret objects, so as to protect sensitive information from being revealed outside cluster boundaries.

This behavior is consistent with what ArgoCD does with similar functions.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- [x] Unit tests
- [x] Integration tests

### Special notes for your reviewer

This PR is a re-submission of #238, in an attempt to avoid the unexpected rebasing complications.
