### PR TITLE
feat: add GVK whitelisting support for status back-reporting

### DIFF
--- a/pkg/controllers/statusbackreporter/controller_test.go
+++ b/pkg/controllers/statusbackreporter/controller_test.go
@@ -739,7 +739,7 @@ func TestValidatePlacementObjectForOriginalResourceStatusBackReporting(t *testin
 			}
 			fakeClient := fakeClientBuilder.Build()
 
-			r := NewReconciler(fakeClient, nil, nil)
+			r := NewReconciler(fakeClient, nil, nil, nil)
 
 			_, shouldSkip, err := r.validatePlacementObjectForOriginalResourceStatusBackReporting(ctx, tc.work)
 			if tc.wantErred {

--- a/pkg/utils/gvkwhitelist/gvkwhitelist.go
+++ b/pkg/utils/gvkwhitelist/gvkwhitelist.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2025 The KubeFleet Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gvkwhitelist
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+const (
+	wildCardCharacter = "*"
+)
+
+// Use a trie-like structure so that we can easily support GVK matching with wildcards.
+type tNode struct {
+	children map[string]*tNode
+}
+
+// WhitelistedGVKs represents a collection of GVKs that are whitelisted for additional processing,
+// e.g., status back-reporting.
+type WhitelistedGVKs struct {
+	root *tNode
+
+	// TO-DO (chenyu1): evaluate if the shortcuts can really help improve performance, as there
+	// might be additional overhead associated with the guarding mutex.
+	shortcuts map[schema.GroupVersionKind]bool
+
+	mu sync.Mutex
+}
+
+// NewWhitelistedGVKs returns a new WhitelistedGVKs instance.
+func NewWhitelistedGVKs() *WhitelistedGVKs {
+	return &WhitelistedGVKs{
+		root: &tNode{
+			children: map[string]*tNode{},
+		},
+		shortcuts: map[schema.GroupVersionKind]bool{},
+	}
+}
+
+// Register adds a new GVK into the whitelist.
+func (w *WhitelistedGVKs) Register(apiGroup, apiVersion, kind string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	newValH := []string{apiGroup, apiVersion, kind}
+
+	if w.root == nil {
+		w.root = &tNode{
+			children: map[string]*tNode{},
+		}
+	}
+
+	curN := w.root
+	for _, val := range newValH {
+		childN, exists := curN.children[val]
+		if !exists {
+			childN = &tNode{
+				children: map[string]*tNode{},
+			}
+			curN.children[val] = childN
+		}
+		curN = childN
+	}
+}
+
+// IsWhitelisted checks if a given GVK is whitelisted.
+func (w *WhitelistedGVKs) IsWhitelisted(gvk schema.GroupVersionKind) bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if matched, ok := w.shortcuts[gvk]; ok {
+		return matched
+	}
+
+	valToCheckH := []string{gvk.Group, gvk.Version, gvk.Kind}
+
+	var match func(node *tNode, depthLeft int) bool
+	match = func(node *tNode, depthLeft int) bool {
+		if depthLeft == 0 {
+			return true
+		}
+
+		valToCheck := valToCheckH[len(valToCheckH)-depthLeft]
+
+		// Check for exact match first.
+		if childN, exists := node.children[valToCheck]; exists {
+			if match(childN, depthLeft-1) {
+				return true
+			}
+		}
+		// Check for wildcard match.
+		if childN, exists := node.children[wildCardCharacter]; exists {
+			if match(childN, depthLeft-1) {
+				return true
+			}
+		}
+		// No match found.
+		return false
+	}
+
+	matched := match(w.root, len(valToCheckH))
+	w.shortcuts[gvk] = matched
+	return matched
+}
+
+// Parse parses a raw string representation of a GVK whitelist into a WhitelistedGVKs instance.
+func Parse(raw string) (*WhitelistedGVKs, error) {
+	if len(raw) == 0 {
+		// Empty input; return a nil pointer. This effectively means that status back-reporting to original
+		// resource is disabled for all GVKs.
+		return nil, nil
+	}
+	whitelist := NewWhitelistedGVKs()
+
+	// Break the raw string into segments, separated by commas (,).
+	gvkSegs := strings.Split(raw, ",")
+
+	for idx := range gvkSegs {
+		seg := gvkSegs[idx]
+
+		// Break each segment into separate parts, separated by slashes (/).
+		parts := strings.Split(seg, "/")
+		var apiGroup, apiVersion, kind string
+		switch {
+		case len(parts) < 2 || len(parts) > 3:
+			return nil, fmt.Errorf("failed to parse GVK whitelist raw string: segment %s is not valid (too few or too many parts)", seg)
+		case len(parts) == 2:
+			// If there are only two parts, the API resource is assumed to be of the core API group.
+			apiGroup = ""
+			apiVersion = parts[0]
+			kind = parts[1]
+		case len(parts) == 3:
+			apiGroup = parts[0]
+			apiVersion = parts[1]
+			kind = parts[2]
+		}
+
+		// Validate the input parts.
+		//
+		// Note that we do not verify if the inputs are consistent with the Kubernetes API conventions (e.g., versions should start with "v");
+		// only the hard requirements are checked.
+		if len(apiGroup) > 0 && apiGroup != "*" {
+			if errs := validation.IsDNS1123Subdomain(apiGroup); len(errs) > 0 {
+				return nil, fmt.Errorf("failed to parse GVK whitelist raw string: segment %s has an invalid API group part: %v", seg, errs)
+			}
+		}
+		if apiVersion != "*" {
+			if errs := validation.IsDNS1123Label(apiVersion); len(errs) > 0 {
+				return nil, fmt.Errorf("failed to parse GVK whitelist raw string: segment %s has an invalid API version part: %v", seg, errs)
+			}
+		}
+		if kind != "*" {
+			if errs := validation.IsDNS1035Label(strings.ToLower(kind)); len(errs) > 0 {
+				return nil, fmt.Errorf("failed to parse GVK whitelist raw string: segment %s has an invalid Kind part: %v", seg, errs)
+			}
+		}
+
+		// Register the GVK into the whitelist.
+		whitelist.Register(apiGroup, apiVersion, kind)
+	}
+	return whitelist, nil
+}

