### PR TITLE
test: add e2e test using label to manage CRP and RP

### DIFF
--- a/test/e2e/mixed_placement_test.go
+++ b/test/e2e/mixed_placement_test.go
@@ -412,7 +412,7 @@ var _ = Describe("mixed ClusterResourcePlacement and ResourcePlacement positive 
 			}, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to remove labels from member clusters")
 		})
 
-		It("picking N clusters with no affinities/topology spread constraints (pick by cluster names in alphanumeric order)", func() {
+		It("picking fixed cluster", func() {
 			crp := &placementv1beta1.ClusterResourcePlacement{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: crpName,


### PR DESCRIPTION
### Description of your changes

add a test case, when the admin manages the ns using the CRP, and the developers manages the application using RP based on the CRP result via cluster labeling.

Fixes #

I have:

- [ ] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

e2e tests


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
