### PR TITLE
fix: pin trivy-action to a specific SHA instead of @master

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -64,7 +64,7 @@ jobs:
           TAG: ${{ env.IMAGE_VERSION }}
 
       - name: Scan ${{ env.REGISTRY }}/${{ env.HUB_AGENT_IMAGE_NAME }}:${{ env.IMAGE_VERSION }}
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.HUB_AGENT_IMAGE_NAME }}:${{ env.IMAGE_VERSION }}
           format: 'table'
@@ -80,7 +80,7 @@ jobs:
 
 
       - name: Scan ${{ env.REGISTRY }}/${{ env.MEMBER_AGENT_IMAGE_NAME }}:${{ env.IMAGE_VERSION }}
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.MEMBER_AGENT_IMAGE_NAME }}:${{ env.IMAGE_VERSION }}
           format: 'table'
@@ -95,7 +95,7 @@ jobs:
           TRIVY_DB_REPOSITORY: mcr.microsoft.com/mirror/ghcr/aquasecurity/trivy-db 
 
       - name: Scan ${{ env.REGISTRY }}/${{ env.REFRESH_TOKEN_IMAGE_NAME }}:${{ env.IMAGE_VERSION }}
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.REFRESH_TOKEN_IMAGE_NAME }}:${{ env.IMAGE_VERSION }}
           format: 'table'


### PR DESCRIPTION
### Description of your changes

This PR replaces the floating `aquasecurity/trivy-action@master` references in the Trivy workflow with the published `v0.35.0` commit SHA. This aligns the workflow with the repository's existing pattern of pinning third-party GitHub Actions to immutable revisions.

Fixes #495

I have:

- [x] Associated this change with a known KubeFleet Issue (Bug, Feature, etc).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- Parsed `.github/workflows/trivy.yml` locally with Ruby's YAML parser
- `git diff --check`

### Special notes for your reviewer

- The Trivy action is pinned to the currently published `v0.35.0` tag commit: `57a97c7e7821a5776cebc9bb87c984fa69cba8f1`.