### PR TITLE
fix: address an issue in AppliedWork object processing when the agent leaves then re-joins

### DIFF
--- a/pkg/controllers/workapplier/controller_test.go
+++ b/pkg/controllers/workapplier/controller_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package workapplier
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -32,8 +33,10 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	fleetv1beta1 "github.com/kubefleet-dev/kubefleet/apis/placement/v1beta1"
 )
@@ -208,7 +211,8 @@ var (
 )
 
 var (
-	ignoreFieldTypeMetaInNamespace = cmpopts.IgnoreFields(corev1.Namespace{}, "TypeMeta")
+	ignoreFieldTypeMetaInNamespace       = cmpopts.IgnoreFields(corev1.Namespace{}, "TypeMeta")
+	ignoreFieldObjectMetaresourceVersion = cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion")
 
 	lessFuncAppliedResourceMeta = func(i, j fleetv1beta1.AppliedResourceMeta) bool {
 		iStr := fmt.Sprintf("%s/%s/%s/%s/%s", i.Group, i.Version, i.Kind, i.Namespace, i.Name)
@@ -260,6 +264,14 @@ func TestMain(m *testing.M) {
 	initializeVariables()
 
 	os.Exit(m.Run())
+}
+
+func fakeClientScheme(t *testing.T) *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	if err := fleetv1beta1.AddToScheme(scheme); err != nil {
+		t.Fatalf("Failed to add placement v1beta1 scheme: %v", err)
+	}
+	return scheme
 }
 
 func initializeVariables() {
@@ -330,5 +342,199 @@ func TestPrepareManifestProcessingBundles(t *testing.T) {
 	}
 	if diff := cmp.Diff(bundles, wantBundles, cmp.AllowUnexported(manifestProcessingBundle{})); diff != "" {
 		t.Errorf("prepareManifestProcessingBundles() mismatches (-got +want):\n%s", diff)
+	}
+}
+
+// TestEnsureAppliedWork tests the ensureAppliedWork method.
+func TestEnsureAppliedWork(t *testing.T) {
+	ctx := context.Background()
+
+	fakeUID := types.UID("foo")
+	testCases := []struct {
+		name            string
+		work            *fleetv1beta1.Work
+		appliedWork     *fleetv1beta1.AppliedWork
+		wantWork        *fleetv1beta1.Work
+		wantAppliedWork *fleetv1beta1.AppliedWork
+	}{
+		{
+			name: "with work cleanup finalizer present, but no corresponding AppliedWork exists",
+			work: &fleetv1beta1.Work{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      workName,
+					Namespace: memberReservedNSName1,
+					Finalizers: []string{
+						fleetv1beta1.WorkFinalizer,
+					},
+				},
+			},
+			wantWork: &fleetv1beta1.Work{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      workName,
+					Namespace: memberReservedNSName1,
+					Finalizers: []string{
+						fleetv1beta1.WorkFinalizer,
+					},
+				},
+			},
+			wantAppliedWork: &fleetv1beta1.AppliedWork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: workName,
+				},
+				Spec: fleetv1beta1.AppliedWorkSpec{
+					WorkName:      workName,
+					WorkNamespace: memberReservedNSName1,
+				},
+			},
+		},
+		{
+			name: "with work cleanup finalizer present, and corresponding AppliedWork exists",
+			work: &fleetv1beta1.Work{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      workName,
+					Namespace: memberReservedNSName1,
+					Finalizers: []string{
+						fleetv1beta1.WorkFinalizer,
+					},
+				},
+			},
+			appliedWork: &fleetv1beta1.AppliedWork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: workName,
+					// Add the UID field to track if the method returns the existing object.
+					UID: fakeUID,
+				},
+				Spec: fleetv1beta1.AppliedWorkSpec{
+					WorkName:      workName,
+					WorkNamespace: memberReservedNSName1,
+				},
+			},
+			wantWork: &fleetv1beta1.Work{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      workName,
+					Namespace: memberReservedNSName1,
+					Finalizers: []string{
+						fleetv1beta1.WorkFinalizer,
+					},
+				},
+			},
+			wantAppliedWork: &fleetv1beta1.AppliedWork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: workName,
+					UID:  fakeUID,
+				},
+				Spec: fleetv1beta1.AppliedWorkSpec{
+					WorkName:      workName,
+					WorkNamespace: memberReservedNSName1,
+				},
+			},
+		},
+		{
+			name: "without work cleanup finalizer, but corresponding AppliedWork exists",
+			work: &fleetv1beta1.Work{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      workName,
+					Namespace: memberReservedNSName1,
+				},
+			},
+			appliedWork: &fleetv1beta1.AppliedWork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: workName,
+					// Add the UID field to track if the method returns the existing object.
+					UID: fakeUID,
+				},
+				Spec: fleetv1beta1.AppliedWorkSpec{
+					WorkName:      workName,
+					WorkNamespace: memberReservedNSName1,
+				},
+			},
+			wantWork: &fleetv1beta1.Work{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      workName,
+					Namespace: memberReservedNSName1,
+					Finalizers: []string{
+						fleetv1beta1.WorkFinalizer,
+					},
+				},
+			},
+			wantAppliedWork: &fleetv1beta1.AppliedWork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: workName,
+					UID:  fakeUID,
+				},
+				Spec: fleetv1beta1.AppliedWorkSpec{
+					WorkName:      workName,
+					WorkNamespace: memberReservedNSName1,
+				},
+			},
+		},
+		{
+			name: "without work cleanup finalizer, and no corresponding AppliedWork exists",
+			work: &fleetv1beta1.Work{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      workName,
+					Namespace: memberReservedNSName1,
+				},
+			},
+			wantWork: &fleetv1beta1.Work{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      workName,
+					Namespace: memberReservedNSName1,
+					Finalizers: []string{
+						fleetv1beta1.WorkFinalizer,
+					},
+				},
+			},
+			wantAppliedWork: &fleetv1beta1.AppliedWork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: workName,
+				},
+				Spec: fleetv1beta1.AppliedWorkSpec{
+					WorkName:      workName,
+					WorkNamespace: memberReservedNSName1,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			hubClientScheme := fakeClientScheme(t)
+			fakeHubClient := fake.NewClientBuilder().
+				WithScheme(hubClientScheme).
+				WithObjects(tc.work).
+				Build()
+
+			memberClientScheme := fakeClientScheme(t)
+			fakeMemberClientBuilder := fake.NewClientBuilder().WithScheme(memberClientScheme)
+			if tc.appliedWork != nil {
+				fakeMemberClientBuilder = fakeMemberClientBuilder.WithObjects(tc.appliedWork)
+			}
+			fakeMemberClient := fakeMemberClientBuilder.Build()
+
+			r := &Reconciler{
+				hubClient:   fakeHubClient,
+				spokeClient: fakeMemberClient,
+			}
+
+			gotAppliedWork, err := r.ensureAppliedWork(ctx, tc.work)
+			if err != nil {
+				t.Fatalf("ensureAppliedWork() = %v, want no error", err)
+			}
+
+			// Verify the Work object.
+			gotWork := &fleetv1beta1.Work{}
+			if err := fakeHubClient.Get(ctx, types.NamespacedName{Name: tc.work.Name, Namespace: tc.work.Namespace}, gotWork); err != nil {
+				t.Fatalf("failed to get Work object from fake hub client: %v", err)
+			}
+			if diff := cmp.Diff(gotWork, tc.wantWork, ignoreFieldObjectMetaresourceVersion); diff != "" {
+				t.Errorf("Work objects diff (-got +want):\n%s", diff)
+			}
+
+			// Verify the AppliedWork object.
+			if diff := cmp.Diff(gotAppliedWork, tc.wantAppliedWork, ignoreFieldObjectMetaresourceVersion); diff != "" {
+				t.Errorf("AppliedWork objects diff (-got +want):\n%s", diff)
+			}
+		})
 	}
 }


