### PR TITLE
fix: fix update run name CEL

### DIFF
--- a/apis/placement/v1beta1/stageupdate_types.go
+++ b/apis/placement/v1beta1/stageupdate_types.go
@@ -96,7 +96,7 @@ type UpdateRunObjList interface {
 // +kubebuilder:printcolumn:JSONPath=`.status.conditions[?(@.type=="Succeeded")].status`,name="Succeeded",type=string
 // +kubebuilder:printcolumn:JSONPath=`.metadata.creationTimestamp`,name="Age",type=date
 // +kubebuilder:printcolumn:JSONPath=`.spec.stagedRolloutStrategyName`,name="Strategy",priority=1,type=string
-// +kubebuilder:validation:XValidation:rule="size(self.metadata.name) < 128",message="metadata.name max length is 127"
+// +kubebuilder:validation:XValidation:rule="size(self.metadata.name) < 64",message="metadata.name max length is 63"
 
 // ClusterStagedUpdateRun represents a stage by stage update process that applies ClusterResourcePlacement
 // selected resources to specified clusters.
@@ -790,7 +790,7 @@ func (c *ClusterApprovalRequestList) GetApprovalRequestObjs() []ApprovalRequestO
 // +kubebuilder:printcolumn:JSONPath=`.status.conditions[?(@.type=="Succeeded")].status`,name="Succeeded",type=string
 // +kubebuilder:printcolumn:JSONPath=`.metadata.creationTimestamp`,name="Age",type=date
 // +kubebuilder:printcolumn:JSONPath=`.spec.stagedRolloutStrategyName`,name="Strategy",priority=1,type=string
-// +kubebuilder:validation:XValidation:rule="size(self.metadata.name) < 128",message="metadata.name max length is 127"
+// +kubebuilder:validation:XValidation:rule="size(self.metadata.name) < 64",message="metadata.name max length is 63"
 
 // StagedUpdateRun represents a stage by stage update process that applies ResourcePlacement
 // selected resources to specified clusters.

--- a/config/crd/bases/placement.kubernetes-fleet.io_clusterstagedupdateruns.yaml
+++ b/config/crd/bases/placement.kubernetes-fleet.io_clusterstagedupdateruns.yaml
@@ -2436,8 +2436,8 @@ spec:
         - spec
         type: object
         x-kubernetes-validations:
-        - message: metadata.name max length is 127
-          rule: size(self.metadata.name) < 128
+        - message: metadata.name max length is 63
+          rule: size(self.metadata.name) < 64
     served: true
     storage: true
     subresources:

--- a/config/crd/bases/placement.kubernetes-fleet.io_stagedupdateruns.yaml
+++ b/config/crd/bases/placement.kubernetes-fleet.io_stagedupdateruns.yaml
@@ -1356,8 +1356,8 @@ spec:
         - spec
         type: object
         x-kubernetes-validations:
-        - message: metadata.name max length is 127
-          rule: size(self.metadata.name) < 128
+        - message: metadata.name max length is 63
+          rule: size(self.metadata.name) < 64
     served: true
     storage: true
     subresources:

--- a/test/apis/placement/v1beta1/api_validation_integration_test.go
+++ b/test/apis/placement/v1beta1/api_validation_integration_test.go
@@ -1129,7 +1129,7 @@ var _ = Describe("Test placement v1beta1 API validation", func() {
 	})
 
 	Context("Test ClusterStagedUpdateRun API validation - invalid cases", func() {
-		It("Should deny creation of ClusterStagedUpdateRun with name length > 127", func() {
+		It("Should deny creation of ClusterStagedUpdateRun with name length > 63", func() {
 			updateRun := placementv1beta1.ClusterStagedUpdateRun{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: fmt.Sprintf(invalidupdateRunNameTemplate, GinkgoParallelProcess()),
@@ -1138,7 +1138,7 @@ var _ = Describe("Test placement v1beta1 API validation", func() {
 			err := hubClient.Create(ctx, &updateRun)
 			var statusErr *k8sErrors.StatusError
 			Expect(errors.As(err, &statusErr)).To(BeTrue(), fmt.Sprintf("Create updateRun call produced error %s. Error type wanted is %s.", reflect.TypeOf(err), reflect.TypeOf(&k8sErrors.StatusError{})))
-			Expect(statusErr.ErrStatus.Message).Should(MatchRegexp("metadata.name max length is 127"))
+			Expect(statusErr.ErrStatus.Message).Should(MatchRegexp("metadata.name max length is 63"))
 		})
 
 		It("Should deny update of ClusterStagedUpdateRun placementName field", func() {


### PR DESCRIPTION
### Description of your changes

I have:
- Updated the CEL validation for the update run name. The name cannot be longer than 63 characters.

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- Manually
- Integration test

### Special notes for your reviewer

Create a clusterStagedUpdateRun with the max characters allowed [which is 127 based on the CEL check](https://github.com/kubefleet-dev/kubefleet/blob/6f3e972bde75040fb6eeaf275de63125dbf9660c/apis/placement/v1beta1/stageupdate_types.go#L99C11-L99C119). When the controller tried to create the cluster approval request I got this error:
 
```bash
"Failed to create the approval request" err="ClusterApprovalRequest.placement.kubernetes-fleet.io .... is invalid: metadata.labels: Invalid value: \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\": must be no more than 63 characters" 
```
 
Seems like the cap for the update run name should be 63 characters not 127 so that it fits in the label. https://github.com/kubefleet-dev/kubefleet/blob/6f3e972bde75040fb6eeaf275de63125dbf9660c/pkg/controllers/updaterun/execution.go#L632

Label Values need to be <= 63 characters (https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set)