--- a/pkg/utils/gvkwhitelist/gvkwhitelist_test.go
+++ b/pkg/utils/gvkwhitelist/gvkwhitelist_test.go
@@ -1,0 +1,460 @@
+/*
+Copyright 2025 The KubeFleet Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gvkwhitelist
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var (
+	sortByPath = func(a, b []string) bool {
+		for i := 0; i < 3; i++ {
+			switch {
+			case a[i] < b[i]:
+				return true
+			case a[i] > b[i]:
+				return false
+			default:
+				// continue to the next path part.
+				i++
+			}
+		}
+		return false // This should never happen.
+	}
+)
+
+func walkWhitelistedGVKTrieTree(node *tNode, pathSoFar []string, res *[][]string) {
+	if len(node.children) == 0 {
+		*res = append(*res, pathSoFar)
+		return
+	}
+
+	for k, v := range node.children {
+		updatedPathSoFar := make([]string, 0, len(pathSoFar)+1)
+		updatedPathSoFar = append(updatedPathSoFar, pathSoFar...)
+		updatedPathSoFar = append(updatedPathSoFar, k)
+		walkWhitelistedGVKTrieTree(v, updatedPathSoFar, res)
+	}
+}
+
+// TestRegister tests the Register method of the WhitelistedGVKs.
+func TestRegister(t *testing.T) {
+	// Register multiple GVKs, with and without wildcards to a whitelist.
+	whitelist := NewWhitelistedGVKs()
+
+	whitelist.Register("apps", "v1", "Deployment")
+	whitelist.Register("batch", "*", "Job")
+	whitelist.Register("", "v1", "ConfigMap")
+	whitelist.Register("example.com", "*", "*")
+	whitelist.Register("*", "*", "*")
+
+	// Verify that the tree has been constructed as expected.
+	//
+	// For simplicity reasons, verify only the paths to each leaf node.
+	paths := make([][]string, 0, 5)
+	walkWhitelistedGVKTrieTree(whitelist.root, []string{}, &paths)
+
+	expectedPaths := [][]string{
+		{"apps", "v1", "Deployment"},
+		{"batch", "*", "Job"},
+		{"", "v1", "ConfigMap"},
+		{"example.com", "*", "*"},
+		{"*", "*", "*"},
+	}
+	// Golang has fair lock implementation; however, there is no guarantee on when a specific goroutine
+	// will wake up first to acquire the lock. As a result, we must sort the path collection before doing
+	// the comparison.
+	if diff := cmp.Diff(paths, expectedPaths, cmpopts.SortSlices(sortByPath)); diff != "" {
+		t.Errorf("unexpected trie tree structure (-got, +want):\n%s", diff)
+	}
+}
+
+// TestIsWhitelisted tests the IsWhitelisted method of the WhitelistedGVKs.
+func TestIsWhitelisted(t *testing.T) {
+	// Build the whitelist.
+	whitelist := NewWhitelistedGVKs()
+
+	whitelist.Register("apps", "v1", "Deployment")
+	whitelist.Register("*", "v1", "CronJob")
+	whitelist.Register("batch", "*", "Job")
+	whitelist.Register("networking.k8s.io", "v1", "*")
+	whitelist.Register("", "v1", "ConfigMap")
+	whitelist.Register("example.com", "*", "*")
+	whitelist.Register("*", "v2alpha1", "*")
+	whitelist.Register("*", "*", "FooBar")
+
+	testCases := []struct {
+		name string
+		gvk  schema.GroupVersionKind
+		want bool
+	}{
+		{
+			name: "apps/v1/Deployment (whitelisted)",
+			gvk: schema.GroupVersionKind{
+				Group:   "apps",
+				Version: "v1",
+				Kind:    "Deployment",
+			},
+			want: true,
+		},
+		{
+			name: "batch/v1/CronJob (whitelisted via wildcard group)",
+			gvk: schema.GroupVersionKind{
+				Group:   "batch",
+				Version: "v1",
+				Kind:    "CronJob",
+			},
+			want: true,
+		},
+		{
+			name: "batch/v1/Job (whitelisted via wildcard version)",
+			gvk: schema.GroupVersionKind{
+				Group:   "batch",
+				Version: "v1",
+				Kind:    "Job",
+			},
+			want: true,
+		},
+		{
+			name: "networking.k8s.io/v1/Ingress (whitelisted via wildcard kind)",
+			gvk: schema.GroupVersionKind{
+				Group:   "networking.k8s.io",
+				Version: "v1",
+				Kind:    "Ingress",
+			},
+			want: true,
+		},
+		{
+			name: "v1/ConfigMap (whitelisted)",
+			gvk: schema.GroupVersionKind{
+				Group:   "",
+				Version: "v1",
+				Kind:    "ConfigMap",
+			},
+			want: true,
+		},
+		{
+			name: "example.com/vAny/AnyKind (whitelisted via wildcard version and kind)",
+			gvk: schema.GroupVersionKind{
+				Group:   "example.com",
+				Version: "vAny",
+				Kind:    "AnyKind",
+			},
+			want: true,
+		},
+		{
+			name: "anygroup/v2alpha1/AnyKind (whitelisted via wildcard group and version)",
+			gvk: schema.GroupVersionKind{
+				Group:   "anygroup",
+				Version: "v2alpha1",
+				Kind:    "AnyKind",
+			},
+			want: true,
+		},
+		{
+			name: "anygroup/vAny/FooBar (whitelisted via wildcard group and any version)",
+			gvk: schema.GroupVersionKind{
+				Group:   "anygroup",
+				Version: "vAny",
+				Kind:    "FooBar",
+			},
+			want: true,
+		},
+		{
+			name: "v1/Pod (not whitelisted)",
+			gvk: schema.GroupVersionKind{
+				Group:   "",
+				Version: "v1",
+				Kind:    "Pod",
+			},
+		},
+		{
+			name: "storage.k8s.io/v1/StorageClass (not whitelisted)",
+			gvk: schema.GroupVersionKind{
+				Group:   "storage.k8s.io",
+				Version: "v1",
+				Kind:    "StorageClass",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := whitelist.IsWhitelisted(tc.gvk)
+			if got != tc.want {
+				t.Errorf("IsWhitelisted(%v) = %v; want %v", tc.gvk, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIsWhitelisted_MatchAll tests the IsWhitelisted method of the WhitelistedGVKs
+// when the whitelist has a rule that matches all GVKs.
+func TestIsWhitelisted_MatchAll(t *testing.T) {
+	// Build the whitelist.
+	whitelist := NewWhitelistedGVKs()
+
+	whitelist.Register("*", "*", "*")
+
+	testCases := []struct {
+		name string
+		gvk  schema.GroupVersionKind
+		want bool
+	}{
+		{
+			name: "apps/v1/Deployment (whitelisted)",
+			gvk: schema.GroupVersionKind{
+				Group:   "apps",
+				Version: "v1",
+				Kind:    "Deployment",
+			},
+			want: true,
+		},
+		{
+			name: "batch/v1/CronJob (whitelisted via wildcard group)",
+			gvk: schema.GroupVersionKind{
+				Group:   "batch",
+				Version: "v1",
+				Kind:    "CronJob",
+			},
+			want: true,
+		},
+		{
+			name: "batch/v1/Job (whitelisted via wildcard version)",
+			gvk: schema.GroupVersionKind{
+				Group:   "batch",
+				Version: "v1",
+				Kind:    "Job",
+			},
+			want: true,
+		},
+		{
+			name: "networking.k8s.io/v1/Ingress (whitelisted via wildcard kind)",
+			gvk: schema.GroupVersionKind{
+				Group:   "networking.k8s.io",
+				Version: "v1",
+				Kind:    "Ingress",
+			},
+			want: true,
+		},
+		{
+			name: "v1/ConfigMap (whitelisted)",
+			gvk: schema.GroupVersionKind{
+				Group:   "",
+				Version: "v1",
+				Kind:    "ConfigMap",
+			},
+			want: true,
+		},
+		{
+			name: "example.com/vAny/AnyKind (whitelisted via wildcard version and kind)",
+			gvk: schema.GroupVersionKind{
+				Group:   "example.com",
+				Version: "vAny",
+				Kind:    "AnyKind",
+			},
+			want: true,
+		},
+		{
+			name: "anygroup/v2alpha1/AnyKind (whitelisted via wildcard group and version)",
+			gvk: schema.GroupVersionKind{
+				Group:   "anygroup",
+				Version: "v2alpha1",
+				Kind:    "AnyKind",
+			},
+			want: true,
+		},
+		{
+			name: "anygroup/vAny/FooBar (whitelisted via wildcard group and any version)",
+			gvk: schema.GroupVersionKind{
+				Group:   "anygroup",
+				Version: "vAny",
+				Kind:    "FooBar",
+			},
+			want: true,
+		},
+		{
+			name: "v1/Pod (not whitelisted)",
+			gvk: schema.GroupVersionKind{
+				Group:   "",
+				Version: "v1",
+				Kind:    "Pod",
+			},
+			want: true,
+		},
+		{
+			name: "storage.k8s.io/v1/StorageClass (not whitelisted)",
+			gvk: schema.GroupVersionKind{
+				Group:   "storage.k8s.io",
+				Version: "v1",
+				Kind:    "StorageClass",
+			},
+			want: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := whitelist.IsWhitelisted(tc.gvk)
+			if got != tc.want {
+				t.Errorf("IsWhitelisted(%v) = %v; want %v", tc.gvk, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestParse tests the Parse function.
+func TestParse(t *testing.T) {
+	testCases := []struct {
+		name               string
+		gvkWhitelistRawStr string
+		wantPaths          [][]string
+		wantErred          bool
+		wantErrPrefix      string
+	}{
+		{
+			name:               "single entry, core API group",
+			gvkWhitelistRawStr: "v1/ConfigMap",
+			wantPaths: [][]string{
+				{"", "v1", "ConfigMap"},
+			},
+		},
+		{
+			name:               "single entry, non-core API group",
+			gvkWhitelistRawStr: "apps/v1/Deployment",
+			wantPaths: [][]string{
+				{"apps", "v1", "Deployment"},
+			},
+		},
+		{
+			name:               "wildcards in API group",
+			gvkWhitelistRawStr: "*/v1/CronJob",
+			wantPaths: [][]string{
+				{"*", "v1", "CronJob"},
+			},
+		},
+		{
+			name:               "wildcards in API version",
+			gvkWhitelistRawStr: "batch/*/Job",
+			wantPaths: [][]string{
+				{"batch", "*", "Job"},
+			},
+		},
+		{
+			name:               "wildcards in Kind",
+			gvkWhitelistRawStr: "networking.k8s.io/v1/*",
+			wantPaths: [][]string{
+				{"networking.k8s.io", "v1", "*"},
+			},
+		},
+		{
+			name:               "wildcards in multiple parts",
+			gvkWhitelistRawStr: "*/*/*",
+			wantPaths: [][]string{
+				{"*", "*", "*"},
+			},
+		},
+		{
+			name:               "multiple entries with and without wildcards",
+			gvkWhitelistRawStr: "apps/v1/Deployment,v1/ConfigMap,*/v1/CronJob,batch/*/Job,networking.k8s.io/v1/*,example.com/*/*",
+			wantPaths: [][]string{
+				{"apps", "v1", "Deployment"},
+				{"", "v1", "ConfigMap"},
+				{"*", "v1", "CronJob"},
+				{"batch", "*", "Job"},
+				{"networking.k8s.io", "v1", "*"},
+				{"example.com", "*", "*"},
+			},
+		},
+		{
+			name:               "invalid API group",
+			gvkWhitelistRawStr: "InvalidGroup!/v1/Deployment",
+			wantErred:          true,
+			wantErrPrefix:      "failed to parse GVK whitelist raw string: segment InvalidGroup!/v1/Deployment has an invalid API group part",
+		},
+		{
+			name:               "invalid API version",
+			gvkWhitelistRawStr: "apps/InvalidVersion!/Deployment",
+			wantErred:          true,
+			wantErrPrefix:      "failed to parse GVK whitelist raw string: segment apps/InvalidVersion!/Deployment has an invalid API version part",
+		},
+		{
+			name:               "invalid Kind",
+			gvkWhitelistRawStr: "apps/v1/InvalidKind!",
+			wantErred:          true,
+			wantErrPrefix:      "failed to parse GVK whitelist raw string: segment apps/v1/InvalidKind! has an invalid Kind part",
+		},
+		{
+			name:               "too few parts",
+			gvkWhitelistRawStr: "v1",
+			wantErred:          true,
+			wantErrPrefix:      "failed to parse GVK whitelist raw string: segment v1 is not valid (too few or too many parts)",
+		},
+		{
+			name:               "too many parts",
+			gvkWhitelistRawStr: "apps/v1/Deployment/ExtraPart",
+			wantErred:          true,
+			wantErrPrefix:      "failed to parse GVK whitelist raw string: segment apps/v1/Deployment/ExtraPart is not valid (too few or too many parts)",
+		},
+		{
+			name:               "empty string",
+			gvkWhitelistRawStr: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			whitelist, err := Parse(tc.gvkWhitelistRawStr)
+			if tc.wantErred {
+				if err == nil {
+					t.Fatalf("Parse() = nil, want erred")
+				}
+
+				if !strings.HasPrefix(err.Error(), tc.wantErrPrefix) {
+					t.Fatalf("Parse() error = %v, want to have error msg prefix %q", err, tc.wantErrPrefix)
+				}
+				return
+			}
+			if len(tc.gvkWhitelistRawStr) == 0 {
+				if whitelist != nil {
+					t.Fatalf("Parse() = %v, want nil whitelist", whitelist)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Parse() = %v, want no error", err)
+			}
+
+			// Verify the trie tree structure.
+			paths := make([][]string, 0, 100)
+			walkWhitelistedGVKTrieTree(whitelist.root, []string{}, &paths)
+
+			// Golang has fair lock implementation; however, there is no guarantee on when a specific goroutine
+			// will wake up first to acquire the lock. As a result, we must sort the path collection before doing
+			// the comparison.
+			if diff := cmp.Diff(paths, tc.wantPaths, cmpopts.SortSlices(sortByPath)); diff != "" {
+				t.Errorf("unexpected trie tree structure (-got, +want):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description of your changes

This PR adds GVK whitelisting support for status back-reporting so that the hub agent will only back-report status information to the original resource for a specific set of GVKs. This helps most in cases where the Fleet hub cluster runs controllers that would reconcile such objects and add their own status, which would lead to contention with the Fleet hub agent.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- [x] Unit tests
- [x] Integration tests


### Special notes for your reviewer

This PR is a prerequisite before we enable the status back-reporting feature in the system.
