### PR TITLE
fix: fix syncRoleBinding to avoid redundant roleBinding update

### DIFF
--- a/pkg/controllers/membercluster/v1beta1/membercluster_controller.go
+++ b/pkg/controllers/membercluster/v1beta1/membercluster_controller.go
@@ -426,6 +426,14 @@ func (r *Reconciler) syncRoleBinding(ctx context.Context, mc *clusterv1beta1.Mem
 			Name:     roleName,
 		},
 	}
+	// For User and Group kind, the APIGroup is defaulted to rbac.authorization.k8s.io if not set.
+	// Reference: https://pkg.go.dev/k8s.io/api/rbac/v1#Subject
+	for i := range expectedRoleBinding.Subjects {
+		subj := &expectedRoleBinding.Subjects[i]
+		if subj.APIGroup == "" && (subj.Kind == rbacv1.GroupKind || subj.Kind == rbacv1.UserKind) {
+			subj.APIGroup = rbacv1.GroupName
+		}
+	}
 
 	// Creates role binding if not found.
 	var currentRoleBinding rbacv1.RoleBinding


### PR DESCRIPTION
### Description of your changes
We have observed that membercluster controller keeps updating the roleBinding of the member clusters even though there's no change at all.
Example logs:
```
I0112 22:53:06.051963       1 v1beta1/membercluster_controller.go:84] "MemberCluster reconciliation starts" memberCluster="/member-1"
I0112 22:53:06.051999       1 v1beta1/membercluster_controller.go:285] "join" memberCluster="member-1"
I0112 22:53:06.052008       1 v1beta1/membercluster_controller.go:327] "Sync the namespace for the member cluster" memberCluster="member-1"
I0112 22:53:06.052024       1 v1beta1/membercluster_controller.go:370] "Sync the role for the member cluster" memberCluster="member-1"
I0112 22:53:06.052052       1 v1beta1/membercluster_controller.go:413] "Sync the roleBinding for the member cluster" memberCluster="member-1"
I0112 22:53:06.052073       1 v1beta1/membercluster_controller.go:451] "updating role binding" memberCluster="member-1" subject={"kind":"User","name":"8ff738a5-abcd-4864-a162-6c18f7c9cbd9"}
I0112 22:53:06.057785       1 v1beta1/membercluster_controller.go:456] "updated role binding" memberCluster="member-1" subject={"kind":"User","name":"8ff738a5-abcd-4864-a162-6c18f7c9cbd9"}
```

Our deepEqual comparison missed that in memberCluster CR, the `APIGroup` of the `.spec.identity` can be empty while the roleBinding returned from the apiserver always have the `APIGroup` set:
```yaml
kubectl get rolebinding -n fleet-member-member-1 fleet-rolebinding-member-1 -o yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  creationTimestamp: ...
  name: fleet-rolebinding-member-1
  namespace: fleet-member-member-1
  ownerReferences:
  - ...
  resourceVersion: "2127"
  uid: ...
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: fleet-role-member-1
subjects:
- apiGroup: rbac.authorization.k8s.io # this is set 
  kind: User
  name: ...
```
```yaml
kubectl get membercluster member-1 -o yaml
apiVersion: cluster.kubernetes-fleet.io/v1
kind: MemberCluster
metadata:
  annotations:
    ...
  creationTimestamp: ...
  finalizers: ...
  labels:
    ...
  name: member-1
  resourceVersion: "16636"
  uid: ...
spec:
  heartbeatPeriodSeconds: 15
  identity: # apiGroup is empty
    kind: User
    name: ...
```

This PR fixes the issue by adding the `APIGroup` if missing. An alternative is to empty the `apiGroup` from the returned roleBinding. Verified that after the fix, no more redundant roleBinding updates anymore.
<!--

Briefly describe what this pull request does. We love pull requests that have a clear purpose. If yours fix an issue,
please uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
