### PR TITLE
feat: add approvalRequest support in kubectl fleet plugin

### DIFF
--- a/tools/fleet/README.md
+++ b/tools/fleet/README.md
@@ -60,17 +60,37 @@ CURRENT   NAME               CLUSTER            AUTHINFO                        
 
 Here you can see that the context of the hub cluster is called `hub` under the `NAME` column.
 
-### Approve a ClusterApprovalRequest
+### Approve an Approval Request
 
-Use the `approve` subcommand to approve ClusterApprovalRequest resources for staged update runs. This allows staged updates to proceed to the next stage by patching an "Approved" condition to the resource status.
+Use the `approve` subcommand to approve approval request resources for staged update runs. This allows staged updates to proceed to the next stage by patching an "Approved" condition to the resource status.
 
+**Supported kinds:**
+| Kind | Alias | Scope | Namespace Flag |
+|------|-------|-------|----------------|
+| `clusterapprovalrequest` | `careq` | Cluster | Not allowed |
+| `approvalrequest` | `areq` | Namespace | Required |
+
+**Cluster-scoped (ClusterApprovalRequest):**
 ```bash
 kubectl fleet approve clusterapprovalrequest --hubClusterContext <hub-cluster-context> --name <approval-request-name>
+# Or using alias:
+kubectl fleet approve careq --hubClusterContext <hub-cluster-context> --name <approval-request-name>
+```
+
+**Namespace-scoped (ApprovalRequest):**
+```bash
+kubectl fleet approve approvalrequest --hubClusterContext <hub-cluster-context> --name <approval-request-name> --namespace <namespace>
+# Or using alias:
+kubectl fleet approve areq --hubClusterContext <hub-cluster-context> --name <approval-request-name> -n <namespace>
 ```
 
 Example:
 ```bash
+# Approve a ClusterApprovalRequest
 kubectl fleet approve clusterapprovalrequest --hubClusterContext hub --name my-approval-request
+
+# Approve an ApprovalRequest in a specific namespace
+kubectl fleet approve approvalrequest --hubClusterContext hub --name my-approval-request --namespace my-namespace
 ```
 
 ### Drain a Member Cluster
@@ -103,13 +123,17 @@ kubectl fleet uncordoncluster --hubClusterContext hub --clusterName member-clust
 
 ### approve
 
-Approves ClusterApprovalRequest resources for staged update runs by:
+Approves approval request resources for staged update runs by:
 
-1. **Status Update**: Patches the ClusterApprovalRequest resource with an "Approved" condition
+1. **Status Update**: Patches the approval request resource with an "Approved" condition
 2. **Stage Progression**: Allows staged updates to proceed to the next stage automatically
 
-The approve command currently supports the following resource kinds:
-- `clusterapprovalrequest`: Approve a ClusterApprovalRequest for staged updates
+The approve command supports the following resource kinds:
+
+| Kind | Alias | Scope | Description |
+|------|-------|-------|-------------|
+| `clusterapprovalrequest` | `careq` | Cluster | Approve a ClusterApprovalRequest (no namespace) |
+| `approvalrequest` | `areq` | Namespace | Approve an ApprovalRequest (requires `--namespace`) |
 
 ### draincluster
 
@@ -134,7 +158,7 @@ If the `cordon` taint is not present on the member cluster, the command will hav
 The `approve` subcommand uses the following flags:
 - `--hubClusterContext`: kubectl context for the hub cluster (required)
 - `--name`: name of the resource to approve (required)
-- `--namespace`: namespace of the resource to approve (optional)
+- `--namespace`, `-n`: namespace of the resource to approve (required for `approvalrequest`, not allowed for `clusterapprovalrequest`)
 
 Both `draincluster` and `uncordoncluster` subcommands use the following flags:
 - `--hubClusterContext`: kubectl context for the hub cluster (required)

--- a/tools/fleet/cmd/approve/approve.go
+++ b/tools/fleet/cmd/approve/approve.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"strings"
 
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -31,23 +30,61 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	placementv1beta1 "github.com/kubefleet-dev/kubefleet/apis/placement/v1beta1"
+	fleetcmd "github.com/kubefleet-dev/kubefleet/tools/fleet/cmd"
 	toolsutils "github.com/kubefleet-dev/kubefleet/tools/utils"
 )
 
