### PR TITLE
test: fix flaky report diff e2e

### DIFF
--- a/test/e2e/placement_drift_diff_test.go
+++ b/test/e2e/placement_drift_diff_test.go
@@ -1383,6 +1383,10 @@ var _ = Describe("report diff mode", func() {
 				}
 			}
 
+			// With workapplier's backoff requeue enabled, it takes longer to report the new diff results.
+			// The backoff logic is: 1 attempt after 5s (fixed delay), 2nd attempt after 2s (initial delay for slow backoff),
+			// fast backoff with exponential rate of 1.5x (as diff report succeeded).
+			// The test takes ~25s to reach this point, so workloadEventuallyDuration (45s) should be enough to cover the backoff delays.
 			Eventually(func() error {
 				crp := &placementv1beta1.ClusterResourcePlacement{}
 				if err := hubClient.Get(ctx, types.NamespacedName{Name: crpName}, crp); err != nil {
@@ -1394,7 +1398,7 @@ var _ = Describe("report diff mode", func() {
 					return fmt.Errorf("CRP status diff (-got, +want): %s", diff)
 				}
 				return nil
-			}, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update CRP status as expected")
+			}, workloadEventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update CRP status as expected")
 		})
 
 		AfterAll(func() {

--- a/test/e2e/resource_placement_drift_diff_test.go
+++ b/test/e2e/resource_placement_drift_diff_test.go
@@ -1556,6 +1556,10 @@ var _ = Describe("report diff mode using RP", Label("resourceplacement"), func()
 				}
 			}
 
+			// With workapplier's backoff requeue enabled, it takes longer to report the new diff results.
+			// The backoff logic is: 1 attempt after 5s (fixed delay), 2nd attempt after 2s (initial delay for slow backoff),
+			// fast backoff with exponential rate of 1.5x (as diff report succeeded).
+			// The test takes ~25s to reach this point, so workloadEventuallyDuration (45s) should be enough to cover the backoff delays.
 			Eventually(func() error {
 				rp := &placementv1beta1.ResourcePlacement{}
 				if err := hubClient.Get(ctx, types.NamespacedName{Name: rpName, Namespace: nsName}, rp); err != nil {
@@ -1567,7 +1571,7 @@ var _ = Describe("report diff mode using RP", Label("resourceplacement"), func()
 					return fmt.Errorf("RP status diff (-got, +want): %s", diff)
 				}
 				return nil
-			}, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update RP status as expected")
+			}, workloadEventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update RP status as expected")
 		})
 
 		AfterAll(func() {


### PR DESCRIPTION
### Description of your changes

Fix flaky report-diff e2e like https://github.com/kubefleet-dev/kubefleet/actions/runs/20232703043/job/58149088651?pr=379. The root cause is that with workapplier backoff requeue enabled, the default eventual duration may not be able to cover the backoff delay so new diff may not be reflected yet.

-->

Fixes #

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
