### PR TITLE
fix: Invalid pr title workflow fix

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,4 +1,9 @@
 name: PR Title Checker
+
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   pull_request:
     types:


### PR DESCRIPTION
### Description of your changes

This pull request makes a small update to the GitHub Actions workflow for PR title checking by specifying explicit permissions for the workflow.

* Added `permissions` settings to the `.github/workflows/pr-title-lint.yml` workflow, granting read access to contents and write access to pull-requests.

Fixes #518 


I have:

- [X] Associated this change with a known KubeFleet Issue (Bug, Feature, etc).
- [ ] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
