### PR TITLE
fix: add webhook readiness check to hub-agent

### DIFF
--- a/cmd/hubagent/main.go
+++ b/cmd/hubagent/main.go
@@ -197,6 +197,14 @@ func main() {
 			exitWithErrorFunc()
 		}
 
+		// Add webhook server readiness check to ensure the pod is not marked ready until
+		// the webhook HTTPS listener is actually serving. This uses controller-runtime's
+		// built-in StartedChecker which verifies the server is listening on the port.
+		if err := mgr.AddReadyzCheck("webhook-server", mgr.GetWebhookServer().StartedChecker()); err != nil {
+			klog.ErrorS(err, "unable to set up webhook server readiness check")
+			exitWithErrorFunc()
+		}
+
 		// When using cert-manager, add a readiness check to ensure CA bundles are injected before marking ready.
 		// This prevents the pod from accepting traffic before cert-manager has populated the webhook CA bundles,
 		// which would cause webhook calls to fail.

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -268,6 +268,7 @@ func (w *Config) Start(ctx context.Context) error {
 		klog.ErrorS(err, "unable to setup webhook configurations in apiserver")
 		return err
 	}
+	klog.V(2).InfoS("webhook configurations created successfully")
 	return nil
 }
 

--- a/test/e2e/setup.sh
+++ b/test/e2e/setup.sh
@@ -149,7 +149,9 @@ helm install hub-agent ../../charts/hub-agent/ \
     --set logFileMaxSize=100000 \
     --set MaxConcurrentClusterPlacement=200 \
     --set resourceSnapshotCreationMinimumInterval=$RESOURCE_SNAPSHOT_CREATION_MINIMUM_INTERVAL \
-    --set resourceChangesCollectionDuration=$RESOURCE_CHANGES_COLLECTION_DURATION
+    --set resourceChangesCollectionDuration=$RESOURCE_CHANGES_COLLECTION_DURATION \
+    --wait \
+    --timeout=2m
 
 # Download CRDs from Fleet networking repo
 export ENDPOINT_SLICE_EXPORT_CRD_URL=https://raw.githubusercontent.com/Azure/fleet-networking/v0.2.7/config/crd/bases/networking.fleet.azure.com_endpointsliceexports.yaml


### PR DESCRIPTION
### Description of your changes

This pull request introduces a readiness check for the webhook component in the hub agent, ensuring that the pod is not marked as ready until the webhook configurations have been successfully created in the API server. This improves the reliability of the deployment by preventing premature readiness signaling. Additional unit tests are added to verify the new readiness logic, and the e2e setup script is updated to wait for the deployment to become ready.

**Webhook readiness improvements:**

* Modified `SetupWebhook` in `cmd/hubagent/main.go` to return the webhook `Config` object and register a readiness check using its `ReadinessChecker` method, ensuring the pod only becomes ready after webhook configuration is complete. [[1]](diffhunk://#diff-dc12684f7ab370528e17e7340358c0614e725ed43fac7b7af203a6d79667e5c2L161-R172) [[2]](diffhunk://#diff-dc12684f7ab370528e17e7340358c0614e725ed43fac7b7af203a6d79667e5c2R211-R228)
* Added an atomic `ready` flag to the `Config` struct in `pkg/webhook/webhook.go`, set to `true` after successful webhook configuration, and implemented the `ReadinessChecker` method to expose this as a health check. [[1]](diffhunk://#diff-df64e37f2222b761c62bd8bf32c0347aae0fe1f46ff6acf0e66c2b61bd30d761R167-R169) [[2]](diffhunk://#diff-df64e37f2222b761c62bd8bf32c0347aae0fe1f46ff6acf0e66c2b61bd30d761R203-R217)

**Testing enhancements:**

* Added unit tests in `pkg/webhook/webhook_test.go` to verify the readiness checker logic, including concurrent access scenarios.

**Deployment reliability:**

* Updated `test/e2e/setup.sh` to explicitly wait for the `hub-agent` deployment (including the webhook) to become ready before proceeding.

**Test code refactoring:**

* Changed test case maps in `pkg/webhook/webhook_test.go` to use pointers, improving test code consistency. [[1]](diffhunk://#diff-54553ccca2e329f7bf1fdf04d002ced7323d3fa477e7fc6e2a0a9d248cb10ab2L17-R18) [[2]](diffhunk://#diff-54553ccca2e329f7bf1fdf04d002ced7323d3fa477e7fc6e2a0a9d248cb10ab2L44-R45) [[3]](diffhunk://#diff-54553ccca2e329f7bf1fdf04d002ced7323d3fa477e7fc6e2a0a9d248cb10ab2L79-R80)

Fixes #404 

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

By running e2e tests with and w/o the changes.

### Special notes for your reviewer

N/A