### PR TITLE
feat: align v1 override types with v1beta1 schema parity

### DIFF
--- a/apis/placement/v1/clusterresourceplacement_types.go
+++ b/apis/placement/v1/clusterresourceplacement_types.go
@@ -29,11 +29,11 @@ import (
 const (
 	// PlacementCleanupFinalizer is a finalizer added by the placement controller to all placement objects, to make sure
 	// that the placement controller can react to placement object deletions if necessary.
-	PlacementCleanupFinalizer = fleetPrefix + "crp-cleanup"
+	PlacementCleanupFinalizer = FleetPrefix + "crp-cleanup"
 
 	// SchedulerCleanupFinalizer is a finalizer added by the scheduler to placement objects, to make sure
 	// that all bindings derived from a placement object can be cleaned up after the placement object is deleted.
-	SchedulerCleanupFinalizer = fleetPrefix + "scheduler-cleanup"
+	SchedulerCleanupFinalizer = FleetPrefix + "scheduler-cleanup"
 )
 
 // make sure the PlacementObj and PlacementObjList interfaces are implemented by the
@@ -1513,7 +1513,7 @@ func (crpl *ClusterResourcePlacementList) GetPlacementObjs() []PlacementObj {
 const (
 	// ResourcePlacementCleanupFinalizer is a finalizer added by the RP controller to all RPs, to make sure
 	// that the RP controller can react to RP deletions if necessary.
-	ResourcePlacementCleanupFinalizer = fleetPrefix + "rp-cleanup"
+	ResourcePlacementCleanupFinalizer = FleetPrefix + "rp-cleanup"
 )
 
 // +genclient

--- a/apis/placement/v1/commons.go
+++ b/apis/placement/v1/commons.go
@@ -17,18 +17,19 @@ limitations under the License.
 package v1
 
 const (
-	// fleetPrefix is the prefix used for official fleet labels/annotations.
+	// FleetPrefix is the prefix used for official fleet labels/annotations.
 	// Unprefixed labels/annotations are reserved for end-users
 	// See https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#label-selector-and-annotation-conventions
-	fleetPrefix = "kubernetes-fleet.io/"
+	FleetPrefix = "kubernetes-fleet.io/"
 )
 
 // NamespacedName comprises a resource name, with a mandatory namespace.
 type NamespacedName struct {
 	// Name is the name of the namespaced scope resource.
-	// +required
+	// +kubebuilder:validation:Required
 	Name string `json:"name"`
+
 	// Namespace is namespace of the namespaced scope resource.
-	// +required
+	// +kubebuilder:validation:Required
 	Namespace string `json:"namespace"`
 }

--- a/apis/placement/v1/override_types.go
+++ b/apis/placement/v1/override_types.go
@@ -25,6 +25,7 @@ import (
 // +genclient:nonNamespaced
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope="Cluster",categories={fleet,fleet-placement}
+// +kubebuilder:validation:XValidation:rule="!has(self.spec.placement) || self.spec.placement.scope != 'Namespaced'",message="clusterResourceOverride placement reference cannot be Namespaced scope"
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ClusterResourceOverride defines a group of override policies about how to override the selected cluster scope resources
@@ -48,7 +49,6 @@ type ClusterResourceOverrideSpec struct {
 	// If set, the override will trigger the placement rollout immediately when the rollout strategy type is RollingUpdate.
 	// Otherwise, it will be applied to the next rollout.
 	// The recommended way is to set the placement so that the override can be rolled out immediately.
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="The placement field is immutable"
 	// +optional
 	Placement *PlacementRef `json:"placement,omitempty"`
 
@@ -84,8 +84,8 @@ const (
 type PlacementRef struct {
 	// Name is the reference to the name of placement.
 	// +required
-
 	Name string `json:"name"`
+
 	// Scope defines the scope of the placement.
 	// A clusterResourceOverride can only reference a clusterResourcePlacement (cluster-scoped),
 	// and a resourceOverride can reference either a clusterResourcePlacement or resourcePlacement (namespaced).

--- a/apis/placement/v1/overridesnapshot_types.go
+++ b/apis/placement/v1/overridesnapshot_types.go
@@ -20,18 +20,18 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 const (
 
-	// OverrideIndexLabel is the label that indicate the policy snapshot index of a cluster policy.
-	OverrideIndexLabel = fleetPrefix + "override-index"
+	// OverrideIndexLabel is the label that indicates the override snapshot index of an override.
+	OverrideIndexLabel = FleetPrefix + "override-index"
 
 	// OverrideSnapshotNameFmt is clusterResourceOverrideSnapshot name format: {CROName}-{OverrideSnapshotIndex}.
 	OverrideSnapshotNameFmt = "%s-%d"
 
 	// OverrideTrackingLabel is the label that points to the cluster resource override that creates a resource snapshot.
-	OverrideTrackingLabel = fleetPrefix + "parent-resource-override"
+	OverrideTrackingLabel = FleetPrefix + "parent-resource-override"
 
 	// OverrideFinalizer is a finalizer added by the override controllers to all override, to make sure
 	// that the override controller can react to override deletions if necessary.
-	OverrideFinalizer = fleetPrefix + "override-cleanup"
+	OverrideFinalizer = FleetPrefix + "override-cleanup"
 )
 
 // +genclient

--- a/apis/placement/v1beta1/overridesnapshot_types.go
+++ b/apis/placement/v1beta1/overridesnapshot_types.go
@@ -20,7 +20,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 const (
 
-	// OverrideIndexLabel is the label that indicate the policy snapshot index of a cluster policy.
+	// OverrideIndexLabel is the label that indicates the override snapshot index of an override.
 	OverrideIndexLabel = FleetPrefix + "override-index"
 
 	// OverrideSnapshotNameFmt is clusterResourceOverrideSnapshot name format: {CROName}-{OverrideSnapshotIndex}.

--- a/config/crd/bases/placement.kubernetes-fleet.io_clusterresourceoverrides.yaml
+++ b/config/crd/bases/placement.kubernetes-fleet.io_clusterresourceoverrides.yaml
@@ -153,6 +153,7 @@ spec:
                   The recommended way is to set the placement so that the override can be rolled out immediately.
                 properties:
                   name:
+                    description: Name is the reference to the name of placement.
                     type: string
                   scope:
                     default: Cluster
@@ -168,9 +169,6 @@ spec:
                 required:
                 - name
                 type: object
-                x-kubernetes-validations:
-                - message: The placement field is immutable
-                  rule: self == oldSelf
               policy:
                 description: Policy defines how to override the selected resources
                   on the target clusters.
@@ -399,6 +397,10 @@ spec:
         required:
         - spec
         type: object
+        x-kubernetes-validations:
+        - message: clusterResourceOverride placement reference cannot be Namespaced
+            scope
+          rule: '!has(self.spec.placement) || self.spec.placement.scope != ''Namespaced'''
     served: true
     storage: false
   - name: v1alpha1

--- a/config/crd/bases/placement.kubernetes-fleet.io_clusterresourceoverridesnapshots.yaml
+++ b/config/crd/bases/placement.kubernetes-fleet.io_clusterresourceoverridesnapshots.yaml
@@ -167,6 +167,7 @@ spec:
                       The recommended way is to set the placement so that the override can be rolled out immediately.
                     properties:
                       name:
+                        description: Name is the reference to the name of placement.
                         type: string
                       scope:
                         default: Cluster
@@ -182,9 +183,6 @@ spec:
                     required:
                     - name
                     type: object
-                    x-kubernetes-validations:
-                    - message: The placement field is immutable
-                      rule: self == oldSelf
                   policy:
                     description: Policy defines how to override the selected resources
                       on the target clusters.

--- a/config/crd/bases/placement.kubernetes-fleet.io_resourceoverrides.yaml
+++ b/config/crd/bases/placement.kubernetes-fleet.io_resourceoverrides.yaml
@@ -52,6 +52,7 @@ spec:
                   The recommended way is to set the placement so that the override can be rolled out immediately.
                 properties:
                   name:
+                    description: Name is the reference to the name of placement.
                     type: string
                   scope:
                     default: Cluster

--- a/config/crd/bases/placement.kubernetes-fleet.io_resourceoverridesnapshots.yaml
+++ b/config/crd/bases/placement.kubernetes-fleet.io_resourceoverridesnapshots.yaml
@@ -66,6 +66,7 @@ spec:
                       The recommended way is to set the placement so that the override can be rolled out immediately.
                     properties:
                       name:
+                        description: Name is the reference to the name of placement.
                         type: string
                       scope:
                         default: Cluster


### PR DESCRIPTION
### Description of your changes

This pull request introduces several improvements and consistency updates to the Fleet placement and override APIs and CRDs. The main changes include standardizing the use of the `FleetPrefix` constant, adding new label and annotation constants, improving validation rules for placement references, and enhancing CRD documentation. These updates help ensure consistency, improve validation, and provide better documentation for users and developers.

**API Consistency and Constants:**

* Replaced all usages of the private `fleetPrefix` constant with the exported `FleetPrefix` constant for labels, annotations, and finalizers across the codebase, ensuring consistent naming and easier reuse. [[1]](diffhunk://#diff-0827d20884e95a3cc92deec3cd942001fe9dd6f1965c4c38e9199a5f01b90a5fL32-R36) [[2]](diffhunk://#diff-0827d20884e95a3cc92deec3cd942001fe9dd6f1965c4c38e9199a5f01b90a5fL1516-R1516) [[3]](diffhunk://#diff-d26be881636b395af6e51bd5fba0118b2d507fcc8d09724278cdbb875027e942L24-R34) [[4]](diffhunk://#diff-5954086f1acd8c77fd982b25ab218b96f05453e95f8def5c91647354dc96a91fL20-R68)
* Added new constants for various labels and annotations (e.g., `IsLatestSnapshotLabel`, `ParentClusterResourceOverrideSnapshotHashAnnotation`, `OverrideClusterNameVariable`) and for override kinds to improve code clarity and maintainability.

**Validation and Schema Improvements:**

* Added a cross-field validation rule to the `ClusterResourceOverride` CRD and Go type to ensure that the placement reference cannot have a `Namespaced` scope. [[1]](diffhunk://#diff-ff66ff229737ac520acd9c37a53011a7f83b25371aa4b6f6fe5b93c4c4a8e322R28) [[2]](diffhunk://#diff-16db12fec4ecaa2e6b94bd11e39283071155ed2e8217e7056f4a709b35f10c1aR400-R403)
* Removed the immutability validation rule for the `placement` field from both the Go type and CRDs, allowing updates to this field. [[1]](diffhunk://#diff-ff66ff229737ac520acd9c37a53011a7f83b25371aa4b6f6fe5b93c4c4a8e322L51) [[2]](diffhunk://#diff-16db12fec4ecaa2e6b94bd11e39283071155ed2e8217e7056f4a709b35f10c1aL171-L173) [[3]](diffhunk://#diff-c41d765f3ee21dfc992d6e5b04ff70ba2f19b0259e64f46a7a84bc16427fce47L185-L187)

**Documentation and Schema Enhancements:**

* Added descriptions for the `name` property in placement references within the CRDs to improve generated documentation and user understanding. [[1]](diffhunk://#diff-16db12fec4ecaa2e6b94bd11e39283071155ed2e8217e7056f4a709b35f10c1aR156) [[2]](diffhunk://#diff-c41d765f3ee21dfc992d6e5b04ff70ba2f19b0259e64f46a7a84bc16427fce47R170) [[3]](diffhunk://#diff-931130bac232422640096e2200d65cb0e19852980dcb57ac61746fd72f7d39e7R55) [[4]](diffhunk://#diff-b3690ef7b102d9aeff9e1a39554207f3fe674b265f43626624d3d41652b3c2f2R69)

**Validation Annotations:**

* Updated struct field tags to use `+kubebuilder:validation:Required` for required fields, aligning with best practices for CRD validation. [[1]](diffhunk://#diff-5954086f1acd8c77fd982b25ab218b96f05453e95f8def5c91647354dc96a91fL20-R68) [[2]](diffhunk://#diff-ff66ff229737ac520acd9c37a53011a7f83b25371aa4b6f6fe5b93c4c4a8e322L86-R86)

Fixes #

I have:

- [ ] Associated this change with a known KubeFleet Issue (Bug, Feature, etc).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
N/A

### Special notes for your reviewer
N/A