### PR TITLE
test: enable CNCF large runners for E2E

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,8 @@ jobs:
           - customized-settings: custom
             resource-snapshot-creation-minimum-interval: 30s
             resource-changes-collection-duration: 15s
-    runs-on: ubuntu-latest
+    runs-on:
+      labels: ubuntu-latest-16-cores
     needs: [
       detect-noop,
     ]


### PR DESCRIPTION
### Description of your changes

This PR sets the E2E GA workflow to use 16-core GitHub large runners, courtesy of CNCF.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

N/A

### Special notes for your reviewer

N/A
