### PR TITLE
fix: refresh binding status when work is first observed with reported status

### DIFF
--- a/pkg/controllers/workgenerator/controller.go
+++ b/pkg/controllers/workgenerator/controller.go
@@ -1470,7 +1470,7 @@ func extractDiffedResourcePlacementsFromWork(work *fleetv1beta1.Work) []fleetv1b
 }
 
 // SetupWithManagerForClusterResourceBinding sets up the controller with the Manager.
-// It watches clusterResourceBinding events and also update/delete events for work.
+// It watches clusterResourceBinding events and also create/update/delete events for work.
 func (r *Reconciler) SetupWithManagerForClusterResourceBinding(mgr controllerruntime.Manager) error {
 	r.recorder = mgr.GetEventRecorderFor("cluster resource binding work generator")
 	return controllerruntime.NewControllerManagedBy(mgr).Named("cluster-resource-binding-work-generator").
@@ -1481,7 +1481,7 @@ func (r *Reconciler) SetupWithManagerForClusterResourceBinding(mgr controllerrun
 }
 
 // SetupWithManagerForResourceBinding sets up the controller with the Manager.
-// It watches resourceBinding events and also update/delete events for work.
+// It watches resourceBinding events and also create/update/delete events for work.
 func (r *Reconciler) SetupWithManagerForResourceBinding(mgr controllerruntime.Manager) error {
 	r.recorder = mgr.GetEventRecorderFor("resource binding work generator")
 	return controllerruntime.NewControllerManagedBy(mgr).Named("resource-binding-work-generator").
@@ -1498,8 +1498,48 @@ func shouldIgnoreWork(enqueueCRB bool, parentNamespaceName string) bool {
 	return false
 }
 
+func hasReportedWorkStatus(work *fleetv1beta1.Work) bool {
+	return len(work.Status.Conditions) > 0 || len(work.Status.ManifestConditions) > 0
+}
+
 func workHandlerFuncs(enqueueCRB bool) handler.Funcs {
 	return handler.Funcs{
+		// we care about work create event as the cache may first observe a work object after the
+		// member side has already updated its status; in that case we still need to refresh the
+		// corresponding binding status.
+		CreateFunc: func(ctx context.Context, evt event.CreateEvent, queue workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+			if evt.Object == nil {
+				klog.ErrorS(controller.NewUnexpectedBehaviorError(fmt.Errorf("createEvent %v received with no metadata", evt)),
+					"Failed to process a create event for work object")
+				return
+			}
+			work, ok := evt.Object.(*fleetv1beta1.Work)
+			if !ok {
+				klog.ErrorS(controller.NewUnexpectedBehaviorError(fmt.Errorf("received object %T not a work object", evt.Object)),
+					"Failed to process a create event for work object")
+				return
+			}
+			parentNamespaceName := evt.Object.GetLabels()[fleetv1beta1.ParentNamespaceLabel]
+			if shouldIgnoreWork(enqueueCRB, parentNamespaceName) {
+				klog.V(2).InfoS("Ignoring the work owned by different placement scope", "work", klog.KObj(evt.Object), "parentNamespaceName", parentNamespaceName, "enqueueCRP", enqueueCRB)
+				return
+			}
+			if !hasReportedWorkStatus(work) {
+				klog.V(5).InfoS("Ignoring the work create event as the work has no reported status yet", "work", klog.KObj(work))
+				return
+			}
+			parentBindingName, exist := evt.Object.GetLabels()[fleetv1beta1.ParentBindingLabel]
+			if !exist {
+				klog.ErrorS(controller.NewUnexpectedBehaviorError(fmt.Errorf("created work has no binding parent")),
+					"Could not find the parent binding label", "created work", evt.Object, "existing label", evt.Object.GetLabels())
+				return
+			}
+			klog.V(2).InfoS("Received a work create event", "work", klog.KObj(evt.Object), "parentBindingName", parentBindingName, "parentNamespaceName", parentNamespaceName)
+			queue.Add(reconcile.Request{NamespacedName: types.NamespacedName{
+				Name:      parentBindingName,
+				Namespace: parentNamespaceName,
+			}})
+		},
 		// we care about work delete event as we want to know when a work is deleted so that we can
 		// delete the corresponding resource binding fast.
 		DeleteFunc: func(ctx context.Context, evt event.DeleteEvent, queue workqueue.TypedRateLimitingInterface[reconcile.Request]) {

--- a/pkg/controllers/workgenerator/controller_test.go
+++ b/pkg/controllers/workgenerator/controller_test.go
@@ -31,10 +31,15 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllertest"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	fleetv1beta1 "github.com/kubefleet-dev/kubefleet/apis/placement/v1beta1"
 	"github.com/kubefleet-dev/kubefleet/pkg/utils"
@@ -50,6 +55,136 @@ var statusCmpOptions = []cmp.Option{
 		// we're within the margin (1s) if x + margin >= y
 		return !t1.Time.Add(1 * time.Second).Before(t2.Time)
 	}),
+}
+
+func TestWorkHandlerCreateFunc(t *testing.T) {
+	tests := map[string]struct {
+		enqueueCRB      bool
+		work            *fleetv1beta1.Work
+		wantEnqueueKeys []reconcile.Request
+	}{
+		"enqueue a cluster-scoped work for a cluster resource binding": {
+			enqueueCRB: true,
+			work: &fleetv1beta1.Work{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster-work",
+					Labels: map[string]string{
+						fleetv1beta1.ParentBindingLabel: "cluster-binding",
+					},
+				},
+				Status: fleetv1beta1.WorkStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   fleetv1beta1.WorkConditionTypeApplied,
+							Status: metav1.ConditionTrue,
+						},
+					},
+				},
+			},
+			wantEnqueueKeys: []reconcile.Request{
+				{NamespacedName: types.NamespacedName{Name: "cluster-binding"}},
+			},
+		},
+		"ignore a namespaced work when handling cluster resource bindings": {
+			enqueueCRB: true,
+			work: &fleetv1beta1.Work{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "resource-work",
+					Labels: map[string]string{
+						fleetv1beta1.ParentBindingLabel:   "resource-binding",
+						fleetv1beta1.ParentNamespaceLabel: "app-namespace",
+					},
+				},
+			},
+		},
+		"enqueue a namespaced work for a resource binding": {
+			enqueueCRB: false,
+			work: &fleetv1beta1.Work{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "resource-work",
+					Labels: map[string]string{
+						fleetv1beta1.ParentBindingLabel:   "resource-binding",
+						fleetv1beta1.ParentNamespaceLabel: "app-namespace",
+					},
+				},
+				Status: fleetv1beta1.WorkStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   fleetv1beta1.WorkConditionTypeApplied,
+							Status: metav1.ConditionTrue,
+						},
+					},
+				},
+			},
+			wantEnqueueKeys: []reconcile.Request{
+				{NamespacedName: types.NamespacedName{Name: "resource-binding", Namespace: "app-namespace"}},
+			},
+		},
+		"ignore a cluster-scoped work when handling resource bindings": {
+			enqueueCRB: false,
+			work: &fleetv1beta1.Work{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster-work",
+					Labels: map[string]string{
+						fleetv1beta1.ParentBindingLabel: "cluster-binding",
+					},
+				},
+			},
+		},
+		"ignore a work without a parent binding label": {
+			enqueueCRB: true,
+			work: &fleetv1beta1.Work{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "invalid-work",
+				},
+			},
+		},
+		"ignore a work without reported status": {
+			enqueueCRB: true,
+			work: &fleetv1beta1.Work{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pending-work",
+					Labels: map[string]string{
+						fleetv1beta1.ParentBindingLabel: "cluster-binding",
+					},
+				},
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			queue := &controllertest.Queue{
+				TypedInterface: workqueue.NewTypedRateLimitingQueue[reconcile.Request](
+					workqueue.DefaultTypedItemBasedRateLimiter[reconcile.Request](),
+				),
+			}
+
+			workHandlerFuncs(tt.enqueueCRB).CreateFunc(context.Background(), event.CreateEvent{Object: tt.work}, queue)
+
+			validateEnqueueBehavior(t, queue, tt.wantEnqueueKeys)
+		})
+	}
+}
+
+func validateEnqueueBehavior(t *testing.T, queue *controllertest.Queue, wantEnqueueKeys []reconcile.Request) {
+	var queuedKeys []reconcile.Request
+	for i := 0; i < queue.Len(); i++ {
+		item, _ := queue.Get()
+		queuedKeys = append(queuedKeys, item)
+	}
+
+	cmpOptions := cmp.Options{
+		cmpopts.EquateEmpty(),
+		cmpopts.IgnoreUnexported(reconcile.Request{}),
+		cmpopts.SortSlices(func(r1, r2 reconcile.Request) bool {
+			return r1.String() < r2.String()
+		}),
+	}
+
+	if !cmp.Equal(queuedKeys, wantEnqueueKeys, cmpOptions...) {
+		t.Errorf("queued keys mismatch, want %v, got %v", wantEnqueueKeys, queuedKeys)
+	}
 }
 
 func TestGetWorkNamePrefixFromSnapshotName(t *testing.T) {


### PR DESCRIPTION
### Description of your changes

This PR makes the work generator recover when its cache first observes a `Work` object after the member side has already reported status. In that case the create event now requeues the parent binding so the binding and placement status can be refreshed instead of remaining stuck at `ApplyInProgress`.

To avoid changing the normal fresh-work flow, the create handler only enqueues when the created `Work` already carries reported status.

Fixes #558

I have:

- [x] Associated this change with a known KubeFleet Issue (Bug, Feature, etc).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- `go test ./pkg/controllers/workgenerator -run TestWorkHandlerCreateFunc -count=1`
- `go test ./pkg/controllers/workgenerator -run TestGetWorkNamePrefixFromSnapshotName -count=1`

### Special notes for your reviewer

- The new create-event path is intentionally gated on `Work` objects that already have reported status to avoid regressing the existing `ApplyInProgress` behavior for freshly created works without member-side status yet.