### PR TITLE
fix: default KUBECONFIG to ~/.kube/config in E2E tests

### DIFF
--- a/test/e2e/framework/cluster.go
+++ b/test/e2e/framework/cluster.go
@@ -18,6 +18,7 @@ package framework
 
 import (
 	"os"
+	"path/filepath"
 
 	"github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -33,8 +34,18 @@ import (
 )
 
 var (
-	kubeconfigPath = os.Getenv("KUBECONFIG")
+	kubeconfigPath string
 )
+
+func init() {
+	kubeconfigPath = os.Getenv("KUBECONFIG")
+	if kubeconfigPath == "" {
+		// Default to $HOME/.kube/config like kubectl does.
+		if home, err := os.UserHomeDir(); err == nil {
+			kubeconfigPath = filepath.Join(home, ".kube", "config")
+		}
+	}
+}
 
 // Cluster object defines the required clients based on the kubeconfig of the test cluster.
 type Cluster struct {

--- a/test/e2e/setup_test.go
+++ b/test/e2e/setup_test.go
@@ -76,7 +76,6 @@ const (
 	hubClusterSAName = "fleet-hub-agent"
 	fleetSystemNS    = "fleet-system"
 
-	kubeConfigPathEnvVarName            = "KUBECONFIG"
 	propertyProviderEnvVarName          = "PROPERTY_PROVIDER"
 	azurePropertyProviderEnvVarValue    = "azure"
 	fleetClusterResourceIDAnnotationKey = "fleet.azure.com/cluster-resource-id"
@@ -323,9 +322,6 @@ func beforeSuiteForAllProcesses() {
 	fs := flag.NewFlagSet("klog", flag.ContinueOnError)
 	klog.InitFlags(fs)
 	Expect(fs.Parse([]string{"--v", "5", "-add_dir_header", "true"})).Should(Succeed())
-
-	// Check if the required environment variable, which specifies the path to kubeconfig file, has been set.
-	Expect(os.Getenv(kubeConfigPathEnvVarName)).NotTo(BeEmpty(), "Required environment variable KUBECONFIG is not set")
 
 	resourceSnapshotCreationMinimumIntervalEnv := os.Getenv("RESOURCE_SNAPSHOT_CREATION_MINIMUM_INTERVAL")
 	if resourceSnapshotCreationMinimumIntervalEnv == "" {

--- a/test/upgrade/after/setup_test.go
+++ b/test/upgrade/after/setup_test.go
@@ -63,8 +63,6 @@ const (
 	memberCluster1EastProdSAName   = "fleet-member-agent-cluster-1"
 	memberCluster2EastCanarySAName = "fleet-member-agent-cluster-2"
 	memberCluster3WestProdSAName   = "fleet-member-agent-cluster-3"
-
-	kubeConfigPathEnvVarName = "KUBECONFIG"
 )
 
 const (
@@ -182,9 +180,6 @@ func beforeSuiteForAllProcesses() {
 	fs := flag.NewFlagSet("klog", flag.ContinueOnError)
 	klog.InitFlags(fs)
 	Expect(fs.Parse([]string{"--v", "5", "-add_dir_header", "true"})).Should(Succeed())
-
-	// Check if the required environment variable, which specifies the path to kubeconfig file, has been set.
-	Expect(os.Getenv(kubeConfigPathEnvVarName)).NotTo(BeEmpty(), "Required environment variable KUBECONFIG is not set")
 
 	// Initialize the cluster objects and their clients.
 	hubCluster = framework.NewCluster(hubClusterName, "", scheme, nil)

--- a/test/upgrade/before/setup_test.go
+++ b/test/upgrade/before/setup_test.go
@@ -67,8 +67,6 @@ const (
 
 	hubClusterSAName = "fleet-hub-agent"
 	fleetSystemNS    = "fleet-system"
-
-	kubeConfigPathEnvVarName = "KUBECONFIG"
 )
 
 const (
@@ -206,9 +204,6 @@ func beforeSuiteForAllProcesses() {
 	fs := flag.NewFlagSet("klog", flag.ContinueOnError)
 	klog.InitFlags(fs)
 	Expect(fs.Parse([]string{"--v", "5", "-add_dir_header", "true"})).Should(Succeed())
-
-	// Check if the required environment variable, which specifies the path to kubeconfig file, has been set.
-	Expect(os.Getenv(kubeConfigPathEnvVarName)).NotTo(BeEmpty(), "Required environment variable KUBECONFIG is not set")
 
 	// Initialize the cluster objects and their clients.
 	hubCluster = framework.NewCluster(hubClusterName, "", scheme, nil)


### PR DESCRIPTION
### Description of your changes

This pull request improves the handling of the kubeconfig path in test setup code. Instead of requiring the `KUBECONFIG` environment variable to be set, the code now defaults to using the standard `$HOME/.kube/config` path if the variable is not present, matching the behavior of `kubectl`. This makes running tests easier and more robust in different environments. Additionally, redundant checks and constants related to `KUBECONFIG` have been removed from the test setup files.

**Kubeconfig Path Handling Improvements:**

* Added logic in `test/e2e/framework/cluster.go` to set `kubeconfigPath` to the value of the `KUBECONFIG` environment variable, or default to `$HOME/.kube/config` if the variable is not set. [[1]](diffhunk://#diff-1faff560912ad0538bb003e26b4a6e605a75f4883cf733e3ef59b44ab9b5ea37R21) [[2]](diffhunk://#diff-1faff560912ad0538bb003e26b4a6e605a75f4883cf733e3ef59b44ab9b5ea37L36-R49)

**Test Setup Simplification:**

* Removed the requirement and associated checks for the `KUBECONFIG` environment variable in `test/e2e/setup_test.go`, `test/upgrade/after/setup_test.go`, and `test/upgrade/before/setup_test.go`. [[1]](diffhunk://#diff-cbecd05d3d19bc074c3463404c4c2d4af4f6b2dde9a15e0e587df4bd97e3a13fL79) [[2]](diffhunk://#diff-cbecd05d3d19bc074c3463404c4c2d4af4f6b2dde9a15e0e587df4bd97e3a13fL334-L336) [[3]](diffhunk://#diff-ea746c0a2ff51ab82c346b537915ed45984f72fbdff6fdaaba1124d5ad0b223dL66-L67) [[4]](diffhunk://#diff-ea746c0a2ff51ab82c346b537915ed45984f72fbdff6fdaaba1124d5ad0b223dL186-L188) [[5]](diffhunk://#diff-6dbea05a853516800d4e9533213ccd82caa93284c176c6eac6ed072665a50906L70-L71) [[6]](diffhunk://#diff-6dbea05a853516800d4e9533213ccd82caa93284c176c6eac6ed072665a50906L210-L212)

Fixes #402 

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

Ran `make clean-e2e-tests && make e2e-tests` before and after the fix. Didn't run into the same issue.


### Special notes for your reviewer

N/A
