### PR TITLE
feat: (CRP-RP namespace affinity) label MemberCluster with namespaces placed by CRP - hub driven approach

### DIFF
--- a/pkg/controllers/membercluster/v1beta1/crp_status_handler.go
+++ b/pkg/controllers/membercluster/v1beta1/crp_status_handler.go
@@ -1,0 +1,266 @@
+/*
+Copyright 2026 The KubeFleet Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	clusterv1beta1 "github.com/kubefleet-dev/kubefleet/apis/cluster/v1beta1"
+	placementv1beta1 "github.com/kubefleet-dev/kubefleet/apis/placement/v1beta1"
+)
+
+// reconcileNamespaceAffinityLabels reconciles namespace affinity labels for a specific MemberCluster
+// by examining all CRPs and their placement status
+func (r *Reconciler) reconcileNamespaceAffinityLabels(ctx context.Context, mc *clusterv1beta1.MemberCluster) error {
+	// Get all ClusterResourcePlacements
+	var crpList placementv1beta1.ClusterResourcePlacementList
+	if err := r.Client.List(ctx, &crpList); err != nil {
+		return fmt.Errorf("failed to list ClusterResourcePlacements: %w", err)
+	}
+
+	klog.V(4).InfoS("Reconciling namespace affinity labels", "cluster", mc.Name, "totalCRPs", len(crpList.Items))
+
+	// Track which CRPs have successfully placed namespaces on this cluster
+	successfulCRPs := make(map[string][]string) // CRP name -> list of namespaces
+
+	for _, crp := range crpList.Items {
+		// Check if this CRP has successfully placed namespaces on our cluster
+		namespaces := r.extractNamespacesForCluster(ctx, &crp, mc.Name)
+		if len(namespaces) > 0 {
+			successfulCRPs[crp.Name] = namespaces
+		}
+	}
+
+	// Update labels based on successful placements
+	if err := r.updateMemberClusterLabelsFromPlacements(ctx, mc, successfulCRPs); err != nil {
+		return fmt.Errorf("failed to update namespace affinity labels: %w", err)
+	}
+
+	return nil
+}
+
+// extractNamespacesForCluster extracts namespace names that were successfully placed on a specific cluster
+func (r *Reconciler) extractNamespacesForCluster(ctx context.Context, crp *placementv1beta1.ClusterResourcePlacement, clusterName string) []string {
+	// Find the placement status for this cluster
+	var targetStatus *placementv1beta1.PerClusterPlacementStatus
+	for i, status := range crp.Status.PerClusterPlacementStatuses {
+		if status.ClusterName == clusterName {
+			targetStatus = &crp.Status.PerClusterPlacementStatuses[i]
+			break
+		}
+	}
+
+	if targetStatus == nil {
+		return nil // Not scheduled on this cluster
+	}
+
+	// Check if placement was successful
+	if !r.hasSuccessfulNamespacePlacement(*targetStatus) {
+		return nil
+	}
+
+	// Extract namespaces from the CRP's resource selectors
+	return r.extractSuccessfulNamespacesFromStatus(ctx, crp.Name, *targetStatus)
+}
+
+// updateMemberClusterLabelsFromPlacements updates namespace affinity labels based on successful placements
+func (r *Reconciler) updateMemberClusterLabelsFromPlacements(
+	ctx context.Context,
+	mc *clusterv1beta1.MemberCluster,
+	successfulCRPs map[string][]string,
+) error {
+	updated := false
+
+	if mc.Labels == nil {
+		mc.Labels = make(map[string]string)
+	}
+
+	// Get current namespace affinity labels to track what needs cleanup
+	currentAffinityLabels := make(map[string]string)
+	for k, v := range mc.Labels {
+		if IsNamespaceAffinityLabel(k) {
+			currentAffinityLabels[k] = v
+		}
+	}
+
+	// Add new labels for successful placements
+	expectedLabels := make(map[string]string)
+	totalExpectedLabels := 0
+
+	for crpName, namespaces := range successfulCRPs {
+		for _, namespace := range namespaces {
+			labelKey := BuildNamespaceAffinityLabelKey(namespace)
+			expectedLabels[labelKey] = crpName
+			totalExpectedLabels++
+		}
+	}
+
+	// Check if we'd exceed the limit
+	if totalExpectedLabels > MaxNamespaceLabelsPerCluster {
+		klog.InfoS("Total expected namespace affinity labels exceed limit, will prioritize by CRP name",
+			"cluster", mc.Name, "expected", totalExpectedLabels, "limit", MaxNamespaceLabelsPerCluster)
+
+		// Prioritize labels (simple approach: alphabetical by CRP name)
+		expectedLabels = r.prioritizeNamespaceLabels(successfulCRPs, MaxNamespaceLabelsPerCluster)
+	}
+
+	// Add/update labels
+	for labelKey, crpName := range expectedLabels {
+		if currentValue, exists := mc.Labels[labelKey]; !exists || currentValue != crpName {
+			mc.Labels[labelKey] = crpName
+			updated = true
+			klog.V(4).InfoS("Updated namespace affinity label",
+				"cluster", mc.Name, "labelKey", labelKey, "crpName", crpName)
+		}
+		// Remove from tracking as it's expected
+		delete(currentAffinityLabels, labelKey)
+	}
+
+	// Remove labels that are no longer needed
+	for labelKey := range currentAffinityLabels {
+		delete(mc.Labels, labelKey)
+		updated = true
+		klog.V(4).InfoS("Removed obsolete namespace affinity label",
+			"cluster", mc.Name, "labelKey", labelKey)
+	}
+
+	if !updated {
+		return nil
+	}
+
+	// Update the MemberCluster
+	if err := r.Client.Update(ctx, mc); err != nil {
+		return fmt.Errorf("failed to update MemberCluster %s with namespace affinity labels: %w", mc.Name, err)
+	}
+
+	klog.V(2).InfoS("Successfully reconciled namespace affinity labels",
+		"cluster", mc.Name, "totalLabels", len(expectedLabels))
+
+	return nil
+}
+
+// prioritizeNamespaceLabels prioritizes namespace labels when the total exceeds the limit
+func (r *Reconciler) prioritizeNamespaceLabels(successfulCRPs map[string][]string, maxLabels int) map[string]string {
+	prioritized := make(map[string]string)
+	count := 0
+
+	// Simple prioritization: process CRPs in alphabetical order
+	crpNames := make([]string, 0, len(successfulCRPs))
+	for crpName := range successfulCRPs {
+		crpNames = append(crpNames, crpName)
+	}
+
+	// Sort to ensure deterministic behavior
+	for i := 0; i < len(crpNames)-1; i++ {
+		for j := i + 1; j < len(crpNames); j++ {
+			if crpNames[i] > crpNames[j] {
+				crpNames[i], crpNames[j] = crpNames[j], crpNames[i]
+			}
+		}
+	}
+
+	for _, crpName := range crpNames {
+		for _, namespace := range successfulCRPs[crpName] {
+			if count >= maxLabels {
+				break
+			}
+			labelKey := BuildNamespaceAffinityLabelKey(namespace)
+			prioritized[labelKey] = crpName
+			count++
+		}
+		if count >= maxLabels {
+			break
+		}
+	}
+
+	return prioritized
+}
+
+// hasSuccessfulNamespacePlacement checks if a cluster has successfully applied namespace resources
+// by examining the conditions in the PerClusterPlacementStatus
+func (r *Reconciler) hasSuccessfulNamespacePlacement(status placementv1beta1.PerClusterPlacementStatus) bool {
+	// Check for Applied condition = True, which indicates resources were successfully applied
+	for _, condition := range status.Conditions {
+		if condition.Type == string(placementv1beta1.PerClusterAppliedConditionType) &&
+			condition.Status == metav1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+// extractSuccessfulNamespacesFromStatus determines which namespaces were successfully placed
+// on a cluster by examining the CRP's selected resources and applied resources
+func (r *Reconciler) extractSuccessfulNamespacesFromStatus(
+	ctx context.Context,
+	crpName string,
+	status placementv1beta1.PerClusterPlacementStatus,
+) []string {
+	// Get the CRP to examine its selected resources (not resource selectors)
+	var crp placementv1beta1.ClusterResourcePlacement
+	if err := r.Client.Get(ctx, client.ObjectKey{Name: crpName}, &crp); err != nil {
+		klog.ErrorS(err, "Failed to get CRP for namespace extraction",
+			"crp", crpName, "cluster", status.ClusterName)
+		return nil
+	}
+
+	// Extract namespace names from the CRP's SelectedResources (resources that were actually found and selected)
+	// This ensures we only consider namespaces that actually exist and were selected for placement
+	var namespaces []string
+	for _, selectedResource := range crp.Status.SelectedResources {
+		if selectedResource.Group == "" && selectedResource.Version == "v1" && selectedResource.Kind == "Namespace" {
+			namespaces = append(namespaces, selectedResource.Name)
+		}
+	}
+
+	// Filter out failed placements - only return namespaces that were successfully applied
+	if len(status.FailedPlacements) > 0 {
+		failedNamespaces := make(map[string]bool)
+		for _, failed := range status.FailedPlacements {
+			if failed.Kind == "Namespace" && failed.Group == "" && failed.Version == "v1" {
+				failedNamespaces[failed.Name] = true
+			}
+		}
+
+		// Remove failed namespaces from the successful list
+		var successfulNamespaces []string
+		for _, ns := range namespaces {
+			if !failedNamespaces[ns] {
+				successfulNamespaces = append(successfulNamespaces, ns)
+			}
+		}
+		namespaces = successfulNamespaces
+	}
+
+	return namespaces
+}
+
+// countNamespaceAffinityLabels counts the current number of namespace affinity labels on a MemberCluster
+func (r *Reconciler) countNamespaceAffinityLabels(labels map[string]string) int {
+	count := 0
+	for labelKey := range labels {
+		if IsNamespaceAffinityLabel(labelKey) {
+			count++
+		}
+	}
+	return count
+}

--- a/pkg/controllers/membercluster/v1beta1/crp_status_handler_test.go
+++ b/pkg/controllers/membercluster/v1beta1/crp_status_handler_test.go
@@ -1,0 +1,574 @@
+/*
+Copyright 2026 The KubeFleet Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	clusterv1beta1 "github.com/kubefleet-dev/kubefleet/apis/cluster/v1beta1"
+	placementv1beta1 "github.com/kubefleet-dev/kubefleet/apis/placement/v1beta1"
+)
+
+func TestHasSuccessfulNamespacePlacement(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   placementv1beta1.PerClusterPlacementStatus
+		expected bool
+	}{
+		{
+			name: "has Applied condition True",
+			status: placementv1beta1.PerClusterPlacementStatus{
+				ClusterName: "cluster-1",
+				Conditions: []metav1.Condition{
+					{
+						Type:   string(placementv1beta1.PerClusterAppliedConditionType),
+						Status: metav1.ConditionTrue,
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "has Applied condition False",
+			status: placementv1beta1.PerClusterPlacementStatus{
+				ClusterName: "cluster-1",
+				Conditions: []metav1.Condition{
+					{
+						Type:   string(placementv1beta1.PerClusterAppliedConditionType),
+						Status: metav1.ConditionFalse,
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "has Applied condition Unknown",
+			status: placementv1beta1.PerClusterPlacementStatus{
+				ClusterName: "cluster-1",
+				Conditions: []metav1.Condition{
+					{
+						Type:   string(placementv1beta1.PerClusterAppliedConditionType),
+						Status: metav1.ConditionUnknown,
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "no Applied condition",
+			status: placementv1beta1.PerClusterPlacementStatus{
+				ClusterName: "cluster-1",
+				Conditions: []metav1.Condition{
+					{
+						Type:   "OtherCondition",
+						Status: metav1.ConditionTrue,
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "no conditions",
+			status: placementv1beta1.PerClusterPlacementStatus{
+				ClusterName: "cluster-1",
+				Conditions:  []metav1.Condition{},
+			},
+			expected: false,
+		},
+		{
+			name: "multiple conditions with Applied True",
+			status: placementv1beta1.PerClusterPlacementStatus{
+				ClusterName: "cluster-1",
+				Conditions: []metav1.Condition{
+					{
+						Type:   "OtherCondition",
+						Status: metav1.ConditionFalse,
+					},
+					{
+						Type:   string(placementv1beta1.PerClusterAppliedConditionType),
+						Status: metav1.ConditionTrue,
+					},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	reconciler := &Reconciler{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := reconciler.hasSuccessfulNamespacePlacement(tt.status)
+			if result != tt.expected {
+				t.Errorf("hasSuccessfulNamespacePlacement() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestExtractSuccessfulNamespacesFromStatus(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = clusterv1beta1.AddToScheme(scheme)
+	_ = placementv1beta1.AddToScheme(scheme)
+
+	tests := []struct {
+		name             string
+		crp              *placementv1beta1.ClusterResourcePlacement
+		status           placementv1beta1.PerClusterPlacementStatus
+		expected         []string
+		expectCRPMissing bool
+	}{
+		{
+			name: "direct namespace selection - success",
+			crp: &placementv1beta1.ClusterResourcePlacement{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-crp"},
+				Spec: placementv1beta1.PlacementSpec{
+					ResourceSelectors: []placementv1beta1.ResourceSelectorTerm{
+						{
+							Group:   "",
+							Version: "v1",
+							Kind:    "Namespace",
+							Name:    "test-ns",
+						},
+					},
+				},
+				Status: placementv1beta1.PlacementStatus{
+					SelectedResources: []placementv1beta1.ResourceIdentifier{
+						{
+							Group:   "",
+							Version: "v1",
+							Kind:    "Namespace",
+							Name:    "test-ns",
+						},
+					},
+				},
+			},
+			status: placementv1beta1.PerClusterPlacementStatus{
+				ClusterName: "cluster-1",
+			},
+			expected: []string{"test-ns"},
+		},
+		{
+			name: "multiple namespace selection - success",
+			crp: &placementv1beta1.ClusterResourcePlacement{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-crp"},
+				Spec: placementv1beta1.PlacementSpec{
+					ResourceSelectors: []placementv1beta1.ResourceSelectorTerm{
+						{
+							Group:   "",
+							Version: "v1",
+							Kind:    "Namespace",
+							Name:    "ns-1",
+						},
+						{
+							Group:   "",
+							Version: "v1",
+							Kind:    "Namespace",
+							Name:    "ns-2",
+						},
+					},
+				},
+				Status: placementv1beta1.PlacementStatus{
+					SelectedResources: []placementv1beta1.ResourceIdentifier{
+						{
+							Group:   "",
+							Version: "v1",
+							Kind:    "Namespace",
+							Name:    "ns-1",
+						},
+						{
+							Group:   "",
+							Version: "v1",
+							Kind:    "Namespace",
+							Name:    "ns-2",
+						},
+					},
+				},
+			},
+			status: placementv1beta1.PerClusterPlacementStatus{
+				ClusterName: "cluster-1",
+			},
+			expected: []string{"ns-1", "ns-2"},
+		},
+		{
+			name: "mixed resource selectors - only namespaces in selected resources",
+			crp: &placementv1beta1.ClusterResourcePlacement{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-crp"},
+				Spec: placementv1beta1.PlacementSpec{
+					ResourceSelectors: []placementv1beta1.ResourceSelectorTerm{
+						{
+							Group:   "",
+							Version: "v1",
+							Kind:    "Namespace",
+							Name:    "test-ns",
+						},
+						{
+							Group:   "apps",
+							Version: "v1",
+							Kind:    "Deployment",
+							Name:    "test-deployment",
+						},
+					},
+				},
+				Status: placementv1beta1.PlacementStatus{
+					SelectedResources: []placementv1beta1.ResourceIdentifier{
+						{
+							Group:   "",
+							Version: "v1",
+							Kind:    "Namespace",
+							Name:    "test-ns",
+						},
+						{
+							Group:   "apps",
+							Version: "v1",
+							Kind:    "Deployment",
+							Name:    "test-deployment",
+						},
+					},
+				},
+			},
+			status: placementv1beta1.PerClusterPlacementStatus{
+				ClusterName: "cluster-1",
+			},
+			expected: []string{"test-ns"},
+		},
+		{
+			name: "no namespace selectors in selected resources",
+			crp: &placementv1beta1.ClusterResourcePlacement{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-crp"},
+				Spec: placementv1beta1.PlacementSpec{
+					ResourceSelectors: []placementv1beta1.ResourceSelectorTerm{
+						{
+							Group:   "apps",
+							Version: "v1",
+							Kind:    "Deployment",
+							Name:    "test-deployment",
+						},
+					},
+				},
+				Status: placementv1beta1.PlacementStatus{
+					SelectedResources: []placementv1beta1.ResourceIdentifier{
+						{
+							Group:   "apps",
+							Version: "v1",
+							Kind:    "Deployment",
+							Name:    "test-deployment",
+						},
+					},
+				},
+			},
+			status: placementv1beta1.PerClusterPlacementStatus{
+				ClusterName: "cluster-1",
+			},
+			expected: []string{},
+		},
+		{
+			name: "namespace selector exists but namespace not selected (non-existent)",
+			crp: &placementv1beta1.ClusterResourcePlacement{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-crp"},
+				Spec: placementv1beta1.PlacementSpec{
+					ResourceSelectors: []placementv1beta1.ResourceSelectorTerm{
+						{
+							Group:   "",
+							Version: "v1",
+							Kind:    "Namespace",
+							Name:    "non-existent-ns",
+						},
+					},
+				},
+				Status: placementv1beta1.PlacementStatus{
+					SelectedResources: []placementv1beta1.ResourceIdentifier{}, // Empty - namespace wasn't found
+				},
+			},
+			status: placementv1beta1.PerClusterPlacementStatus{
+				ClusterName: "cluster-1",
+			},
+			expected: []string{}, // Should be empty because namespace wasn't actually selected
+		},
+		{
+			name: "namespace selection with failures",
+			crp: &placementv1beta1.ClusterResourcePlacement{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-crp"},
+				Spec: placementv1beta1.PlacementSpec{
+					ResourceSelectors: []placementv1beta1.ResourceSelectorTerm{
+						{
+							Group:   "",
+							Version: "v1",
+							Kind:    "Namespace",
+							Name:    "ns-1",
+						},
+						{
+							Group:   "",
+							Version: "v1",
+							Kind:    "Namespace",
+							Name:    "ns-2",
+						},
+					},
+				},
+				Status: placementv1beta1.PlacementStatus{
+					SelectedResources: []placementv1beta1.ResourceIdentifier{
+						{
+							Group:   "",
+							Version: "v1",
+							Kind:    "Namespace",
+							Name:    "ns-1",
+						},
+						{
+							Group:   "",
+							Version: "v1",
+							Kind:    "Namespace",
+							Name:    "ns-2",
+						},
+					},
+				},
+			},
+			status: placementv1beta1.PerClusterPlacementStatus{
+				ClusterName: "cluster-1",
+				FailedPlacements: []placementv1beta1.FailedResourcePlacement{
+					{
+						ResourceIdentifier: placementv1beta1.ResourceIdentifier{
+							Group:   "",
+							Version: "v1",
+							Kind:    "Namespace",
+							Name:    "ns-1",
+						},
+						Condition: metav1.Condition{
+							Type:   "Applied",
+							Status: metav1.ConditionFalse,
+							Reason: "some error",
+						},
+					},
+				},
+			},
+			expected: []string{"ns-2"}, // ns-1 should be filtered out due to failure
+		},
+		{
+			name:             "CRP not found",
+			crp:              nil, // Will not be created in fake client
+			expectCRPMissing: true,
+			status: placementv1beta1.PerClusterPlacementStatus{
+				ClusterName: "cluster-1",
+			},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var fakeClient client.Client
+			if tt.expectCRPMissing {
+				fakeClient = fake.NewClientBuilder().WithScheme(scheme).Build()
+			} else {
+				fakeClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(tt.crp).Build()
+			}
+
+			reconciler := &Reconciler{Client: fakeClient}
+			ctx := context.Background()
+
+			var crpName string
+			if tt.crp != nil {
+				crpName = tt.crp.Name
+			} else {
+				crpName = "nonexistent-crp"
+			}
+
+			result := reconciler.extractSuccessfulNamespacesFromStatus(ctx, crpName, tt.status)
+
+			if len(result) != len(tt.expected) {
+				t.Errorf("extractSuccessfulNamespacesFromStatus() returned %d namespaces, want %d", len(result), len(tt.expected))
+				t.Errorf("Got: %v, Want: %v", result, tt.expected)
+				return
+			}
+
+			// Convert to sets for comparison
+			resultSet := make(map[string]bool)
+			for _, ns := range result {
+				resultSet[ns] = true
+			}
+			expectedSet := make(map[string]bool)
+			for _, ns := range tt.expected {
+				expectedSet[ns] = true
+			}
+
+			for ns := range expectedSet {
+				if !resultSet[ns] {
+					t.Errorf("Expected namespace %v not found in result", ns)
+				}
+			}
+			for ns := range resultSet {
+				if !expectedSet[ns] {
+					t.Errorf("Unexpected namespace %v found in result", ns)
+				}
+			}
+		})
+	}
+}
+
+func TestCountNamespaceAffinityLabels(t *testing.T) {
+	tests := []struct {
+		name     string
+		labels   map[string]string
+		expected int
+	}{
+		{
+			name:     "no labels",
+			labels:   map[string]string{},
+			expected: 0,
+		},
+		{
+			name:     "nil labels",
+			labels:   nil,
+			expected: 0,
+		},
+		{
+			name: "only namespace affinity labels",
+			labels: map[string]string{
+				"kubernetes-fleet.io/namespace-ns1": "crp1",
+				"kubernetes-fleet.io/namespace-ns2": "crp2",
+			},
+			expected: 2,
+		},
+		{
+			name: "mixed labels",
+			labels: map[string]string{
+				"kubernetes-fleet.io/namespace-ns1": "crp1",
+				"kubernetes-fleet.io/namespace-ns2": "crp2",
+				"app":                               "test",
+				"environment":                       "prod",
+				"kubernetes-fleet.io/cluster-name":  "test",
+			},
+			expected: 2,
+		},
+		{
+			name: "no namespace affinity labels",
+			labels: map[string]string{
+				"app":                              "test",
+				"kubernetes-fleet.io/cluster-name": "test",
+			},
+			expected: 0,
+		},
+		{
+			name: "invalid namespace affinity labels",
+			labels: map[string]string{
+				"example.com/namespace-ns1":      "crp1", // wrong domain
+				"kubernetes-fleet.io/ns1":        "crp2", // missing namespace- prefix
+				"kubernetes-fleet.io/namespace-": "crp3", // empty namespace
+			},
+			expected: 0,
+		},
+	}
+
+	reconciler := &Reconciler{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := reconciler.countNamespaceAffinityLabels(tt.labels)
+			if result != tt.expected {
+				t.Errorf("countNamespaceAffinityLabels() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestPrioritizeNamespaceLabels(t *testing.T) {
+	tests := []struct {
+		name           string
+		successfulCRPs map[string][]string
+		maxLabels      int
+		expectedCount  int
+		expectFirst    string // First CRP name alphabetically should be prioritized
+	}{
+		{
+			name: "within limit",
+			successfulCRPs: map[string][]string{
+				"crp-b": {"ns1", "ns2"},
+				"crp-a": {"ns3"},
+			},
+			maxLabels:     10,
+			expectedCount: 3,
+			expectFirst:   "crp-a", // Alphabetically first
+		},
+		{
+			name: "exceeds limit",
+			successfulCRPs: map[string][]string{
+				"crp-z": {"ns1", "ns2"},
+				"crp-a": {"ns3", "ns4"},
+				"crp-b": {"ns5"},
+			},
+			maxLabels:     3,
+			expectedCount: 3,
+			expectFirst:   "crp-a",
+		},
+		{
+			name: "exactly at limit",
+			successfulCRPs: map[string][]string{
+				"crp-b": {"ns1"},
+				"crp-a": {"ns2"},
+			},
+			maxLabels:     2,
+			expectedCount: 2,
+			expectFirst:   "crp-a",
+		},
+		{
+			name:           "empty input",
+			successfulCRPs: map[string][]string{},
+			maxLabels:      5,
+			expectedCount:  0,
+		},
+	}
+
+	reconciler := &Reconciler{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := reconciler.prioritizeNamespaceLabels(tt.successfulCRPs, tt.maxLabels)
+
+			if len(result) != tt.expectedCount {
+				t.Errorf("prioritizeNamespaceLabels() returned %d labels, want %d", len(result), tt.expectedCount)
+			}
+
+			if tt.expectFirst != "" {
+				// Find a label that should belong to the first CRP
+				found := false
+				for _, crpValue := range result {
+					if crpValue == tt.expectFirst {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("Expected to find labels from CRP %s, but didn't", tt.expectFirst)
+				}
+			}
+
+			// Verify all results are valid namespace affinity labels
+			for labelKey, crpName := range result {
+				if !IsNamespaceAffinityLabel(labelKey) {
+					t.Errorf("Invalid namespace affinity label generated: %s", labelKey)
+				}
+				if crpName == "" {
+					t.Errorf("Empty CRP name for label %s", labelKey)
+				}
+			}
+		})
+	}
+}

--- a/pkg/controllers/membercluster/v1beta1/namespace_affinity.go
+++ b/pkg/controllers/membercluster/v1beta1/namespace_affinity.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2026 The KubeFleet Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"strings"
+
+	placementv1beta1 "github.com/kubefleet-dev/kubefleet/apis/placement/v1beta1"
+)
+
+const (
+	// NamespaceAffinityLabelKeyPrefix is the prefix for namespace affinity labels on MemberCluster
+	// Format: kubernetes-fleet.io/namespace-<namespace-name>
+	NamespaceAffinityLabelKeyPrefix = placementv1beta1.FleetPrefix + "namespace-"
+
+	// MaxNamespaceLabelsPerCluster is the maximum number of namespace affinity labels allowed per MemberCluster
+	// to prevent excessive resource usage and API server overhead
+	MaxNamespaceLabelsPerCluster = 200
+)
+
+// BuildNamespaceAffinityLabelKey builds the label key for namespace affinity
+// Returns: kubernetes-fleet.io/namespace-<namespace-name>
+func BuildNamespaceAffinityLabelKey(namespaceName string) string {
+	return NamespaceAffinityLabelKeyPrefix + namespaceName
+}
+
+// ParseNamespaceFromAffinityLabel extracts namespace name from affinity label key
+// Returns namespace name if the key matches the pattern, empty string otherwise
+func ParseNamespaceFromAffinityLabel(labelKey string) string {
+	if len(labelKey) <= len(NamespaceAffinityLabelKeyPrefix) {
+		return ""
+	}
+
+	if !startsWithPrefix(labelKey, NamespaceAffinityLabelKeyPrefix) {
+		return ""
+	}
+
+	return labelKey[len(NamespaceAffinityLabelKeyPrefix):]
+}
+
+// IsNamespaceAffinityLabel checks if a label key is a namespace affinity label
+func IsNamespaceAffinityLabel(labelKey string) bool {
+	if !strings.HasPrefix(labelKey, NamespaceAffinityLabelKeyPrefix) {
+		return false
+	}
+
+	// Extract namespace name and validate it's not empty or invalid
+	namespace := strings.TrimPrefix(labelKey, NamespaceAffinityLabelKeyPrefix)
+	if namespace == "" || strings.HasPrefix(namespace, "-") || strings.HasSuffix(namespace, "-") || strings.Contains(namespace, "--") {
+		return false
+	}
+
+	return true
+}
+
+// startsWithPrefix checks if string starts with prefix (avoiding external dependencies)
+func startsWithPrefix(s, prefix string) bool {
+	return len(s) >= len(prefix) && s[0:len(prefix)] == prefix
+}

--- a/pkg/controllers/membercluster/v1beta1/namespace_affinity_test.go
+++ b/pkg/controllers/membercluster/v1beta1/namespace_affinity_test.go
@@ -1,0 +1,290 @@
+/*
+Copyright 2026 The KubeFleet Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"strings"
+	"testing"
+
+	placementv1beta1 "github.com/kubefleet-dev/kubefleet/apis/placement/v1beta1"
+)
+
+func TestBuildNamespaceAffinityLabelKey(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+		expected  string
+	}{
+		{
+			name:      "basic namespace",
+			namespace: "test-ns",
+			expected:  "kubernetes-fleet.io/namespace-test-ns",
+		},
+		{
+			name:      "system namespace",
+			namespace: "kube-system",
+			expected:  "kubernetes-fleet.io/namespace-kube-system",
+		},
+		{
+			name:      "default namespace",
+			namespace: "default",
+			expected:  "kubernetes-fleet.io/namespace-default",
+		},
+		{
+			name:      "long namespace name",
+			namespace: "very-long-namespace-name-that-should-work",
+			expected:  "kubernetes-fleet.io/namespace-very-long-namespace-name-that-should-work",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := BuildNamespaceAffinityLabelKey(tt.namespace)
+			if result != tt.expected {
+				t.Errorf("BuildNamespaceAffinityLabelKey() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseNamespaceFromAffinityLabel(t *testing.T) {
+	tests := []struct {
+		name     string
+		labelKey string
+		expected string
+	}{
+		{
+			name:     "valid namespace affinity label",
+			labelKey: "kubernetes-fleet.io/namespace-test-ns",
+			expected: "test-ns",
+		},
+		{
+			name:     "system namespace",
+			labelKey: "kubernetes-fleet.io/namespace-kube-system",
+			expected: "kube-system",
+		},
+		{
+			name:     "default namespace",
+			labelKey: "kubernetes-fleet.io/namespace-default",
+			expected: "default",
+		},
+		{
+			name:     "invalid label - different prefix",
+			labelKey: "example.com/namespace-test-ns",
+			expected: "",
+		},
+		{
+			name:     "invalid label - missing namespace prefix",
+			labelKey: "kubernetes-fleet.io/test-ns",
+			expected: "",
+		},
+		{
+			name:     "empty label key",
+			labelKey: "",
+			expected: "",
+		},
+		{
+			name:     "namespace with dashes",
+			labelKey: "kubernetes-fleet.io/namespace-my-test-namespace",
+			expected: "my-test-namespace",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ParseNamespaceFromAffinityLabel(tt.labelKey)
+			if result != tt.expected {
+				t.Errorf("ParseNamespaceFromAffinityLabel() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsNamespaceAffinityLabel(t *testing.T) {
+	tests := []struct {
+		name     string
+		labelKey string
+		expected bool
+	}{
+		{
+			name:     "valid namespace affinity label",
+			labelKey: "kubernetes-fleet.io/namespace-test-ns",
+			expected: true,
+		},
+		{
+			name:     "valid with system namespace",
+			labelKey: "kubernetes-fleet.io/namespace-kube-system",
+			expected: true,
+		},
+		{
+			name:     "invalid - different domain",
+			labelKey: "example.com/namespace-test-ns",
+			expected: false,
+		},
+		{
+			name:     "invalid - missing namespace prefix",
+			labelKey: "kubernetes-fleet.io/test-ns",
+			expected: false,
+		},
+		{
+			name:     "invalid - different fleet label",
+			labelKey: "kubernetes-fleet.io/cluster-name",
+			expected: false,
+		},
+		{
+			name:     "empty string",
+			labelKey: "",
+			expected: false,
+		},
+		{
+			name:     "only prefix",
+			labelKey: "kubernetes-fleet.io/namespace-",
+			expected: false,
+		},
+		{
+			name:     "double dash namespace",
+			labelKey: "kubernetes-fleet.io/namespace--invalid",
+			expected: false, // According to K8s naming conventions
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsNamespaceAffinityLabel(tt.labelKey)
+			if result != tt.expected {
+				t.Errorf("IsNamespaceAffinityLabel() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNamespaceAffinityConstants(t *testing.T) {
+	// Test that constants have expected values
+	expectedPrefix := placementv1beta1.FleetPrefix + "namespace-"
+	if NamespaceAffinityLabelKeyPrefix != expectedPrefix {
+		t.Errorf("NamespaceAffinityLabelKeyPrefix = %v, want %v", NamespaceAffinityLabelKeyPrefix, expectedPrefix)
+	}
+
+	// Test that max limit is reasonable
+	if MaxNamespaceLabelsPerCluster <= 0 {
+		t.Errorf("MaxNamespaceLabelsPerCluster should be positive, got %v", MaxNamespaceLabelsPerCluster)
+	}
+	if MaxNamespaceLabelsPerCluster > 1000 {
+		t.Errorf("MaxNamespaceLabelsPerCluster seems too high, got %v", MaxNamespaceLabelsPerCluster)
+	}
+}
+
+func TestNamespaceAffinityLabelKeyPrefixIntegration(t *testing.T) {
+	// Test integration between BuildNamespaceAffinityLabelKey and the prefix constant
+	namespace := "test-ns"
+	expectedKey := NamespaceAffinityLabelKeyPrefix + namespace
+	actualKey := BuildNamespaceAffinityLabelKey(namespace)
+
+	if actualKey != expectedKey {
+		t.Errorf("BuildNamespaceAffinityLabelKey integration failed. Expected %v, got %v", expectedKey, actualKey)
+	}
+
+	// Test that IsNamespaceAffinityLabel recognizes keys built with BuildNamespaceAffinityLabelKey
+	if !IsNamespaceAffinityLabel(actualKey) {
+		t.Errorf("IsNamespaceAffinityLabel should return true for key built with BuildNamespaceAffinityLabelKey")
+	}
+
+	// Test that ParseNamespaceFromAffinityLabel can extract the namespace correctly
+	extractedNamespace := ParseNamespaceFromAffinityLabel(actualKey)
+	if extractedNamespace != namespace {
+		t.Errorf("ParseNamespaceFromAffinityLabel failed to extract namespace. Expected %v, got %v", namespace, extractedNamespace)
+	}
+}
+
+func TestRoundTripNamespaceAffinity(t *testing.T) {
+	testCases := []string{
+		"default",
+		"kube-system",
+		"fleet-system",
+		"app-namespace",
+		"test-ns-with-dashes",
+		"a",
+		"namespace123",
+	}
+
+	for _, namespace := range testCases {
+		t.Run("namespace-"+namespace, func(t *testing.T) {
+			// Build label key
+			labelKey := BuildNamespaceAffinityLabelKey(namespace)
+
+			// Verify it's recognized as namespace affinity label
+			if !IsNamespaceAffinityLabel(labelKey) {
+				t.Errorf("Built label key %v should be recognized as namespace affinity label", labelKey)
+			}
+
+			// Parse namespace back
+			parsedNamespace := ParseNamespaceFromAffinityLabel(labelKey)
+			if parsedNamespace != namespace {
+				t.Errorf("Round-trip failed for namespace %v. Parsed: %v", namespace, parsedNamespace)
+			}
+		})
+	}
+}
+
+func TestNamespaceAffinityLabelValidation(t *testing.T) {
+	// Test edge cases and validation
+	tests := []struct {
+		name          string
+		namespace     string
+		shouldBeValid bool
+	}{
+		{
+			name:          "empty namespace",
+			namespace:     "",
+			shouldBeValid: false,
+		},
+		{
+			name:          "very long namespace",
+			namespace:     strings.Repeat("a", 253), // K8s limit is 253 chars
+			shouldBeValid: true,
+		},
+		{
+			name:          "namespace with dots",
+			namespace:     "app.namespace",
+			shouldBeValid: true,
+		},
+		{
+			name:          "namespace starting with dash",
+			namespace:     "-invalid",
+			shouldBeValid: false, // K8s doesn't allow leading dash
+		},
+		{
+			name:          "namespace ending with dash",
+			namespace:     "invalid-",
+			shouldBeValid: false, // K8s doesn't allow trailing dash
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			labelKey := BuildNamespaceAffinityLabelKey(tt.namespace)
+			isValid := IsNamespaceAffinityLabel(labelKey)
+
+			if tt.shouldBeValid && !isValid {
+				t.Errorf("Expected namespace %v to produce valid label, but got invalid", tt.namespace)
+			}
+			if !tt.shouldBeValid && isValid {
+				t.Errorf("Expected namespace %v to produce invalid label, but got valid", tt.namespace)
+			}
+		})
+	}
+}

--- a/test/e2e/namespace_affinity_labeling_test.go
+++ b/test/e2e/namespace_affinity_labeling_test.go
@@ -1,0 +1,315 @@
+/*
+Copyright 2026 The KubeFleet Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	clusterv1beta1 "github.com/kubefleet-dev/kubefleet/apis/cluster/v1beta1"
+	placementv1beta1 "github.com/kubefleet-dev/kubefleet/apis/placement/v1beta1"
+	"github.com/kubefleet-dev/kubefleet/pkg/utils"
+)
+
+var _ = Describe("MemberCluster namespace affinity labeling", Label("resourceplacement", "namespaceaffinity"), Ordered, func() {
+	crpName := fmt.Sprintf(crpNameTemplate, GinkgoParallelProcess())
+	testNamespace1 := fmt.Sprintf("test-ns1-%d", GinkgoParallelProcess())
+	testNamespace2 := fmt.Sprintf("test-ns2-%d", GinkgoParallelProcess())
+
+	BeforeAll(func() {
+		By("creating test namespaces on hub cluster")
+		// Create test namespaces on hub cluster that we'll select in our CRPs
+		for _, nsName := range []string{testNamespace1, testNamespace2} {
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nsName,
+					Labels: map[string]string{
+						"test-label": "e2e-namespace-affinity",
+					},
+				},
+			}
+			Expect(hubClient.Create(ctx, ns)).Should(SatisfyAny(Succeed(), &utils.AlreadyExistMatcher{}))
+		}
+	})
+
+	AfterAll(func() {
+		By("cleaning up test namespaces on hub cluster")
+		for _, nsName := range []string{testNamespace1, testNamespace2} {
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName}}
+			_ = hubClient.Delete(ctx, ns) // Ignore errors as namespace might not exist
+		}
+
+		By("cleaning up CRP")
+		ensureCRPAndRelatedResourcesDeleted(crpName, allMemberClusters)
+	})
+
+	Context("when CRP selects namespaces directly", func() {
+		It("should add namespace affinity labels to MemberClusters", func() {
+			By("creating a CRP that selects test namespaces")
+			crp := &placementv1beta1.ClusterResourcePlacement{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: crpName,
+				},
+				Spec: placementv1beta1.PlacementSpec{
+					ResourceSelectors: []placementv1beta1.ResourceSelectorTerm{{
+						Group:   "",
+						Version: "v1",
+						Kind:    "Namespace",
+						Name:    testNamespace1,
+					}, {
+						Group:   "",
+						Version: "v1",
+						Kind:    "Namespace",
+						Name:    testNamespace2,
+					},
+					},
+					Policy: &placementv1beta1.PlacementPolicy{
+						PlacementType: placementv1beta1.PickAllPlacementType,
+					},
+				},
+			}
+			Expect(hubClient.Create(ctx, crp)).To(Succeed(), "Failed to create CRP")
+
+			By("verifying CRP is applied successfully on all member clusters")
+			namespaceResourceIdentifiers := []placementv1beta1.ResourceIdentifier{
+				{
+					Group:     "",
+					Version:   "v1",
+					Kind:      "Namespace",
+					Name:      testNamespace1,
+					Namespace: "",
+				},
+				{
+					Group:     "",
+					Version:   "v1",
+					Kind:      "Namespace",
+					Name:      testNamespace2,
+					Namespace: "",
+				},
+			}
+			crpStatusUpdatedActual := crpStatusUpdatedActual(namespaceResourceIdentifiers, allMemberClusterNames, nil, "0")
+			Eventually(crpStatusUpdatedActual, eventuallyDuration*2, eventuallyInterval).Should(Succeed(),
+				"Failed to apply CRP on all member clusters")
+
+			By("verifying MemberCluster objects get namespace affinity labels")
+			expectedLabelKey1 := "kubernetes-fleet.io/namespace-" + testNamespace1
+			expectedLabelKey2 := "kubernetes-fleet.io/namespace-" + testNamespace2
+
+			for _, cluster := range allMemberClusters {
+				mcName := cluster.ClusterName
+				Eventually(func() bool {
+					var mc clusterv1beta1.MemberCluster
+					err := hubClient.Get(ctx, types.NamespacedName{Name: mcName}, &mc)
+					if err != nil {
+						return false
+					}
+
+					// Check if both namespace affinity labels are present
+					val1, exists1 := mc.Labels[expectedLabelKey1]
+					val2, exists2 := mc.Labels[expectedLabelKey2]
+
+					return exists1 && exists2 && val1 == crpName && val2 == crpName
+				}, eventuallyDuration, eventuallyInterval).Should(BeTrue(),
+					"MemberCluster %s should have namespace affinity labels for both test namespaces", mcName)
+			}
+		})
+	})
+
+	Context("when CRP placement fails", func() {
+		It("should remove namespace affinity labels when CRP is deleted", func() {
+			By("deleting the CRP")
+			crp := &placementv1beta1.ClusterResourcePlacement{
+				ObjectMeta: metav1.ObjectMeta{Name: crpName},
+			}
+			Expect(hubClient.Delete(ctx, crp)).To(Succeed(), "Failed to delete CRP")
+
+			By("verifying namespace affinity labels are removed from MemberClusters")
+			expectedLabelKey1 := "kubernetes-fleet.io/namespace-" + testNamespace1
+			expectedLabelKey2 := "kubernetes-fleet.io/namespace-" + testNamespace2
+
+			for _, cluster := range allMemberClusters {
+				mcName := cluster.ClusterName
+				Eventually(func() bool {
+					var mc clusterv1beta1.MemberCluster
+					err := hubClient.Get(ctx, types.NamespacedName{Name: mcName}, &mc)
+					if err != nil {
+						return false
+					}
+
+					// Labels should be removed
+					_, exists1 := mc.Labels[expectedLabelKey1]
+					_, exists2 := mc.Labels[expectedLabelKey2]
+
+					return !exists1 && !exists2
+				}, eventuallyDuration, eventuallyInterval).Should(BeTrue(),
+					"MemberCluster %s should not have namespace affinity labels after CRP deletion", mcName)
+			}
+		})
+	})
+
+	Context("when CRP targets non-existent namespaces", func() {
+		It("should not add labels for failed placements", func() {
+			nonExistentNS := fmt.Sprintf("non-existent-ns-%d", GinkgoParallelProcess())
+			crpNameFail := fmt.Sprintf("crp-fail-%d", GinkgoParallelProcess())
+
+			defer func() {
+				By("cleaning up failed CRP")
+				ensureCRPAndRelatedResourcesDeleted(crpNameFail, allMemberClusters)
+			}()
+
+			By("creating a CRP that selects non-existent namespace")
+			crp := &placementv1beta1.ClusterResourcePlacement{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: crpNameFail,
+				},
+				Spec: placementv1beta1.PlacementSpec{
+					ResourceSelectors: []placementv1beta1.ResourceSelectorTerm{{
+						Group:   "",
+						Version: "v1",
+						Kind:    "Namespace",
+						Name:    nonExistentNS,
+					}},
+					Policy: &placementv1beta1.PlacementPolicy{
+						PlacementType: placementv1beta1.PickAllPlacementType,
+					},
+				},
+			}
+			Expect(hubClient.Create(ctx, crp)).To(Succeed(), "Failed to create CRP")
+
+			By("verifying MemberCluster objects do not get namespace affinity labels for failed placement")
+			expectedLabelKey := "kubernetes-fleet.io/namespace-" + nonExistentNS
+
+			for _, cluster := range allMemberClusters {
+				mcName := cluster.ClusterName
+				Consistently(func() bool {
+					var mc clusterv1beta1.MemberCluster
+					err := hubClient.Get(ctx, types.NamespacedName{Name: mcName}, &mc)
+					if err != nil {
+						return true // If we can't get MC, assume no label
+					}
+
+					// Label should NOT be present for failed placement
+					_, exists := mc.Labels[expectedLabelKey]
+					return !exists
+				}, eventuallyDuration, eventuallyInterval).Should(BeTrue(),
+					"MemberCluster %s should not have namespace affinity labels for failed placement", mcName)
+			}
+		})
+	})
+
+	Context("when multiple CRPs target the same namespace", func() {
+		It("should handle label conflicts appropriately", func() {
+			crpName2 := fmt.Sprintf("crp2-%d", GinkgoParallelProcess())
+			sharedNamespace := fmt.Sprintf("shared-ns-%d", GinkgoParallelProcess())
+
+			defer func() {
+				By("cleaning up both CRPs")
+				ensureCRPAndRelatedResourcesDeleted(crpName2, allMemberClusters)
+				// Note: original crp cleanup is handled in AfterAll
+			}()
+
+			By("creating shared namespace on hub cluster")
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: sharedNamespace,
+				},
+			}
+			Expect(hubClient.Create(ctx, ns)).Should(SatisfyAny(Succeed(), &utils.AlreadyExistMatcher{}))
+
+			By("creating first CRP targeting shared namespace")
+			crp1 := &placementv1beta1.ClusterResourcePlacement{
+				ObjectMeta: metav1.ObjectMeta{Name: crpName},
+				Spec: placementv1beta1.PlacementSpec{
+					ResourceSelectors: []placementv1beta1.ResourceSelectorTerm{{
+						Group:   "",
+						Version: "v1",
+						Kind:    "Namespace",
+						Name:    sharedNamespace,
+					}},
+					Policy: &placementv1beta1.PlacementPolicy{
+						PlacementType: placementv1beta1.PickAllPlacementType,
+					},
+				},
+			}
+			Expect(hubClient.Create(ctx, crp1)).To(Succeed())
+
+			By("creating second CRP targeting the same shared namespace")
+			crp2 := &placementv1beta1.ClusterResourcePlacement{
+				ObjectMeta: metav1.ObjectMeta{Name: crpName2},
+				Spec: placementv1beta1.PlacementSpec{
+					ResourceSelectors: []placementv1beta1.ResourceSelectorTerm{{
+						Group:   "",
+						Version: "v1",
+						Kind:    "Namespace",
+						Name:    sharedNamespace,
+					}},
+					Policy: &placementv1beta1.PlacementPolicy{
+						PlacementType: placementv1beta1.PickAllPlacementType,
+					},
+				},
+			}
+			Expect(hubClient.Create(ctx, crp2)).To(Succeed())
+
+			By("verifying exactly one MemberCluster label exists from the successful CRP")
+			expectedLabelKey := "kubernetes-fleet.io/namespace-" + sharedNamespace
+
+			for _, cluster := range allMemberClusters {
+				mcName := cluster.ClusterName
+				Eventually(func() bool {
+					var mc clusterv1beta1.MemberCluster
+					err := hubClient.Get(ctx, types.NamespacedName{Name: mcName}, &mc)
+					if err != nil {
+						return false
+					}
+
+					// Label should exist with exactly one of the CRP names (whichever succeeded)
+					val, exists := mc.Labels[expectedLabelKey]
+					return exists && (val == crpName || val == crpName2)
+				}, eventuallyDuration, eventuallyInterval).Should(BeTrue(),
+					"MemberCluster %s should have namespace affinity label from the successful CRP", mcName)
+
+				// Verify there's exactly one label (not conflicting labels)
+				Eventually(func() bool {
+					var mc clusterv1beta1.MemberCluster
+					err := hubClient.Get(ctx, types.NamespacedName{Name: mcName}, &mc)
+					if err != nil {
+						return false
+					}
+
+					// Count namespace affinity labels - should be exactly 1
+					count := 0
+					for k := range mc.Labels {
+						if k == expectedLabelKey {
+							count++
+						}
+					}
+					return count == 1
+				}, eventuallyDuration, eventuallyInterval).Should(BeTrue(),
+					"MemberCluster %s should have exactly one namespace affinity label", mcName)
+			}
+
+			By("cleaning up shared namespace")
+			ns = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: sharedNamespace}}
+			Expect(hubClient.Delete(ctx, ns)).Should(SatisfyAny(Succeed(), &utils.NotFoundMatcher{}))
+		})
+	})
+})


### PR DESCRIPTION
### Description of your changes

The design is:
- Implemented in this PR: "Our controller will automatically add a label, <domain-prefix>/< namespace-name>: <crp-name> to the corresponding memberCluster CR based on the CRP scheduling decisions, which is created by the infra team."
- Will be implemented in a followup PR: "The customers do not need to specify the clusterAffinity, and our scheduler will try to schedule the RP on the clusters which have the namespace."

Something different from the design doc:
Design: The value of namespace label <crp-name> will be empty if the namespace is created by the customers manually.
What I implemented: Label only exists for namespaces created by CRP to avoid having too many labels

Approved Design Doc: https://microsoft.sharepoint.com/:w:/r/teams/aks-caravel/_layouts/15/Doc.aspx?sourcedoc=%7BEC4121C8-9672-4AD6-93B7-7B0DC7CA7F1D%7D&file=CRP%20and%20RP%20affinity%20design.docx&action=default&mobileredirect=true

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
