### PR TITLE
feat: rename update run state

### DIFF
--- a/apis/placement/v1beta1/stageupdate_types.go
+++ b/apis/placement/v1beta1/stageupdate_types.go
@@ -171,9 +171,9 @@ const (
 
 // UpdateRunSpec defines the desired rollout strategy and the snapshot indices of the resources to be updated.
 // It specifies a stage-by-stage update process across selected clusters for the given ResourcePlacement object.
-// +kubebuilder:validation:XValidation:rule="!has(oldSelf.state) || oldSelf.state != 'Initialize' || self.state != 'Pause'",message="invalid state transition: cannot transition from Initialize to Pause"
-// +kubebuilder:validation:XValidation:rule="!has(oldSelf.state) || oldSelf.state != 'Execute' || self.state != 'Initialize'",message="invalid state transition: cannot transition from Execute to Initialize"
-// +kubebuilder:validation:XValidation:rule="!has(oldSelf.state) || oldSelf.state != 'Pause' || self.state != 'Initialize'",message="invalid state transition: cannot transition from Pause to Initialize"
+// +kubebuilder:validation:XValidation:rule="!(has(oldSelf.state) && oldSelf.state == 'Initialize' && self.state == 'Pause')",message="invalid state transition: cannot transition from Initialize to Pause"
+// +kubebuilder:validation:XValidation:rule="!(has(oldSelf.state) && oldSelf.state == 'Execute' && self.state == 'Initialize')",message="invalid state transition: cannot transition from Execute to Initialize"
+// +kubebuilder:validation:XValidation:rule="!(has(oldSelf.state) && oldSelf.state == 'Pause' && self.state == 'Initialize')",message="invalid state transition: cannot transition from Pause to Initialize"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.state) || oldSelf.state != 'Abandon' || self.state == 'Abandon'",message="invalid state transition: Abandon is a terminal state and cannot transition to any other state"
 type UpdateRunSpec struct {
 	// PlacementName is the name of placement that this update run is applied to.

--- a/config/crd/bases/placement.kubernetes-fleet.io_clusterstagedupdateruns.yaml
+++ b/config/crd/bases/placement.kubernetes-fleet.io_clusterstagedupdateruns.yaml
@@ -1205,16 +1205,16 @@ spec:
             x-kubernetes-validations:
             - message: 'invalid state transition: cannot transition from Initialize
                 to Pause'
-              rule: '!has(oldSelf.state) || oldSelf.state != ''Initialize'' || self.state
-                != ''Pause'''
+              rule: '!(has(oldSelf.state) && oldSelf.state == ''Initialize'' && self.state
+                == ''Pause'')'
             - message: 'invalid state transition: cannot transition from Execute to
                 Initialize'
-              rule: '!has(oldSelf.state) || oldSelf.state != ''Execute'' || self.state
-                != ''Initialize'''
+              rule: '!(has(oldSelf.state) && oldSelf.state == ''Execute'' && self.state
+                == ''Initialize'')'
             - message: 'invalid state transition: cannot transition from Pause to
                 Initialize'
-              rule: '!has(oldSelf.state) || oldSelf.state != ''Pause'' || self.state
-                != ''Initialize'''
+              rule: '!(has(oldSelf.state) && oldSelf.state == ''Pause'' && self.state
+                == ''Initialize'')'
             - message: 'invalid state transition: Abandon is a terminal state and
                 cannot transition to any other state'
               rule: '!has(oldSelf.state) || oldSelf.state != ''Abandon'' || self.state

--- a/config/crd/bases/placement.kubernetes-fleet.io_stagedupdateruns.yaml
+++ b/config/crd/bases/placement.kubernetes-fleet.io_stagedupdateruns.yaml
@@ -125,16 +125,16 @@ spec:
             x-kubernetes-validations:
             - message: 'invalid state transition: cannot transition from Initialize
                 to Pause'
-              rule: '!has(oldSelf.state) || oldSelf.state != ''Initialize'' || self.state
-                != ''Pause'''
+              rule: '!(has(oldSelf.state) && oldSelf.state == ''Initialize'' && self.state
+                == ''Pause'')'
             - message: 'invalid state transition: cannot transition from Execute to
                 Initialize'