-const (
-	// kindClusterApprovalRequest is the kind for ClusterApprovalRequest.
-	kindClusterApprovalRequest = "clusterapprovalrequest"
-	// kindApprovalRequest is the kind for ApprovalRequest.
-	kindApprovalRequest = "approvalrequest"
-	// aliasClusterApprovalRequest is the short alias for ClusterApprovalRequest.
-	aliasClusterApprovalRequest = "careq"
-	// aliasApprovalRequest is the short alias for ApprovalRequest.
-	aliasApprovalRequest = "areq"
-)
+// approveKindConfig extends fleetcmd.KindConfig with approve-specific validation and handler.
+type approveKindConfig struct {
+	fleetcmd.KindConfig
+	validate func(o *approveOptions) error
+	handler  func(o *approveOptions, ctx context.Context) error
+}
+
+var approveKindConfigs = []approveKindConfig{
+	{
+		KindConfig: fleetcmd.KindConfig{
+			Canonical: fleetcmd.KindClusterApprovalRequest,
+			Aliases:   []string{fleetcmd.AliasClusterApprovalRequest},
+		},
+		validate: func(o *approveOptions) error {
+			if o.namespace != "" {
+				return fmt.Errorf("%s is cluster-scoped and does not accept a namespace", fleetcmd.KindClusterApprovalRequest)
+			}
+			return nil
+		},
+		handler: (*approveOptions).approveClusterApprovalRequest,
+	},
+	{
+		KindConfig: fleetcmd.KindConfig{
+			Canonical: fleetcmd.KindApprovalRequest,
+			Aliases:   []string{fleetcmd.AliasApprovalRequest},
+		},
+		validate: func(o *approveOptions) error {
+			if o.namespace == "" {
+				return fmt.Errorf("namespace is required for %s (use --namespace or -n flag)", fleetcmd.KindApprovalRequest)
+			}
+			return nil
+		},
+		handler: (*approveOptions).approveApprovalRequest,
+	},
+}
+
+// approveKinds maps canonical kind names and aliases to their approveKindConfig.
+var approveKinds = map[string]*approveKindConfig{}
+
+func init() {
+	for i := range approveKindConfigs {
+		cfg := &approveKindConfigs[i]
+		approveKinds[cfg.Canonical] = cfg
+		for _, a := range cfg.Aliases {
+			approveKinds[a] = cfg
+		}
+	}
+}
 
 type approveOptions struct {
 	hubClusterContext string
-	kind              string
 	name              string
 	namespace         string
 
@@ -72,14 +109,17 @@ Supported kinds:
 For namespace-scoped resources (approvalrequest), you must also specify the --namespace flag.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			o.kind = normalizeKind(args[0])
-			if err := o.validate(); err != nil {
+			cfg, err := fleetcmd.ResolveKind(args[0], approveKinds)
+			if err != nil {
+				return err
+			}
+			if err := o.validate(cfg); err != nil {
 				return err
 			}
 			if err := o.setupClient(); err != nil {
 				return err
 			}
-			return o.run(cmd.Context())
+			return o.run(cmd.Context(), cfg)
 		},
 	}
 
@@ -94,49 +134,16 @@ For namespace-scoped resources (approvalrequest), you must also specify the --na
 	return cmd
 }
 
-// normalizeKind converts kind aliases to their canonical form.
-func normalizeKind(kind string) string {
-	switch strings.ToLower(kind) {
-	case aliasClusterApprovalRequest:
-		return kindClusterApprovalRequest
-	case aliasApprovalRequest:
-		return kindApprovalRequest
-	default:
-		return strings.ToLower(kind)
-	}
-}
-
 // validate checks that the options are valid.
-func (o *approveOptions) validate() error {
-	if o.kind == "" {
-		return fmt.Errorf("resource kind is required")
-	}
+func (o *approveOptions) validate(cfg *approveKindConfig) error {
 	if o.name == "" {
 		return fmt.Errorf("resource name is required")
 	}
-
-	switch o.kind {
-	case kindClusterApprovalRequest:
-		// Cluster-scoped, no namespace required.
-	case kindApprovalRequest:
-		if o.namespace == "" {
-			return fmt.Errorf("namespace is required for approvalrequest resources (use --namespace or -n flag)")
-		}
-	default:
-		return fmt.Errorf("unsupported resource kind %q, supported kinds are: clusterapprovalrequest (careq), approvalrequest (areq)", o.kind)
-	}
-	return nil
+	return cfg.validate(o)
 }
 
-func (o *approveOptions) run(ctx context.Context) error {
-	switch o.kind {
-	case kindClusterApprovalRequest:
-		return o.approveClusterApprovalRequest(ctx)
-	case kindApprovalRequest:
-		return o.approveApprovalRequest(ctx)
-	default:
-		return fmt.Errorf("unsupported resource kind %q", o.kind)
-	}
+func (o *approveOptions) run(ctx context.Context, cfg *approveKindConfig) error {
+	return cfg.handler(o, ctx)
 }
 
 // approveClusterApprovalRequest approves a ClusterApprovalRequest (cluster-scoped).
@@ -161,7 +168,6 @@ func (o *approveOptions) approveClusterApprovalRequest(ctx context.Context) erro
 
 		return o.hubClient.Status().Update(ctx, &car)
 	})
