### PR TITLE
test: fix a flakiness issue in E2E test suite (1/)

### DIFF
--- a/test/e2e/resource_placement_drift_diff_test.go
+++ b/test/e2e/resource_placement_drift_diff_test.go
@@ -1579,7 +1579,14 @@ var _ = Describe("report diff mode using RP", Label("resourceplacement"), func()
 		})
 
 		AfterAll(func() {
-			ensureRPAndRelatedResourcesDeleted(types.NamespacedName{Name: rpName, Namespace: nsName}, allMemberClusters)
+			// Clean up the created resources.
+
+			// For the RP-related resources, ignore the first member cluster as it has pre-existing resources.
+			ensureRPAndRelatedResourcesDeleted(types.NamespacedName{Name: rpName, Namespace: nsName}, []*framework.Cluster{
+				memberCluster2EastCanary,
+				memberCluster3WestProd,
+			})
+			// Note that the pre-existing namespace (not the configMaps) has been taken over by the CRP.
 			ensureCRPAndRelatedResourcesDeleted(crpName, allMemberClusters)
 		})
 	})


### PR DESCRIPTION
### Description of your changes

This PR resolves an issue in the RP E2E test suite where a namespace is taken over by the CRP and thus cannot be deleted successfully.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

N/A

### Special notes for your reviewer

N/A