### PR TITLE
fix: use the uncached client when validating override

### DIFF
--- a/pkg/webhook/clusterresourceoverride/clusterresourceoverride_validating_webhook.go
+++ b/pkg/webhook/clusterresourceoverride/clusterresourceoverride_validating_webhook.go
@@ -40,6 +40,8 @@ var (
 )
 
 type clusterResourceOverrideValidator struct {
+	// Note: we have to use the uncached client here to avoid getting stale data
+	// since we need to guarantee that a resource cannot be selected by multiple overrides.
 	client  client.Reader
 	decoder webhook.AdmissionDecoder
 }

--- a/pkg/webhook/resourceoverride/resourceoverride_validating_webhook.go
+++ b/pkg/webhook/resourceoverride/resourceoverride_validating_webhook.go
@@ -40,6 +40,8 @@ var (
 )
 
 type resourceOverrideValidator struct {
+	// Note: we have to use the uncached client here to avoid getting stale data
+	// since we need to guarantee that a resource cannot be selected by multiple overrides.
 	client  client.Reader
 	decoder webhook.AdmissionDecoder
 }


### PR DESCRIPTION
### Description of your changes

The webhook test flakiness was caused by cached client, when calling validateResourceOverrideResourceLimit

https://github.com/kubefleet-dev/kubefleet/actions/runs/19808825678/job/56747368075

Fixes #

I have:

- [ ] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