-
 	if err != nil {
 		return fmt.Errorf("failed to approve ClusterApprovalRequest %q: %w", o.name, err)
 	}
@@ -192,7 +198,6 @@ func (o *approveOptions) approveApprovalRequest(ctx context.Context) error {
 
 		return o.hubClient.Status().Update(ctx, &ar)
 	})
-
 	if err != nil {
 		return fmt.Errorf("failed to approve ApprovalRequest %q in namespace %q: %w", o.name, o.namespace, err)
 	}

--- a/tools/fleet/cmd/approve/approve_test.go
+++ b/tools/fleet/cmd/approve/approve_test.go
@@ -30,82 +30,21 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	placementv1beta1 "github.com/kubefleet-dev/kubefleet/apis/placement/v1beta1"
+	fleetcmd "github.com/kubefleet-dev/kubefleet/tools/fleet/cmd"
 )
-
-func TestNormalizeKind(t *testing.T) {
-	tests := []struct {
-		name  string
-		input string
-		want  string
-	}{
-		{
-			name:  "clusterapprovalrequest lowercase",
-			input: "clusterapprovalrequest",
-			want:  "clusterapprovalrequest",
-		},
-		{
-			name:  "clusterapprovalrequest uppercase",
-			input: "CLUSTERAPPROVALREQUEST",
-			want:  "clusterapprovalrequest",
-		},
-		{
-			name:  "careq alias",
-			input: "careq",
-			want:  "clusterapprovalrequest",
-		},
-		{
-			name:  "CAREQ alias uppercase",
-			input: "CAREQ",
-			want:  "clusterapprovalrequest",
-		},
-		{
-			name:  "approvalrequest lowercase",
-			input: "approvalrequest",
-			want:  "approvalrequest",
-		},
-		{
-			name:  "approvalrequest uppercase",
-			input: "APPROVALREQUEST",
-			want:  "approvalrequest",
-		},
-		{
-			name:  "areq alias",
-			input: "areq",
-			want:  "approvalrequest",
-		},
-		{
-			name:  "AREQ alias uppercase",
-			input: "AREQ",
-			want:  "approvalrequest",
-		},
-		{
-			name:  "unknown kind preserved lowercase",
-			input: "SomeOtherKind",
-			want:  "someotherkind",
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got := normalizeKind(tc.input)
-			if got != tc.want {
-				t.Errorf("normalizeKind(%q) = %q, want %q", tc.input, got, tc.want)
-			}
-		})
-	}
-}
 
 func TestValidate(t *testing.T) {
 	tests := []struct {
 		name       string
+		kind       string
 		opts       approveOptions
 		wantErr    bool
 		wantErrMsg string
 	}{
 		{
-			name: "empty kind should fail",
+			name: "empty kind should fail in resolveKind",
+			kind: "",
 			opts: approveOptions{
-				kind: "",
 				name: "test-name",
 			},
 			wantErr:    true,
@@ -113,8 +52,8 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			name: "empty name should fail",
+			kind: fleetcmd.KindClusterApprovalRequest,
 			opts: approveOptions{
-				kind: kindClusterApprovalRequest,
 				name: "",
 			},
 			wantErr:    true,
@@ -122,8 +61,8 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			name: "unsupported kind should fail",
+			kind: "unsupported",
 			opts: approveOptions{
-				kind: "unsupported",
 				name: "test-name",
 			},
 			wantErr:    true,
@@ -131,25 +70,35 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			name: "clusterapprovalrequest without namespace is valid",
+			kind: fleetcmd.KindClusterApprovalRequest,
 			opts: approveOptions{
-				kind: kindClusterApprovalRequest,
 				name: "test-name",
 			},
 			wantErr: false,
 		},
 		{
-			name: "approvalrequest without namespace should fail",
+			name: "clusterapprovalrequest with namespace should fail",
+			kind: fleetcmd.KindClusterApprovalRequest,
 			opts: approveOptions{
-				kind: kindApprovalRequest,
+				name:      "test-name",
+				namespace: "some-namespace",
+			},
+			wantErr:    true,
+			wantErrMsg: "does not accept a namespace",
+		},
+		{
+			name: "approvalrequest without namespace should fail",
+			kind: fleetcmd.KindApprovalRequest,
+			opts: approveOptions{
 				name: "test-name",
 			},
 			wantErr:    true,
-			wantErrMsg: "namespace is required for approvalrequest resources",
+			wantErrMsg: "namespace is required for",
 		},
 		{
 			name: "approvalrequest with namespace is valid",
+			kind: fleetcmd.KindApprovalRequest,
 			opts: approveOptions{
-				kind:      kindApprovalRequest,
 				name:      "test-name",
 				namespace: "test-namespace",
 			},
@@ -159,7 +108,16 @@ func TestValidate(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			err := tc.opts.validate()
+			cfg, err := fleetcmd.ResolveKind(tc.kind, approveKinds)
+			if err != nil {
+				if tc.wantErr && strings.Contains(err.Error(), tc.wantErrMsg) {
+					return
+				}
+				t.Errorf("ResolveKind(%q) = %v, want nil", tc.kind, err)
+				return
+			}
+
+			err = tc.opts.validate(cfg)
 
 			if tc.wantErr {
 				if err == nil {
@@ -186,7 +144,6 @@ func TestApproveClusterApprovalRequest(t *testing.T) {
 
 	tests := []struct {
 		name                       string
-		kind                       string
 		requestName                string
 		existingClusterApprovalReq *placementv1beta1.ClusterApprovalRequest
 		wantCondition              *metav1.Condition
@@ -195,7 +152,6 @@ func TestApproveClusterApprovalRequest(t *testing.T) {
 	}{
 		{
 			name:        "successfully approve ClusterApprovalRequest",
-			kind:        kindClusterApprovalRequest,
 			requestName: "test-approval",
 			existingClusterApprovalReq: &placementv1beta1.ClusterApprovalRequest{
 				ObjectMeta: metav1.ObjectMeta{
@@ -214,28 +170,7 @@ func TestApproveClusterApprovalRequest(t *testing.T) {
 			wantErr:       false,
 		},
 		{
-			name:        "approve ClusterApprovalRequest using careq alias",
-			kind:        kindClusterApprovalRequest,
-			requestName: "test-approval-alias",
-			existingClusterApprovalReq: &placementv1beta1.ClusterApprovalRequest{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:       "test-approval-alias",
-					Generation: 1,
-				},
-				Spec: placementv1beta1.ApprovalRequestSpec{
-					TargetUpdateRun: "test-update-run",
-					TargetStage:     "test-stage",
-				},
-				Status: placementv1beta1.ApprovalRequestStatus{
-					Conditions: []metav1.Condition{},
-				},
-			},
-			wantCondition: &wantCondition,
-			wantErr:       false,
-		},
-		{
 			name:        "approve ClusterApprovalRequest with existing conditions",
-			kind:        kindClusterApprovalRequest,
 			requestName: "test-approval-existing",
 			existingClusterApprovalReq: &placementv1beta1.ClusterApprovalRequest{
 				ObjectMeta: metav1.ObjectMeta{
@@ -261,7 +196,6 @@ func TestApproveClusterApprovalRequest(t *testing.T) {
 		},
 		{
 			name:        "update existing Approved condition",
-			kind:        kindClusterApprovalRequest,
 			requestName: "test-approval-update",
 			existingClusterApprovalReq: &placementv1beta1.ClusterApprovalRequest{
 				ObjectMeta: metav1.ObjectMeta{
@@ -288,7 +222,6 @@ func TestApproveClusterApprovalRequest(t *testing.T) {
 		},
 		{
 			name:                       "ClusterApprovalRequest not found",
-			kind:                       kindClusterApprovalRequest,
 			requestName:                "non-existent-approval",
 			existingClusterApprovalReq: nil,
 			wantErr:                    true,
@@ -311,7 +244,6 @@ func TestApproveClusterApprovalRequest(t *testing.T) {
 				Build()
 
 			o := &approveOptions{
-				kind:      tc.kind,
 				name:      tc.requestName,
 				hubClient: fakeClient,
 			}
@@ -359,7 +291,6 @@ func TestApproveApprovalRequest(t *testing.T) {
 
 	tests := []struct {
 		name                string
-		kind                string
 		requestName         string
 		namespace           string
 		existingApprovalReq *placementv1beta1.ApprovalRequest
@@ -369,7 +300,6 @@ func TestApproveApprovalRequest(t *testing.T) {
 	}{
 		{
 			name:        "successfully approve ApprovalRequest",
-			kind:        kindApprovalRequest,
 			requestName: "test-approval",
 			namespace:   "test-namespace",
 			existingApprovalReq: &placementv1beta1.ApprovalRequest{
@@ -390,30 +320,7 @@ func TestApproveApprovalRequest(t *testing.T) {
 			wantErr:       false,
 		},
 		{
-			name:        "approve ApprovalRequest using areq alias",
-			kind:        kindApprovalRequest,
-			requestName: "test-approval-alias",
-			namespace:   "test-namespace",
-			existingApprovalReq: &placementv1beta1.ApprovalRequest{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:       "test-approval-alias",
-					Namespace:  "test-namespace",
-					Generation: 1,
-				},
-				Spec: placementv1beta1.ApprovalRequestSpec{
-					TargetUpdateRun: "test-update-run",
-					TargetStage:     "test-stage",
-				},
-				Status: placementv1beta1.ApprovalRequestStatus{
-					Conditions: []metav1.Condition{},
-				},
-			},
-			wantCondition: &wantCondition,
-			wantErr:       false,
-		},
-		{
 			name:        "approve ApprovalRequest with existing conditions",
-			kind:        kindApprovalRequest,
 			requestName: "test-approval-existing",
 			namespace:   "test-namespace",
 			existingApprovalReq: &placementv1beta1.ApprovalRequest{
@@ -441,7 +348,6 @@ func TestApproveApprovalRequest(t *testing.T) {
 		},
 		{
 			name:        "update existing Approved condition",
-			kind:        kindApprovalRequest,
 			requestName: "test-approval-update",
 			namespace:   "test-namespace",
 			existingApprovalReq: &placementv1beta1.ApprovalRequest{
@@ -470,7 +376,6 @@ func TestApproveApprovalRequest(t *testing.T) {
 		},
 		{
 			name:                "ApprovalRequest not found",
-			kind:                kindApprovalRequest,
 			requestName:         "non-existent-approval",
 			namespace:           "test-namespace",
 			existingApprovalReq: nil,
@@ -479,7 +384,6 @@ func TestApproveApprovalRequest(t *testing.T) {
 		},
 		{
 			name:        "ApprovalRequest in wrong namespace not found",
-			kind:        kindApprovalRequest,
 			requestName: "test-approval",
 			namespace:   "wrong-namespace",
 			existingApprovalReq: &placementv1beta1.ApprovalRequest{
@@ -513,7 +417,6 @@ func TestApproveApprovalRequest(t *testing.T) {
 				Build()
 
 			o := &approveOptions{
-				kind:      tc.kind,
 				name:      tc.requestName,
 				namespace: tc.namespace,
 				hubClient: fakeClient,
@@ -579,7 +482,7 @@ func TestRun(t *testing.T) {
 	}{
 		{
 			name:        "run dispatches to ClusterApprovalRequest",
-			kind:        kindClusterApprovalRequest,
+			kind:        fleetcmd.KindClusterApprovalRequest,
 			requestName: "test-approval",
 			existingClusterApprovalReq: &placementv1beta1.ClusterApprovalRequest{
 				ObjectMeta: metav1.ObjectMeta{
@@ -596,7 +499,7 @@ func TestRun(t *testing.T) {
 		},
 		{
 			name:        "run dispatches to ApprovalRequest",
-			kind:        kindApprovalRequest,
+			kind:        fleetcmd.KindApprovalRequest,
 			requestName: "test-approval",
 			namespace:   "test-namespace",
 			existingApprovalReq: &placementv1beta1.ApprovalRequest{
@@ -639,13 +542,21 @@ func TestRun(t *testing.T) {
 				WithStatusSubresource(&placementv1beta1.ClusterApprovalRequest{}, &placementv1beta1.ApprovalRequest{}).
 				Build()
 
+			cfg, err := fleetcmd.ResolveKind(tc.kind, approveKinds)
+			if err != nil {
+				if tc.wantErr && strings.Contains(err.Error(), tc.wantErrMsg) {
+					return
+				}
+				t.Errorf("ResolveKind(%q) = %v, want nil", tc.kind, err)
+				return
+			}
+
 			o := &approveOptions{
-				kind:      tc.kind,
 				name:      tc.requestName,
 				namespace: tc.namespace,
 				hubClient: fakeClient,
 			}
-			err := o.run(context.Background())
+			err = o.run(context.Background(), cfg)
 
 			if tc.wantErr {
 				if err == nil {
@@ -662,7 +573,7 @@ func TestRun(t *testing.T) {
 			}
 
 			// Verify the resource was updated correctly based on kind.
-			if tc.kind == kindClusterApprovalRequest {
+			if tc.kind == fleetcmd.KindClusterApprovalRequest {
 				var updatedCAR placementv1beta1.ClusterApprovalRequest
 				err = fakeClient.Get(context.Background(), client.ObjectKey{Name: tc.requestName}, &updatedCAR)
 				if err != nil {
@@ -674,7 +585,7 @@ func TestRun(t *testing.T) {
 					cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime", "ObservedGeneration")); diff != "" {
 					t.Errorf("condition mismatch (-want +got):\n%s", diff)
 				}
-			} else if tc.kind == kindApprovalRequest {
+			} else if tc.kind == fleetcmd.KindApprovalRequest {
 				var updatedAR placementv1beta1.ApprovalRequest
 				err = fakeClient.Get(context.Background(), client.ObjectKey{Name: tc.requestName, Namespace: tc.namespace}, &updatedAR)
 				if err != nil {

--- a/tools/fleet/cmd/types.go
+++ b/tools/fleet/cmd/types.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2025 The KubeFleet Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Canonical kind names for approval requests.
+const (
+	KindClusterApprovalRequest = "clusterapprovalrequest"
+	KindApprovalRequest        = "approvalrequest"
+)
+
+// Aliases for approval request kinds.
+const (
+	AliasClusterApprovalRequest = "careq"
+	AliasApprovalRequest        = "areq"
+)
+
+// KindConfig defines the configuration for a resource kind.
+// This allows commands to handle multiple resource kinds with different
+// validation rules and handlers without using switch statements.
+type KindConfig struct {
+	// Canonical is the canonical name of the kind (e.g., "clusterapprovalrequest").
+	Canonical string
+	// Aliases are short aliases for the kind (e.g., "careq").
+	Aliases []string
+}
+
+// ResolveKind resolves a kind string (canonical or alias) to its value from the provided map.
+// The lookup is case-insensitive.
+func ResolveKind[T any](kind string, kinds map[string]*T) (*T, error) {
+	if kind == "" {
+		return nil, fmt.Errorf("resource kind is required")
+	}
+	lower := strings.ToLower(kind)
+	cfg, ok := kinds[lower]
+	if !ok {
+		return nil, fmt.Errorf("unsupported resource kind %q", kind)
+	}
+	return cfg, nil
+}


### PR DESCRIPTION
### Description of your changes

Fixes #564

I have: add support for approval requests (namespace-scope) for staged update run.

- [x] Associated this change with a known KubeFleet Issue (Bug, Feature, etc).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

Locally:

<img width="1538" height="107" alt="image" src="https://github.com/user-attachments/assets/d6e18f96-ea5f-4a6e-b643-99cd72cbe88b" />



### Special notes for your reviewer

Examples:

```bash
britaniar@britaniaPC:~/projects/kubefleet$ KUBECONFIG=$HOME/.kube/config kubectl fleet approve approvalrequest --hubClusterContext kind-hub --name example-run-after-canary --namespace application-1
2026/04/03 13:55:16 ApprovalRequest "example-run-after-canary" in namespace "application-1" approved successfully
britaniar@britaniaPC:~/projects/kubefleet$ kubectl get sur example-run -n application-1 -o yaml
apiVersion: placement.kubernetes-fleet.io/v1
kind: StagedUpdateRun
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"placement.kubernetes-fleet.io/v1","kind":"StagedUpdateRun","metadata":{"annotations":{},"name":"example-run","namespace":"application-1"},"spec":{"placementName":"rp-1","stagedRolloutStrategyName":"sus-1","state":"Run"}}
  creationTimestamp: "2026-04-03T20:52:39Z"
  finalizers:
  - kubernetes-fleet.io/stagedupdaterun-finalizer
  generation: 3
  name: example-run
  namespace: application-1
  resourceVersion: "4832"
  uid: b700a366-086b-45f3-b0f8-ab0c748fc3ef
spec:
  placementName: rp-1
  resourceSnapshotIndex: ""
  stagedRolloutStrategyName: sus-1
  state: Run
status:
  appliedStrategy:
    comparisonOption: PartialComparison
    type: ClientSideApply
    whenToApply: Always
    whenToTakeOver: Always
  conditions:
  - lastTransitionTime: "2026-04-03T20:52:39Z"
    message: The UpdateRun initialized successfully
    observedGeneration: 3
    reason: UpdateRunInitializedSuccessfully
    status: "True"
    type: Initialized
  - lastTransitionTime: "2026-04-03T20:55:16Z"
    message: The updateRun is waiting for before-stage tasks in stage prod to complete
    observedGeneration: 3
    reason: UpdateRunWaiting
    status: "False"
    type: Progressing
  deletionStageStatus:
    clusters: []
    stageName: kubernetes-fleet.io/deleteStage
  policyObservedClusterCount: 3
  policySnapshotIndexUsed: "0"
  resourceSnapshotIndexUsed: "0"
  stagedUpdateStrategySnapshot:
    stages:
    - afterStageTasks:
      - type: Approval
      - type: TimedWait
        waitTime: 5s
      labelSelector:
        matchLabels:
          env: canary
      maxConcurrency: 1
      name: canary
    - beforeStageTasks:
      - type: Approval
      labelSelector:
        matchLabels:
          env: prod
      maxConcurrency: 1
      name: prod
  stagesStatus:
  - afterStageTaskStatus:
    - approvalRequestName: example-run-after-canary
      conditions:
      - lastTransitionTime: "2026-04-03T20:54:11Z"
        message: ApprovalRequest object is created
        observedGeneration: 3
        reason: StageTaskApprovalRequestCreated
        status: "True"
        type: ApprovalRequestCreated
      - lastTransitionTime: "2026-04-03T20:55:16Z"
        message: ApprovalRequest object is approved
        observedGeneration: 3
        reason: StageTaskApprovalRequestApproved
        status: "True"
        type: ApprovalRequestApproved
      type: Approval
    - conditions:
      - lastTransitionTime: "2026-04-03T20:54:16Z"
        message: Wait time elapsed
        observedGeneration: 3
        reason: AfterStageTaskWaitTimeElapsed
        status: "True"
        type: WaitTimeElapsed
      type: TimedWait
    clusters:
    - clusterName: kind-cluster-2
      conditions:
      - lastTransitionTime: "2026-04-03T20:53:56Z"
        message: Cluster update completed successfully
        observedGeneration: 3
        reason: ClusterUpdatingSucceeded
        status: "True"
        type: Succeeded
      - lastTransitionTime: "2026-04-03T20:53:56Z"
        message: Cluster update started
        observedGeneration: 3
        reason: ClusterUpdatingStarted
        status: "True"
        type: Started
    conditions:
    - lastTransitionTime: "2026-04-03T20:54:11Z"
      message: All clusters in the stage are updated and after-stage tasks are completed
      observedGeneration: 3
      reason: StageUpdatingSucceeded
      status: "False"
      type: Progressing
    - lastTransitionTime: "2026-04-03T20:55:16Z"
      message: Stage update completed successfully
      observedGeneration: 3
      reason: StageUpdatingSucceeded
      status: "True"
      type: Succeeded
    endTime: "2026-04-03T20:55:16Z"
    stageName: canary
    startTime: "2026-04-03T20:53:56Z"
  - beforeStageTaskStatus:
    - approvalRequestName: example-run-before-prod
      conditions:
      - lastTransitionTime: "2026-04-03T20:55:16Z"
        message: ApprovalRequest object is created
        observedGeneration: 3
        reason: StageTaskApprovalRequestCreated
        status: "True"
        type: ApprovalRequestCreated
      type: Approval
    clusters:
    - clusterName: kind-cluster-1
    - clusterName: kind-cluster-3
    conditions:
    - lastTransitionTime: "2026-04-03T20:55:16Z"
      message: Not all before-stage tasks are completed, waiting for approval
      observedGeneration: 3
      reason: StageUpdatingWaiting
      status: "False"
      type: Progressing
    stageName: prod
```
