### PR TITLE
fix: add nil checks to E2E cleanup functions

### DIFF
--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -589,6 +589,9 @@ func setupInvalidClusters() {
 }
 
 func cleanupInvalidClusters() {
+	if hubClient == nil {
+		return
+	}
 	invalidClusterNames := []string{memberCluster4UnhealthyName, memberCluster5LeftName}
 	for _, name := range invalidClusterNames {
 		mcObj := &clusterv1beta1.MemberCluster{
@@ -658,6 +661,9 @@ func createResourcesForFleetGuardRail() {
 
 // deleteResourcesForFleetGuardRail deletes resources created for guard rail E2Es.
 func deleteResourcesForFleetGuardRail() {
+	if hubClient == nil {
+		return
+	}
 	crb := rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-cluster-role-binding",
@@ -674,6 +680,9 @@ func deleteResourcesForFleetGuardRail() {
 }
 
 func deleteTestResourceCRD() {
+	if hubClient == nil {
+		return
+	}
 	crd := apiextensionsv1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "testresources.test.kubernetes-fleet.io",
@@ -938,6 +947,9 @@ func cleanupConfigMapOnCluster(cluster *framework.Cluster) {
 
 // setMemberClusterToLeave sets a specific member cluster to leave the fleet.
 func setMemberClusterToLeave(memberCluster *framework.Cluster) {
+	if hubClient == nil {
+		return
+	}
 	mcObj := &clusterv1beta1.MemberCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: memberCluster.ClusterName,
@@ -1020,6 +1032,9 @@ func cleanupAnotherValidOwnerReference(nsName string) {
 
 // checkIfMemberClusterHasLeft verifies if the specified member cluster has left.
 func checkIfMemberClusterHasLeft(memberCluster *framework.Cluster) {
+	if hubClient == nil {
+		return
+	}
 	Eventually(func() error {
 		mcObj := &clusterv1beta1.MemberCluster{}
 		if err := hubClient.Get(ctx, types.NamespacedName{Name: memberCluster.ClusterName}, mcObj); !k8serrors.IsNotFound(err) {


### PR DESCRIPTION
### Description of your changes

This pull request improves the robustness of several test utility functions by adding early return checks for a `nil` `hubClient` in the `test/e2e/utils_test.go` file. This prevents potential `nil` pointer dereference errors during test execution when the `hubClient` is not initialized.

Key improvements for error prevention and test stability:

* Added early return checks for `hubClient == nil` in the following functions to prevent `nil` pointer dereferences: `cleanupInvalidClusters`, `deleteResourcesForFleetGuardRail`, `deleteTestResourceCRD`, `setMemberClusterToLeave`, and `checkIfMemberClusterHasLeft`. [[1]](diffhunk://#diff-303170c6f597058ddfc1425f2e9d0f171e9835dc73979dbc3b3b6eacff467a85R588-R590) [[2]](diffhunk://#diff-303170c6f597058ddfc1425f2e9d0f171e9835dc73979dbc3b3b6eacff467a85R660-R662) [[3]](diffhunk://#diff-303170c6f597058ddfc1425f2e9d0f171e9835dc73979dbc3b3b6eacff467a85R679-R681) [[4]](diffhunk://#diff-303170c6f597058ddfc1425f2e9d0f171e9835dc73979dbc3b3b6eacff467a85R882-R884) [[5]](diffhunk://#diff-303170c6f597058ddfc1425f2e9d0f171e9835dc73979dbc3b3b6eacff467a85R967-R969)

Fixes #403 

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

Again by running `make clean-e2e-tests && make e2e-tests` before and after the fix.


### Special notes for your reviewer

N/A
