### PR TITLE
fix: check the caData field too

### DIFF
--- a/pkg/controllers/clusterinventory/clusterprofile/controller.go
+++ b/pkg/controllers/clusterinventory/clusterprofile/controller.go
@@ -201,7 +201,6 @@ func (r *Reconciler) fillInClusterStatus(mc *clusterv1beta1.MemberCluster, cp *c
 	} else {
 		// throw an alert
 		_ = controller.NewUnexpectedBehaviorError(fmt.Errorf("cluster certificate authority data not found in member cluster %s status", mc.Name))
-		cp.Status.AccessProviders[0].Cluster.InsecureSkipTLSVerify = true
 	}
 }
 

--- a/pkg/propertyprovider/azure/provider.go
+++ b/pkg/propertyprovider/azure/provider.go
@@ -261,9 +261,13 @@ func (p *PropertyProvider) Start(ctx context.Context, config *rest.Config) error
 		}
 		p.clusterCertificateAuthority = cadata
 		p.clusterCertificateAuthorityObservedTime = time.Now()
+		klog.V(2).Info("Cached cluster certificate authority data from file")
+	} else if len(config.CAData) > 0 {
+		p.clusterCertificateAuthority = config.CAData
+		p.clusterCertificateAuthorityObservedTime = time.Now()
 		klog.V(2).Info("Cached cluster certificate authority data")
 	} else {
-		err := fmt.Errorf("rest.Config CAFile empty: %s", config.CAFile)
+		err := fmt.Errorf("rest.Config has empty CAFile and CAData")
 		klog.ErrorS(err, "No certificate authority data available in rest.Config")
 	}
 


### PR DESCRIPTION
### Description of your changes
Fix the issue that clusterProfile's CAData is not populated.  No test can be easily added as the member agent use incluster usually which does not have CAData populated. This only happens if somehow a kubeConfig env is set for a controller.

Fixes #

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
