### PR TITLE
fix: change the error msg reg exp

### DIFF
--- a/test/apis/placement/v1beta1/api_validation_integration_test.go
+++ b/test/apis/placement/v1beta1/api_validation_integration_test.go
@@ -1409,7 +1409,7 @@ var _ = Describe("Test placement v1beta1 API validation", func() {
 			err := hubClient.Create(ctx, &strategy)
 			var statusErr *k8sErrors.StatusError
 			Expect(errors.As(err, &statusErr)).To(BeTrue(), fmt.Sprintf("Create updateRunStrategy call produced error %s. Error type wanted is %s.", reflect.TypeOf(err), reflect.TypeOf(&k8sErrors.StatusError{})))
-			Expect(statusErr.ErrStatus.Message).Should(MatchRegexp("Too long: may not be longer than 63"))
+			Expect(statusErr.ErrStatus.Message).Should(MatchRegexp("Too long: may not be more than 63 bytes"))
 		})
 
 		It("Should deny creation of ClusterStagedUpdateStrategy with invalid stage config - stage name with invalid characters", func() {


### PR DESCRIPTION
### Description of your changes

Somehow Tim Hockin wanted to change the error msg mapping to tooLong error a while back. 
https://github.com/kubernetes/kubernetes/commit/4d0e1c8fd4c6577d90dfa1fca67113b8b0af739a

This breaks one of our test after we bump the testEnv binary to newer version.

Fixes #

I have:

- [ ] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