### PR DESCRIPTION
### Description of your changes

This PR fixes an issue that, when a member agent leaves then re-joins, the work applier might see an AppliedWork without UID due to `AlreadyExists` errors, which might trigger processing failures (cannot takeover objects).

The cause of the issue was that, the work applier has a `Leave` method, which is called when the member agent leaves a fleet, and this method will strip off all Work objects off their finalizers without doing any cleanup, so that resources will be left alone on the member cluster; if the member agent later decides to re-join, the work applier will see some Work objects with no finalizers but existing corresponding AppliedWork objects (and the applied resources) -> now, in the `ensureAppliedWork` method of the work applier, the system will attempt to first re-create the AppliedWork then add the finalizer back, and the re-creation will always fail (due to AlreadyExists errors); in this case the `ensureAppliedWork` method returns an `AppliedWork` with no system-populated data (specifically no UID), and this will lead the work applier to complain about ownership mismatches in resources applied before (cannot takeover errors).

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- [x] Unit tests
- [x] Integration tests

### Special notes for your reviewer

Note: we do have an integration test that covers the case; however, it never flares before -> note that the `ensureAppliedWork` code was already there before the new work applier and there were no changes on that integration tests either. We only find out about this issue after #420 was prepared, which enabled Ginkgo-based parallelized running of all integration tests in the work applier.
