### PR TITLE
fix: use the mc generation when copying the agentStatus

### DIFF
--- a/pkg/controllers/membercluster/v1beta1/membercluster_controller_test.go
+++ b/pkg/controllers/membercluster/v1beta1/membercluster_controller_test.go
@@ -706,6 +706,8 @@ func TestMarkMemberClusterJoined(t *testing.T) {
 
 func TestSyncInternalMemberClusterStatus(t *testing.T) {
 	now := metav1.Now()
+	imcObservedGeneration := int64(1)
+	mcObservedGeneration := int64(2)
 	tests := map[string]struct {
 		r                     *Reconciler
 		internalMemberCluster *clusterv1beta1.InternalMemberCluster
@@ -728,6 +730,7 @@ func TestSyncInternalMemberClusterStatus(t *testing.T) {
 							Status:             propertyProviderConditionStatus1,
 							Reason:             propertyProviderConditionReason1,
 							Message:            propertyProviderConditionMessage1,
+							ObservedGeneration: imcObservedGeneration,
 							LastTransitionTime: now,
 						},
 						{
@@ -735,6 +738,7 @@ func TestSyncInternalMemberClusterStatus(t *testing.T) {
 							Status:             propertyProviderConditionStatus2,
 							Reason:             propertyProviderConditionReason2,
 							Message:            propertyProviderConditionMessage2,
+							ObservedGeneration: imcObservedGeneration,
 							LastTransitionTime: now,
 						},
 					},
@@ -768,9 +772,10 @@ func TestSyncInternalMemberClusterStatus(t *testing.T) {
 							Type: clusterv1beta1.MemberAgent,
 							Conditions: []metav1.Condition{
 								{
-									Type:   string(clusterv1beta1.AgentJoined),
-									Status: metav1.ConditionTrue,
-									Reason: "Joined",
+									Type:               string(clusterv1beta1.AgentJoined),
+									Status:             metav1.ConditionTrue,
+									Reason:             "Joined",
+									ObservedGeneration: imcObservedGeneration,
 								},
 							},
 							LastReceivedHeartbeat: now,
@@ -779,9 +784,10 @@ func TestSyncInternalMemberClusterStatus(t *testing.T) {
 							Type: clusterv1beta1.ServiceExportImportAgent,
 							Conditions: []metav1.Condition{
 								{
-									Type:   string(clusterv1beta1.AgentJoined),
-									Status: metav1.ConditionTrue,
-									Reason: "Joined",
+									Type:               string(clusterv1beta1.AgentJoined),
+									Status:             metav1.ConditionTrue,
+									Reason:             "Joined",
+									ObservedGeneration: imcObservedGeneration,
 								},
 							},
 							LastReceivedHeartbeat: now,
@@ -789,24 +795,31 @@ func TestSyncInternalMemberClusterStatus(t *testing.T) {
 					},
 				},
 			},
-			memberCluster: &clusterv1beta1.MemberCluster{},
+			memberCluster: &clusterv1beta1.MemberCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: mcObservedGeneration,
+				},
+			},
 			wantedMemberCluster: &clusterv1beta1.MemberCluster{
 				Status: clusterv1beta1.MemberClusterStatus{
 					Conditions: []metav1.Condition{
 						{
-							Type:   string(clusterv1beta1.ConditionTypeMemberClusterJoined),
-							Status: metav1.ConditionTrue,
-							Reason: reasonMemberClusterJoined,
+							Type:               string(clusterv1beta1.ConditionTypeMemberClusterJoined),
+							Status:             metav1.ConditionTrue,
+							Reason:             reasonMemberClusterJoined,
+							ObservedGeneration: mcObservedGeneration,
 						},
 						{
-							Type:   propertyProviderConditionType1,
-							Status: propertyProviderConditionStatus1,
-							Reason: propertyProviderConditionReason1,
+							Type:               propertyProviderConditionType1,
+							Status:             propertyProviderConditionStatus1,
+							Reason:             propertyProviderConditionReason1,
+							ObservedGeneration: mcObservedGeneration,
 						},
 						{
-							Type:   propertyProviderConditionType2,
-							Status: propertyProviderConditionStatus2,
-							Reason: propertyProviderConditionReason2,
+							Type:               propertyProviderConditionType2,
+							Status:             propertyProviderConditionStatus2,
+							Reason:             propertyProviderConditionReason2,
+							ObservedGeneration: mcObservedGeneration,
 						},
 					},
 					Properties: map[clusterv1beta1.PropertyName]clusterv1beta1.PropertyValue{
@@ -839,9 +852,10 @@ func TestSyncInternalMemberClusterStatus(t *testing.T) {
 							Type: clusterv1beta1.MemberAgent,
 							Conditions: []metav1.Condition{
 								{
-									Type:   string(clusterv1beta1.AgentJoined),
-									Status: metav1.ConditionTrue,
-									Reason: "Joined",
+									Type:               string(clusterv1beta1.AgentJoined),
+									Status:             metav1.ConditionTrue,
+									Reason:             "Joined",
+									ObservedGeneration: mcObservedGeneration,
 								},
 							},
 							LastReceivedHeartbeat: now,
@@ -850,9 +864,10 @@ func TestSyncInternalMemberClusterStatus(t *testing.T) {
 							Type: clusterv1beta1.ServiceExportImportAgent,
 							Conditions: []metav1.Condition{
 								{
-									Type:   string(clusterv1beta1.AgentJoined),
-									Status: metav1.ConditionTrue,
-									Reason: "Joined",
+									Type:               string(clusterv1beta1.AgentJoined),
+									Status:             metav1.ConditionTrue,
+									Reason:             "Joined",
+									ObservedGeneration: mcObservedGeneration,
 								},
 							},
 							LastReceivedHeartbeat: now,
@@ -885,9 +900,10 @@ func TestSyncInternalMemberClusterStatus(t *testing.T) {
 							Type: clusterv1beta1.MemberAgent,
 							Conditions: []metav1.Condition{
 								{
-									Type:   string(clusterv1beta1.AgentJoined),
-									Status: metav1.ConditionFalse,
-									Reason: "Left",
+									Type:               string(clusterv1beta1.AgentJoined),
+									Status:             metav1.ConditionFalse,
+									Reason:             "Left",
+									ObservedGeneration: imcObservedGeneration,
 								},
 							},
 							LastReceivedHeartbeat: now,
@@ -896,9 +912,10 @@ func TestSyncInternalMemberClusterStatus(t *testing.T) {
 							Type: clusterv1beta1.ServiceExportImportAgent,
 							Conditions: []metav1.Condition{
 								{
-									Type:   string(clusterv1beta1.AgentJoined),
-									Status: metav1.ConditionFalse,
-									Reason: "Left",
+									Type:               string(clusterv1beta1.AgentJoined),
+									Status:             metav1.ConditionFalse,
+									Reason:             "Left",
+									ObservedGeneration: imcObservedGeneration,
 								},
 							},
 							LastReceivedHeartbeat: now,
@@ -906,19 +923,25 @@ func TestSyncInternalMemberClusterStatus(t *testing.T) {
 					},
 				},
 			},
-			memberCluster: &clusterv1beta1.MemberCluster{},
+			memberCluster: &clusterv1beta1.MemberCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: mcObservedGeneration,
+				},
+			},
 			wantedMemberCluster: &clusterv1beta1.MemberCluster{
 				Status: clusterv1beta1.MemberClusterStatus{
 					Conditions: []metav1.Condition{
 						{
-							Type:   string(clusterv1beta1.ConditionTypeMemberClusterJoined),
-							Status: metav1.ConditionFalse,
-							Reason: reasonMemberClusterLeft,
+							Type:               string(clusterv1beta1.ConditionTypeMemberClusterJoined),
+							Status:             metav1.ConditionFalse,
+							Reason:             reasonMemberClusterLeft,
+							ObservedGeneration: mcObservedGeneration,
 						},
 						{
-							Type:   string(clusterv1beta1.ConditionTypeMemberClusterReadyToJoin),
-							Status: metav1.ConditionFalse,
-							Reason: reasonMemberClusterNotReadyToJoin,
+							Type:               string(clusterv1beta1.ConditionTypeMemberClusterReadyToJoin),
+							Status:             metav1.ConditionFalse,
+							Reason:             reasonMemberClusterNotReadyToJoin,
+							ObservedGeneration: mcObservedGeneration,
 						},
 					},
 					ResourceUsage: clusterv1beta1.ResourceUsage{
@@ -935,9 +958,10 @@ func TestSyncInternalMemberClusterStatus(t *testing.T) {
 							Type: clusterv1beta1.MemberAgent,
 							Conditions: []metav1.Condition{
 								{
-									Type:   string(clusterv1beta1.AgentJoined),
-									Status: metav1.ConditionFalse,
-									Reason: "Left",
+									Type:               string(clusterv1beta1.AgentJoined),
+									Status:             metav1.ConditionFalse,
+									Reason:             "Left",
+									ObservedGeneration: mcObservedGeneration,
 								},
 							},
 							LastReceivedHeartbeat: now,
@@ -946,9 +970,10 @@ func TestSyncInternalMemberClusterStatus(t *testing.T) {
 							Type: clusterv1beta1.ServiceExportImportAgent,
 							Conditions: []metav1.Condition{
 								{
-									Type:   string(clusterv1beta1.AgentJoined),
-									Status: metav1.ConditionFalse,
-									Reason: "Left",
+									Type:               string(clusterv1beta1.AgentJoined),
+									Status:             metav1.ConditionFalse,
+									Reason:             "Left",
+									ObservedGeneration: mcObservedGeneration,
 								},
 							},
 							LastReceivedHeartbeat: now,
@@ -981,9 +1006,10 @@ func TestSyncInternalMemberClusterStatus(t *testing.T) {
 							Type: clusterv1beta1.MemberAgent,
 							Conditions: []metav1.Condition{
 								{
-									Type:   string(clusterv1beta1.AgentJoined),
-									Status: metav1.ConditionTrue,
-									Reason: "Joined",
+									Type:               string(clusterv1beta1.AgentJoined),
+									Status:             metav1.ConditionTrue,
+									Reason:             "Joined",
+									ObservedGeneration: imcObservedGeneration,
 								},
 							},
 							LastReceivedHeartbeat: now,
@@ -992,9 +1018,10 @@ func TestSyncInternalMemberClusterStatus(t *testing.T) {
 							Type: clusterv1beta1.ServiceExportImportAgent,
 							Conditions: []metav1.Condition{
 								{
-									Type:   string(clusterv1beta1.AgentJoined),
-									Status: metav1.ConditionFalse,
-									Reason: "Left",
+									Type:               string(clusterv1beta1.AgentJoined),
+									Status:             metav1.ConditionFalse,
+									Reason:             "Left",
+									ObservedGeneration: imcObservedGeneration,
 								},
 							},
 							LastReceivedHeartbeat: now,
@@ -1002,14 +1029,19 @@ func TestSyncInternalMemberClusterStatus(t *testing.T) {
 					},
 				},
 			},
-			memberCluster: &clusterv1beta1.MemberCluster{},
+			memberCluster: &clusterv1beta1.MemberCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: mcObservedGeneration,
+				},
+			},
 			wantedMemberCluster: &clusterv1beta1.MemberCluster{
 				Status: clusterv1beta1.MemberClusterStatus{
 					Conditions: []metav1.Condition{
 						{
-							Type:   string(clusterv1beta1.ConditionTypeMemberClusterJoined),
-							Status: metav1.ConditionUnknown,
-							Reason: reasonMemberClusterUnknown,
+							Type:               string(clusterv1beta1.ConditionTypeMemberClusterJoined),
+							Status:             metav1.ConditionUnknown,
+							Reason:             reasonMemberClusterUnknown,
+							ObservedGeneration: mcObservedGeneration,
 						},
 					},
 					ResourceUsage: clusterv1beta1.ResourceUsage{
@@ -1026,9 +1058,10 @@ func TestSyncInternalMemberClusterStatus(t *testing.T) {
 							Type: clusterv1beta1.MemberAgent,
 							Conditions: []metav1.Condition{
 								{
-									Type:   string(clusterv1beta1.AgentJoined),
-									Status: metav1.ConditionTrue,
-									Reason: "Joined",
+									Type:               string(clusterv1beta1.AgentJoined),
+									Status:             metav1.ConditionTrue,
+									Reason:             "Joined",
+									ObservedGeneration: mcObservedGeneration,
 								},
 							},
 							LastReceivedHeartbeat: now,
@@ -1037,9 +1070,10 @@ func TestSyncInternalMemberClusterStatus(t *testing.T) {
 							Type: clusterv1beta1.ServiceExportImportAgent,
 							Conditions: []metav1.Condition{
 								{
-									Type:   string(clusterv1beta1.AgentJoined),
-									Status: metav1.ConditionFalse,
-									Reason: "Left",
+									Type:               string(clusterv1beta1.AgentJoined),
+									Status:             metav1.ConditionFalse,
+									Reason:             "Left",
+									ObservedGeneration: mcObservedGeneration,
 								},
 							},
 							LastReceivedHeartbeat: now,
@@ -1068,7 +1102,11 @@ func TestSyncInternalMemberClusterStatus(t *testing.T) {
 					},
 				},
 			},
-			memberCluster: &clusterv1beta1.MemberCluster{},
+			memberCluster: &clusterv1beta1.MemberCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: mcObservedGeneration,
+				},
+			},
 			wantedMemberCluster: &clusterv1beta1.MemberCluster{
 				Status: clusterv1beta1.MemberClusterStatus{
 					ResourceUsage: clusterv1beta1.ResourceUsage{
@@ -1082,9 +1120,10 @@ func TestSyncInternalMemberClusterStatus(t *testing.T) {
 					},
 					Conditions: []metav1.Condition{
 						{
-							Type:   string(clusterv1beta1.ConditionTypeMemberClusterJoined),
-							Status: metav1.ConditionUnknown,
-							Reason: reasonMemberClusterUnknown,
+							Type:               string(clusterv1beta1.ConditionTypeMemberClusterJoined),
+							Status:             metav1.ConditionUnknown,
+							Reason:             reasonMemberClusterUnknown,
+							ObservedGeneration: mcObservedGeneration,
 						},
 					},
 				},
@@ -1125,9 +1164,10 @@ func TestSyncInternalMemberClusterStatus(t *testing.T) {
 							Type: clusterv1beta1.MemberAgent,
 							Conditions: []metav1.Condition{
 								{
-									Type:   string(clusterv1beta1.AgentJoined),
-									Status: metav1.ConditionTrue,
-									Reason: "Joined",
+									Type:               string(clusterv1beta1.AgentJoined),
+									Status:             metav1.ConditionTrue,
+									Reason:             "Joined",
+									ObservedGeneration: imcObservedGeneration,
 								},
 							},
 							LastReceivedHeartbeat: now,
@@ -1136,9 +1176,10 @@ func TestSyncInternalMemberClusterStatus(t *testing.T) {
 							Type: clusterv1beta1.ServiceExportImportAgent,
 							Conditions: []metav1.Condition{
 								{
-									Type:   string(clusterv1beta1.AgentJoined),
-									Status: metav1.ConditionTrue,
-									Reason: "Joined",
+									Type:               string(clusterv1beta1.AgentJoined),
+									Status:             metav1.ConditionTrue,
+									Reason:             "Joined",
+									ObservedGeneration: imcObservedGeneration,
 								},
 							},
 							LastReceivedHeartbeat: now,
@@ -1147,9 +1188,10 @@ func TestSyncInternalMemberClusterStatus(t *testing.T) {
 							Type: clusterv1beta1.MultiClusterServiceAgent,
 							Conditions: []metav1.Condition{
 								{
-									Type:   string(clusterv1beta1.AgentJoined),
-									Status: metav1.ConditionFalse,
-									Reason: "Left",
+									Type:               string(clusterv1beta1.AgentJoined),
+									Status:             metav1.ConditionFalse,
+									Reason:             "Left",
+									ObservedGeneration: imcObservedGeneration,
 								},
 							},
 							LastReceivedHeartbeat: now,
@@ -1157,14 +1199,19 @@ func TestSyncInternalMemberClusterStatus(t *testing.T) {
 					},
 				},
 			},
-			memberCluster: &clusterv1beta1.MemberCluster{},
+			memberCluster: &clusterv1beta1.MemberCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: mcObservedGeneration,
+				},
+			},
 			wantedMemberCluster: &clusterv1beta1.MemberCluster{
 				Status: clusterv1beta1.MemberClusterStatus{
 					Conditions: []metav1.Condition{
 						{
-							Type:   string(clusterv1beta1.ConditionTypeMemberClusterJoined),
-							Status: metav1.ConditionTrue,
-							Reason: reasonMemberClusterJoined,
+							Type:               string(clusterv1beta1.ConditionTypeMemberClusterJoined),
+							Status:             metav1.ConditionTrue,
+							Reason:             reasonMemberClusterJoined,
+							ObservedGeneration: mcObservedGeneration,
 						},
 					},
 					ResourceUsage: clusterv1beta1.ResourceUsage{
@@ -1181,9 +1228,10 @@ func TestSyncInternalMemberClusterStatus(t *testing.T) {
 							Type: clusterv1beta1.MemberAgent,
 							Conditions: []metav1.Condition{
 								{
-									Type:   string(clusterv1beta1.AgentJoined),
-									Status: metav1.ConditionTrue,
-									Reason: "Joined",
+									Type:               string(clusterv1beta1.AgentJoined),
+									Status:             metav1.ConditionTrue,
+									Reason:             "Joined",
+									ObservedGeneration: mcObservedGeneration,
 								},
 							},
 							LastReceivedHeartbeat: now,
@@ -1192,9 +1240,10 @@ func TestSyncInternalMemberClusterStatus(t *testing.T) {
 							Type: clusterv1beta1.ServiceExportImportAgent,
 							Conditions: []metav1.Condition{
 								{
-									Type:   string(clusterv1beta1.AgentJoined),
-									Status: metav1.ConditionTrue,
-									Reason: "Joined",
+									Type:               string(clusterv1beta1.AgentJoined),
+									Status:             metav1.ConditionTrue,
+									Reason:             "Joined",
+									ObservedGeneration: mcObservedGeneration,
 								},
 							},
 							LastReceivedHeartbeat: now,
@@ -1203,9 +1252,10 @@ func TestSyncInternalMemberClusterStatus(t *testing.T) {
 							Type: clusterv1beta1.MultiClusterServiceAgent,
 							Conditions: []metav1.Condition{
 								{
-									Type:   string(clusterv1beta1.AgentJoined),
-									Status: metav1.ConditionFalse,
-									Reason: "Left",
+									Type:               string(clusterv1beta1.AgentJoined),
+									Status:             metav1.ConditionFalse,
+									Reason:             "Left",
+									ObservedGeneration: mcObservedGeneration,
 								},
 							},
 							LastReceivedHeartbeat: now,
@@ -1238,9 +1288,10 @@ func TestSyncInternalMemberClusterStatus(t *testing.T) {
 							Type: clusterv1beta1.MemberAgent,
 							Conditions: []metav1.Condition{
 								{
-									Type:   string(clusterv1beta1.AgentJoined),
-									Status: metav1.ConditionTrue,
-									Reason: "Joined",
+									Type:               string(clusterv1beta1.AgentJoined),
+									Status:             metav1.ConditionTrue,
+									Reason:             "Joined",
+									ObservedGeneration: imcObservedGeneration,
 								},
 							},
 							LastReceivedHeartbeat: now,
@@ -1248,14 +1299,19 @@ func TestSyncInternalMemberClusterStatus(t *testing.T) {
 					},
 				},
 			},
-			memberCluster: &clusterv1beta1.MemberCluster{},
+			memberCluster: &clusterv1beta1.MemberCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: mcObservedGeneration,
+				},
+			},
 			wantedMemberCluster: &clusterv1beta1.MemberCluster{
 				Status: clusterv1beta1.MemberClusterStatus{
 					Conditions: []metav1.Condition{
 						{
-							Type:   string(clusterv1beta1.ConditionTypeMemberClusterJoined),
-							Status: metav1.ConditionUnknown,
-							Reason: reasonMemberClusterUnknown,
+							Type:               string(clusterv1beta1.ConditionTypeMemberClusterJoined),
+							Status:             metav1.ConditionUnknown,
+							Reason:             reasonMemberClusterUnknown,
+							ObservedGeneration: mcObservedGeneration,
 						},
 					},
 					ResourceUsage: clusterv1beta1.ResourceUsage{
@@ -1272,9 +1328,10 @@ func TestSyncInternalMemberClusterStatus(t *testing.T) {
 							Type: clusterv1beta1.MemberAgent,
 							Conditions: []metav1.Condition{
 								{
-									Type:   string(clusterv1beta1.AgentJoined),
-									Status: metav1.ConditionTrue,
-									Reason: "Joined",
+									Type:               string(clusterv1beta1.AgentJoined),
+									Status:             metav1.ConditionTrue,
+									Reason:             "Joined",
+									ObservedGeneration: mcObservedGeneration,
 								},
 							},
 							LastReceivedHeartbeat: now,
@@ -1307,9 +1364,10 @@ func TestSyncInternalMemberClusterStatus(t *testing.T) {
 							Type: clusterv1beta1.MemberAgent,
 							Conditions: []metav1.Condition{
 								{
-									Type:   string(clusterv1beta1.AgentJoined),
-									Status: metav1.ConditionTrue,
-									Reason: "Joined",
+									Type:               string(clusterv1beta1.AgentJoined),
+									Status:             metav1.ConditionTrue,
+									Reason:             "Joined",
+									ObservedGeneration: imcObservedGeneration,
 								},
 							},
 							LastReceivedHeartbeat: now,
@@ -1321,14 +1379,19 @@ func TestSyncInternalMemberClusterStatus(t *testing.T) {
 					},
 				},
 			},
-			memberCluster: &clusterv1beta1.MemberCluster{},
+			memberCluster: &clusterv1beta1.MemberCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: mcObservedGeneration,
+				},
+			},
 			wantedMemberCluster: &clusterv1beta1.MemberCluster{
 				Status: clusterv1beta1.MemberClusterStatus{
 					Conditions: []metav1.Condition{
 						{
-							Type:   string(clusterv1beta1.ConditionTypeMemberClusterJoined),
-							Status: metav1.ConditionUnknown,
-							Reason: reasonMemberClusterUnknown,
+							Type:               string(clusterv1beta1.ConditionTypeMemberClusterJoined),
+							Status:             metav1.ConditionUnknown,
+							Reason:             reasonMemberClusterUnknown,
+							ObservedGeneration: mcObservedGeneration,
 						},
 					},
 					ResourceUsage: clusterv1beta1.ResourceUsage{
@@ -1345,9 +1408,10 @@ func TestSyncInternalMemberClusterStatus(t *testing.T) {
 							Type: clusterv1beta1.MemberAgent,
 							Conditions: []metav1.Condition{
 								{
-									Type:   string(clusterv1beta1.AgentJoined),
-									Status: metav1.ConditionTrue,
-									Reason: "Joined",
+									Type:               string(clusterv1beta1.AgentJoined),
+									Status:             metav1.ConditionTrue,
+									Reason:             "Joined",
+									ObservedGeneration: mcObservedGeneration,
 								},
 							},
 							LastReceivedHeartbeat: now,
@@ -1384,9 +1448,10 @@ func TestSyncInternalMemberClusterStatus(t *testing.T) {
 							Type: clusterv1beta1.MemberAgent,
 							Conditions: []metav1.Condition{
 								{
-									Type:   string(clusterv1beta1.AgentJoined),
-									Status: metav1.ConditionTrue,
-									Reason: "Joined",
+									Type:               string(clusterv1beta1.AgentJoined),
+									Status:             metav1.ConditionTrue,
+									Reason:             "Joined",
+									ObservedGeneration: imcObservedGeneration,
 								},
 							},
 							LastReceivedHeartbeat: now,
@@ -1398,14 +1463,19 @@ func TestSyncInternalMemberClusterStatus(t *testing.T) {
 					},
 				},
 			},
-			memberCluster: &clusterv1beta1.MemberCluster{},
+			memberCluster: &clusterv1beta1.MemberCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: mcObservedGeneration,
+				},
+			},
 			wantedMemberCluster: &clusterv1beta1.MemberCluster{
 				Status: clusterv1beta1.MemberClusterStatus{
 					Conditions: []metav1.Condition{
 						{
-							Type:   string(clusterv1beta1.ConditionTypeMemberClusterJoined),
-							Status: metav1.ConditionUnknown,
-							Reason: reasonMemberClusterUnknown,
+							Type:               string(clusterv1beta1.ConditionTypeMemberClusterJoined),
+							Status:             metav1.ConditionUnknown,
+							Reason:             reasonMemberClusterUnknown,
+							ObservedGeneration: mcObservedGeneration,
 						},
 					},
 					ResourceUsage: clusterv1beta1.ResourceUsage{
@@ -1422,9 +1492,10 @@ func TestSyncInternalMemberClusterStatus(t *testing.T) {
 							Type: clusterv1beta1.MemberAgent,
 							Conditions: []metav1.Condition{
 								{
-									Type:   string(clusterv1beta1.AgentJoined),
-									Status: metav1.ConditionTrue,
-									Reason: "Joined",
+									Type:               string(clusterv1beta1.AgentJoined),
+									Status:             metav1.ConditionTrue,
+									Reason:             "Joined",
+									ObservedGeneration: mcObservedGeneration,
 								},
 							},
 							LastReceivedHeartbeat: now,


### PR DESCRIPTION
### Description of your changes

The wrong observedGeneration generated wrong log info about healthy condition.

> 2025-12-10T10:10:23.355648245Z stderr F I1210 10:10:23.355609       1 v1beta1/membercluster_controller.go:542] "Update the memberCluster status" memberCluster="kind-cluster-2" joined=true healthy=false lastReceivedHeartbeat="2025-12-10T10:10:23Z"

https://github.com/kubefleet-dev/kubefleet/blob/main/pkg/controllers/membercluster/v1beta1/membercluster_controller.go#L542

The bug won't cause the scheduling failure, as we did not check the generation when checking the cluster status in https://github.com/kubefleet-dev/kubefleet/blob/main/pkg/scheduler/clustereligibilitychecker/checker.go#L127


Fixes #

I have:

- [ ] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

Updated the unit tests and validated in the e2e tests

```
grep -rin "healthy=false" .
./hub-agent-hub-agent_0.log.20251215-065512.log:22435:2025-12-15T06:54:45.501260198Z stderr F I1215 06:54:45.501201       1 v1beta1/membercluster_controller.go:552] "Update the memberCluster status" memberCluster="mc-11" joined=false healthy=false lastReceivedHeartbeat="nil"
```
the healthy will be false when the agent has not joined yet.

### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