-              rule: '!has(oldSelf.state) || oldSelf.state != ''Execute'' || self.state
-                != ''Initialize'''
+              rule: '!(has(oldSelf.state) && oldSelf.state == ''Execute'' && self.state
+                == ''Initialize'')'
             - message: 'invalid state transition: cannot transition from Pause to
                 Initialize'
-              rule: '!has(oldSelf.state) || oldSelf.state != ''Pause'' || self.state
-                != ''Initialize'''
+              rule: '!(has(oldSelf.state) && oldSelf.state == ''Pause'' && self.state
+                == ''Initialize'')'
             - message: 'invalid state transition: Abandon is a terminal state and
                 cannot transition to any other state'
               rule: '!has(oldSelf.state) || oldSelf.state != ''Abandon'' || self.state

--- a/test/apis/placement/v1beta1/api_validation_integration_test.go
+++ b/test/apis/placement/v1beta1/api_validation_integration_test.go
@@ -1813,7 +1813,7 @@ var _ = Describe("Test placement v1beta1 API validation", func() {
 		})
 	})
 
-	Context("Test ClusterStagedUpdateRun State API validation - valid NotStarted state transitions", func() {
+	Context("Test ClusterStagedUpdateRun State API validation - valid Initialize state transitions", func() {
 		var updateRun *placementv1beta1.ClusterStagedUpdateRun
 		updateRunName := fmt.Sprintf(validupdateRunNameTemplate, GinkgoParallelProcess())
 
@@ -1839,7 +1839,7 @@ var _ = Describe("Test placement v1beta1 API validation", func() {
 					Name: "unspecfied-state-update-run-" + fmt.Sprintf("%d", GinkgoParallelProcess()),
 				},
 				Spec: placementv1beta1.UpdateRunSpec{
-					// State not specified - should default to NotStarted
+					// State not specified - should default to Initialize
 				},
 			}
 			Expect(hubClient.Create(ctx, updateRunWithDefaultState)).Should(Succeed())
@@ -1847,7 +1847,7 @@ var _ = Describe("Test placement v1beta1 API validation", func() {
 			Expect(hubClient.Delete(ctx, updateRunWithDefaultState)).Should(Succeed())
 		})
 
-		It("should allow creation of ClusterStagedUpdateRun with empty state (defaults to NotStarted)", func() {
+		It("should allow creation of ClusterStagedUpdateRun with empty state (defaults to Initialize)", func() {
 			updateRun := &placementv1beta1.ClusterStagedUpdateRun{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "empty-state-update-run-" + fmt.Sprintf("%d", GinkgoParallelProcess()),
@@ -1861,18 +1861,18 @@ var _ = Describe("Test placement v1beta1 API validation", func() {
 			Expect(hubClient.Delete(ctx, updateRun)).Should(Succeed())
 		})
 
-		It("should allow transition from NotStarted to Started", func() {
+		It("should allow transition from Initialize to Execute", func() {
 			updateRun.Spec.State = placementv1beta1.StateStarted
 			Expect(hubClient.Update(ctx, updateRun)).Should(Succeed())
 		})
 
-		It("should allow transition from NotStarted to Abandoned", func() {
+		It("should allow transition from Initialize to Abandon", func() {
 			updateRun.Spec.State = placementv1beta1.StateAbandoned
 			Expect(hubClient.Update(ctx, updateRun)).Should(Succeed())
 		})
 	})
 
-	Context("Test ClusterStagedUpdateRun State API validation - valid Started state transitions", func() {
+	Context("Test ClusterStagedUpdateRun State API validation - valid Execute state transitions", func() {
 		var updateRun *placementv1beta1.ClusterStagedUpdateRun
 		updateRunName := fmt.Sprintf(validupdateRunNameTemplate, GinkgoParallelProcess())
 
@@ -1892,18 +1892,18 @@ var _ = Describe("Test placement v1beta1 API validation", func() {
 			Expect(hubClient.Delete(ctx, updateRun)).Should(Succeed())
 		})
 
-		It("should allow transition from Started to Stopped", func() {
+		It("should allow transition from Execute to Pause", func() {
 			updateRun.Spec.State = placementv1beta1.StateStopped
 			Expect(hubClient.Update(ctx, updateRun)).Should(Succeed())
 		})
 
-		It("should allow transition from Started to Abandoned", func() {
+		It("should allow transition from Execute to Abandon", func() {
 			updateRun.Spec.State = placementv1beta1.StateAbandoned
 			Expect(hubClient.Update(ctx, updateRun)).Should(Succeed())
 		})
 	})
 
-	Context("Test ClusterStagedUpdateRun State API validation - valid Stopped state transitions", func() {
+	Context("Test ClusterStagedUpdateRun State API validation - valid Pause state transitions", func() {
 		var updateRun *placementv1beta1.ClusterStagedUpdateRun
 		updateRunName := fmt.Sprintf(validupdateRunNameTemplate, GinkgoParallelProcess())
 
@@ -1917,7 +1917,7 @@ var _ = Describe("Test placement v1beta1 API validation", func() {
 				},
 			}
 			Expect(hubClient.Create(ctx, updateRun)).Should(Succeed())
-			// Transition to Stopped state first
+			// Transition to Pause state first
 			updateRun.Spec.State = placementv1beta1.StateStopped
 			Expect(hubClient.Update(ctx, updateRun)).Should(Succeed())
 		})
@@ -1926,12 +1926,12 @@ var _ = Describe("Test placement v1beta1 API validation", func() {
 			Expect(hubClient.Delete(ctx, updateRun)).Should(Succeed())
 		})
 
-		It("should allow transition from Stopped to Started", func() {
+		It("should allow transition from Pause to Execute", func() {
 			updateRun.Spec.State = placementv1beta1.StateStarted
 			Expect(hubClient.Update(ctx, updateRun)).Should(Succeed())
 		})
 
-		It("should allow transition from Stopped to Abandoned", func() {
+		It("should allow transition from Pause to Abandon", func() {
 			updateRun.Spec.State = placementv1beta1.StateAbandoned
 			Expect(hubClient.Update(ctx, updateRun)).Should(Succeed())
 		})
@@ -1947,7 +1947,7 @@ var _ = Describe("Test placement v1beta1 API validation", func() {
 			}
 		})
 
-		It("should deny transition from NotStarted to Stopped", func() {
+		It("should deny transition from Initialize to Pause", func() {
 			updateRun = &placementv1beta1.ClusterStagedUpdateRun{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: updateRunName,
@@ -1962,10 +1962,10 @@ var _ = Describe("Test placement v1beta1 API validation", func() {
 			err := hubClient.Update(ctx, updateRun)
 			var statusErr *k8sErrors.StatusError
 			Expect(errors.As(err, &statusErr)).To(BeTrue(), fmt.Sprintf("Update ClusterStagedUpdateRun call produced error %s. Error type wanted is %s.", reflect.TypeOf(err), reflect.TypeOf(&k8sErrors.StatusError{})))
-			Expect(statusErr.ErrStatus.Message).Should(MatchRegexp("invalid state transition: cannot transition from NotStarted to Stopped"))
+			Expect(statusErr.ErrStatus.Message).Should(MatchRegexp("invalid state transition: cannot transition from Initialize to Pause"))
 		})
 
-		It("should deny transition from Started to NotStarted", func() {
+		It("should deny transition from Execute to Initialize", func() {
 			updateRun = &placementv1beta1.ClusterStagedUpdateRun{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: updateRunName,
@@ -1980,10 +1980,10 @@ var _ = Describe("Test placement v1beta1 API validation", func() {
 			err := hubClient.Update(ctx, updateRun)
 			var statusErr *k8sErrors.StatusError
 			Expect(errors.As(err, &statusErr)).To(BeTrue(), fmt.Sprintf("Update ClusterStagedUpdateRun call produced error %s. Error type wanted is %s.", reflect.TypeOf(err), reflect.TypeOf(&k8sErrors.StatusError{})))
-			Expect(statusErr.ErrStatus.Message).Should(MatchRegexp("invalid state transition: cannot transition from Started to NotStarted"))
+			Expect(statusErr.ErrStatus.Message).Should(MatchRegexp("invalid state transition: cannot transition from Execute to Initialize"))
 		})
 
-		It("should deny transition from Stopped to NotStarted", func() {
+		It("should deny transition from Pause to Initialize", func() {
 			updateRun = &placementv1beta1.ClusterStagedUpdateRun{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: updateRunName,
@@ -1994,19 +1994,19 @@ var _ = Describe("Test placement v1beta1 API validation", func() {
 			}
 			Expect(hubClient.Create(ctx, updateRun)).Should(Succeed())
 
-			// Transition to Stopped first
+			// Transition to Pause first
 			updateRun.Spec.State = placementv1beta1.StateStopped
 			Expect(hubClient.Update(ctx, updateRun)).Should(Succeed())
 
-			// Try to transition back to NotStarted
+			// Try to transition back to Initialize
 			updateRun.Spec.State = placementv1beta1.StateNotStarted
 			err := hubClient.Update(ctx, updateRun)
 			var statusErr *k8sErrors.StatusError
 			Expect(errors.As(err, &statusErr)).To(BeTrue(), fmt.Sprintf("Update ClusterStagedUpdateRun call produced error %s. Error type wanted is %s.", reflect.TypeOf(err), reflect.TypeOf(&k8sErrors.StatusError{})))
-			Expect(statusErr.ErrStatus.Message).Should(MatchRegexp("invalid state transition: cannot transition from Stopped to NotStarted"))
+			Expect(statusErr.ErrStatus.Message).Should(MatchRegexp("invalid state transition: cannot transition from Pause to Initialize"))
 		})
 
-		It("should deny transition from Abandoned to NotStarted", func() {
+		It("should deny transition from Abandon to Initialize", func() {
 			updateRun = &placementv1beta1.ClusterStagedUpdateRun{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: updateRunName,
@@ -2021,10 +2021,10 @@ var _ = Describe("Test placement v1beta1 API validation", func() {
 			err := hubClient.Update(ctx, updateRun)
 			var statusErr *k8sErrors.StatusError
 			Expect(errors.As(err, &statusErr)).To(BeTrue(), fmt.Sprintf("Update ClusterStagedUpdateRun call produced error %s. Error type wanted is %s.", reflect.TypeOf(err), reflect.TypeOf(&k8sErrors.StatusError{})))
-			Expect(statusErr.ErrStatus.Message).Should(MatchRegexp("invalid state transition: Abandoned is a terminal state and cannot transition to any other state"))
+			Expect(statusErr.ErrStatus.Message).Should(MatchRegexp("invalid state transition: Abandon is a terminal state and cannot transition to any other state"))
 		})
 
-		It("should deny transition from Abandoned to Started", func() {
+		It("should deny transition from Abandon to Execute", func() {
 			updateRun = &placementv1beta1.ClusterStagedUpdateRun{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: updateRunName,
@@ -2039,10 +2039,10 @@ var _ = Describe("Test placement v1beta1 API validation", func() {
 			err := hubClient.Update(ctx, updateRun)
 			var statusErr *k8sErrors.StatusError
 			Expect(errors.As(err, &statusErr)).To(BeTrue(), fmt.Sprintf("Update ClusterStagedUpdateRun call produced error %s. Error type wanted is %s.", reflect.TypeOf(err), reflect.TypeOf(&k8sErrors.StatusError{})))
-			Expect(statusErr.ErrStatus.Message).Should(MatchRegexp("invalid state transition: Abandoned is a terminal state and cannot transition to any other state"))
+			Expect(statusErr.ErrStatus.Message).Should(MatchRegexp("invalid state transition: Abandon is a terminal state and cannot transition to any other state"))
 		})
 
-		It("should deny transition from Abandoned to Stopped", func() {
+		It("should deny transition from Abandon to Pause", func() {
 			updateRun = &placementv1beta1.ClusterStagedUpdateRun{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: updateRunName,
@@ -2057,7 +2057,7 @@ var _ = Describe("Test placement v1beta1 API validation", func() {
 			err := hubClient.Update(ctx, updateRun)
 			var statusErr *k8sErrors.StatusError
 			Expect(errors.As(err, &statusErr)).To(BeTrue(), fmt.Sprintf("Update ClusterStagedUpdateRun call produced error %s. Error type wanted is %s.", reflect.TypeOf(err), reflect.TypeOf(&k8sErrors.StatusError{})))
-			Expect(statusErr.ErrStatus.Message).Should(MatchRegexp("invalid state transition: Abandoned is a terminal state and cannot transition to any other state"))
+			Expect(statusErr.ErrStatus.Message).Should(MatchRegexp("invalid state transition: Abandon is a terminal state and cannot transition to any other state"))
 		})
 	})
 
@@ -2077,7 +2077,7 @@ var _ = Describe("Test placement v1beta1 API validation", func() {
 			err := hubClient.Create(ctx, updateRun)
 			var statusErr *k8sErrors.StatusError
 			Expect(errors.As(err, &statusErr)).To(BeTrue(), fmt.Sprintf("Create ClusterStagedUpdateRun call produced error %s. Error type wanted is %s.", reflect.TypeOf(err), reflect.TypeOf(&k8sErrors.StatusError{})))
-			Expect(statusErr.ErrStatus.Message).Should(MatchRegexp("supported values: \"NotStarted\", \"Started\", \"Stopped\", \"Abandoned\""))
+			Expect(statusErr.ErrStatus.Message).Should(MatchRegexp("supported values: \"Initialize\", \"Execute\", \"Pause\", \"Abandon\""))
 		})
 	})
 


### PR DESCRIPTION
### Description of your changes
Rename the update run state so that they 
1. reflect that they are desired state instead of status
2. better convey the idea
3. keep the golang varible so it won't break existing PR


Fixes #

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
