### PR TITLE
docs: add release guide and align chart publishing

### DIFF
--- a/.github/.copilot/breadcrumbs/2026-04-06-0033-release-process-doc.md
+++ b/.github/.copilot/breadcrumbs/2026-04-06-0033-release-process-doc.md
@@ -15,14 +15,15 @@
 1. Add a new top-level `RELEASE.md` instead of hiding the runbook inside chart consumer docs.
 2. Keep `CONTRIBUTING.md` lightweight and add a short pointer to `RELEASE.md`.
 3. Document the workflow-derived chart versioning explicitly so maintainers do not edit `Chart.yaml` only to cut a release.
-4. Treat the GitHub release page as the trigger point, while clarifying that the actual shipped artifacts live in GHCR and the chart repositories.
+4. Treat the semver tag as the actual automation trigger; the GitHub release page is the normal way to create that tag.
+5. Fix `chart.yml` so manual dispatch checks out the tagged ref and the `gh-pages` publication path uses tag-derived chart metadata too.
 
 ## Implementation Notes
 
 - `RELEASE.md` is grounded in `.github/workflows/release.yml`, `.github/workflows/chart.yml`, `.github/workflows/setup-release.yml`, and the `push` / `helm-push` Make targets.
+- `.github/workflows/chart.yml` is updated so both publication paths use the tagged ref, and the `gh-pages` publication path rewrites chart metadata to the release version before packaging.
 - The guide documents verification of:
   - GitHub release visibility
   - GHCR image tags with and without the `v` prefix
   - OCI Helm chart version and appVersion
   - GitHub Pages chart publication
-

--- a/.github/.copilot/breadcrumbs/2026-04-06-0033-release-process-doc.md
+++ b/.github/.copilot/breadcrumbs/2026-04-06-0033-release-process-doc.md
@@ -1,0 +1,28 @@
+# Release Process Documentation
+
+**Date**: April 6, 2026 00:33 IST  
+**Task**: Document the maintainer release process for KubeFleet and link it from the contribution guide.
+
+## Requirements
+
+1. Add maintainer-facing release documentation for issue `#536`.
+2. Base the instructions on the existing tag-driven GitHub Actions workflows.
+3. Explain the tag format, published artifacts, rerun path, and post-release verification.
+4. Make the documentation discoverable from `CONTRIBUTING.md`.
+
+## Decisions
+
+1. Add a new top-level `RELEASE.md` instead of hiding the runbook inside chart consumer docs.
+2. Keep `CONTRIBUTING.md` lightweight and add a short pointer to `RELEASE.md`.
+3. Document the workflow-derived chart versioning explicitly so maintainers do not edit `Chart.yaml` only to cut a release.
+4. Treat the GitHub release page as the trigger point, while clarifying that the actual shipped artifacts live in GHCR and the chart repositories.
+
+## Implementation Notes
+
+- `RELEASE.md` is grounded in `.github/workflows/release.yml`, `.github/workflows/chart.yml`, `.github/workflows/setup-release.yml`, and the `push` / `helm-push` Make targets.
+- The guide documents verification of:
+  - GitHub release visibility
+  - GHCR image tags with and without the `v` prefix
+  - OCI Helm chart version and appVersion
+  - GitHub Pages chart publication
+

--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -29,8 +29,22 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
         with:
+          ref: ${{ needs.export-registry.outputs.tag }}
           submodules: true
           fetch-depth: 0
+      - name: Prepare release chart metadata
+        run: |
+          set -euo pipefail
+
+          RELEASE_TAG="${{ needs.export-registry.outputs.tag }}"
+          CHART_VERSION="${{ needs.export-registry.outputs.version }}"
+
+          for chart in hub-agent member-agent; do
+            chart_file="charts/${chart}/Chart.yaml"
+            sed -i.bak -E "s/^version: .*/version: ${CHART_VERSION}/" "${chart_file}"
+            sed -i.bak -E "s/^appVersion: .*/appVersion: \"${RELEASE_TAG}\"/" "${chart_file}"
+            rm -f "${chart_file}.bak"
+          done
       - name: Publish Helm chart to GitHub Pages
         uses: stefanprodan/helm-gh-pages@v1.7.0
         with:
@@ -45,6 +59,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ needs.export-registry.outputs.tag }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3.6.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,10 @@ The KubeFleet project has adopted the CNCF Code of Conduct. Refer to our [Commun
 2. Fork the desired repository, then develop and test your code changes.
 3. Submit a pull request.
 
+## Releasing KubeFleet
+
+Project maintainers can follow the [release guide](RELEASE.md) to publish a GitHub release and verify the published images and Helm charts.
+
 ## Issue and pull request management
 
 Anyone can comment on issues and submit reviews for pull requests. In order to be assigned an issue or pull request, you can leave a `/assign <your Github ID>` comment on the issue or pull request.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,10 +11,12 @@ Publishing a GitHub release with a semver tag publishes all of the following art
   - `ghcr.io/kubefleet-dev/kubefleet/hub-agent`
   - `ghcr.io/kubefleet-dev/kubefleet/member-agent`
   - `ghcr.io/kubefleet-dev/kubefleet/refresh-token`
-- Helm charts in both GHCR and GitHub Pages:
+- Helm charts in GHCR as OCI artifacts:
   - `oci://ghcr.io/kubefleet-dev/kubefleet/charts/hub-agent`
   - `oci://ghcr.io/kubefleet-dev/kubefleet/charts/member-agent`
-  - `https://kubefleet-dev.github.io/kubefleet/charts`
+- Helm chart repository content on the `gh-pages` branch under `charts/`
+
+If GitHub Pages is enabled for the repository's `gh-pages` branch, the traditional Helm repository is served from `https://kubefleet-dev.github.io/kubefleet/charts`.
 
 The release automation is defined in:
 
@@ -29,6 +31,7 @@ The release automation is defined in:
 - The commit you want to release is already merged and validated on `main` or the relevant `release-*` maintenance branch.
 - The required GitHub Actions workflows are green for the commit you intend to tag.
 - If you are using the CLI flow, `gh` is installed and authenticated.
+- If you want the traditional Helm repository URL to be publicly reachable, GitHub Pages must be enabled for the repository's `gh-pages` branch.
 
 ## Tag and Version Rules
 
@@ -41,7 +44,7 @@ The release automation is defined in:
   - `version: 0.2.3`
   - `appVersion: v0.2.3`
 
-Do not edit `charts/*/Chart.yaml` only to cut a release. The chart workflow injects the release `version` and `appVersion` during packaging, so the tag is the source of truth for published chart versions.
+Do not edit `charts/*/Chart.yaml` only to cut a release. The chart workflow prepares the release metadata from the tag before publishing OCI charts and the `gh-pages` chart repository content, so the tag is the source of truth for published chart versions.
 
 ## Create the GitHub Release
 
@@ -51,13 +54,15 @@ Create the release from the exact commit you want to ship.
 
 ```bash
 TAG=v0.2.3
-TARGET=origin/main
+TARGET_SHA=<full commit sha>
 
 gh release create "${TAG}" \
-  --target "${TARGET}" \
+  --target "${TARGET_SHA}" \
   --title "${TAG}" \
   --generate-notes
 ```
+
+Prefer using a full commit SHA so the release is pinned to the exact revision you intend to ship. If you intentionally want the current branch tip instead, pass the GitHub branch name such as `main` or `release-0.2`.
 
 For a prerelease, add `--prerelease`.
 
@@ -70,7 +75,7 @@ For a prerelease, add `--prerelease`.
 5. Mark the release as a prerelease if needed.
 6. Publish the release.
 
-Publishing the release creates or publishes the tag, which triggers the release automation.
+The release automation is triggered by creating and pushing the semver tag. Publishing a GitHub release usually does that as part of the release flow when you create a new tag from the UI or CLI. Publishing or editing a release page for an already-existing tag does not trigger the workflows again by itself.
 
 ## What the Automation Does
 
@@ -88,11 +93,13 @@ Publishing the release creates or publishes the tag, which triggers the release 
 `.github/workflows/chart.yml`:
 
 - validates the same tag via `.github/workflows/setup-release.yml`
+- checks out the tagged ref for both publication paths
+- prepares the chart metadata from the release tag before publishing
 - packages `charts/hub-agent` and `charts/member-agent`
 - sets chart `version` to `${TAG#v}`
 - sets chart `appVersion` to `${TAG}`
 - publishes the charts to GHCR as OCI artifacts
-- updates the GitHub Pages chart repository
+- updates the `gh-pages` chart repository content
 - verifies that the packaged chart `appVersion` matches the release tag
 
 The GitHub release page itself does not need binary assets attached to it; the release artifacts are the published images and charts above.
@@ -104,7 +111,9 @@ After publishing the release, watch these workflows in GitHub Actions:
 - `Release Images`
 - `Helm Chart Publisher`
 
-Both workflows also support `workflow_dispatch` with a `tag` input. Use that to rerun the release jobs for an existing tag when the tagged commit is already correct and you only need to retry the automation.
+Prefer rerunning the original tag-triggered workflow run from GitHub Actions when a release job needs to be retried.
+
+Both workflows also expose `workflow_dispatch` with a `tag` input. Because both workflows check out the tagged ref, a manual dispatch can safely rebuild the release artifacts for an existing tag when the tagged commit is already correct and you only need to retry the automation.
 
 If the tagged commit itself is wrong, do not force-move the release tag after artifacts have already been published. Fix the issue on a new commit and cut a new release tag instead.
 
@@ -148,7 +157,19 @@ Verify that the output reports:
 - `version: ${VERSION}`
 - `appVersion: ${TAG}`
 
-### 4. Verify the GitHub Pages Helm Repository
+### 4. Verify the `gh-pages` Chart Repository Content
+
+First verify that the `gh-pages` branch contains the expected chart metadata:
+
+```bash
+curl -sSfL https://raw.githubusercontent.com/kubefleet-dev/kubefleet/gh-pages/charts/index.yaml
+```
+
+Confirm that the new chart version appears in the generated index.
+
+### 5. Verify the Traditional Helm Repository URL
+
+If GitHub Pages is enabled for the repository, verify the public Helm repository endpoint:
 
 ```bash
 helm repo add kubefleet https://kubefleet-dev.github.io/kubefleet/charts
@@ -167,5 +188,5 @@ Confirm that the new chart version is visible for both `hub-agent` and `member-a
 - GHCR image tags exist with and without the `v` prefix.
 - OCI charts exist at version `${TAG#v}`.
 - Chart `appVersion` matches the full tag `${TAG}`.
-- The GitHub Pages chart repository shows the new chart version.
-
+- The `gh-pages` branch index shows the new chart version.
+- If GitHub Pages is enabled, the public Helm repository shows the new chart version.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,171 @@
+# KubeFleet Release Process
+
+This document describes how KubeFleet maintainers publish a release from the `kubefleet-dev/kubefleet` repository.
+
+## What a Release Publishes
+
+Publishing a GitHub release with a semver tag publishes all of the following artifacts from the same tagged commit:
+
+- A GitHub release page for the tag, for example `v0.2.2`
+- Container images in GitHub Container Registry (GHCR):
+  - `ghcr.io/kubefleet-dev/kubefleet/hub-agent`
+  - `ghcr.io/kubefleet-dev/kubefleet/member-agent`
+  - `ghcr.io/kubefleet-dev/kubefleet/refresh-token`
+- Helm charts in both GHCR and GitHub Pages:
+  - `oci://ghcr.io/kubefleet-dev/kubefleet/charts/hub-agent`
+  - `oci://ghcr.io/kubefleet-dev/kubefleet/charts/member-agent`
+  - `https://kubefleet-dev.github.io/kubefleet/charts`
+
+The release automation is defined in:
+
+- `.github/workflows/release.yml`
+- `.github/workflows/chart.yml`
+- `.github/workflows/setup-release.yml`
+
+## Prerequisites
+
+- You have permission to create releases and tags in `kubefleet-dev/kubefleet`.
+- You have permission to publish packages to the repository's GHCR namespace.
+- The commit you want to release is already merged and validated on `main` or the relevant `release-*` maintenance branch.
+- The required GitHub Actions workflows are green for the commit you intend to tag.
+- If you are using the CLI flow, `gh` is installed and authenticated.
+
+## Tag and Version Rules
+
+- Release tags must begin with `v` and use semantic versioning, for example `v0.2.3`.
+- The workflows derive the chart version by stripping the leading `v`, so `v0.2.3` becomes chart version `0.2.3`.
+- The release image workflow publishes image tags both with and without the `v` prefix:
+  - `ghcr.io/kubefleet-dev/kubefleet/hub-agent:v0.2.3`
+  - `ghcr.io/kubefleet-dev/kubefleet/hub-agent:0.2.3`
+- The chart publishing workflow packages the charts with:
+  - `version: 0.2.3`
+  - `appVersion: v0.2.3`
+
+Do not edit `charts/*/Chart.yaml` only to cut a release. The chart workflow injects the release `version` and `appVersion` during packaging, so the tag is the source of truth for published chart versions.
+
+## Create the GitHub Release
+
+Create the release from the exact commit you want to ship.
+
+### Option 1: GitHub CLI
+
+```bash
+TAG=v0.2.3
+TARGET=origin/main
+
+gh release create "${TAG}" \
+  --target "${TARGET}" \
+  --title "${TAG}" \
+  --generate-notes
+```
+
+For a prerelease, add `--prerelease`.
+
+### Option 2: GitHub UI
+
+1. Open the repository's Releases page.
+2. Choose `Draft a new release`.
+3. Create a new tag in the form `vX.Y.Z`, or select an existing one.
+4. Point the release at the exact commit or branch tip you want to publish.
+5. Mark the release as a prerelease if needed.
+6. Publish the release.
+
+Publishing the release creates or publishes the tag, which triggers the release automation.
+
+## What the Automation Does
+
+### Release Images Workflow
+
+`.github/workflows/release.yml`:
+
+- validates the tag via `.github/workflows/setup-release.yml`
+- checks out the tagged ref
+- builds and pushes the `hub-agent`, `member-agent`, and `refresh-token` images
+- publishes image tags with and without the `v` prefix
+
+### Helm Chart Publisher Workflow
+
+`.github/workflows/chart.yml`:
+
+- validates the same tag via `.github/workflows/setup-release.yml`
+- packages `charts/hub-agent` and `charts/member-agent`
+- sets chart `version` to `${TAG#v}`
+- sets chart `appVersion` to `${TAG}`
+- publishes the charts to GHCR as OCI artifacts
+- updates the GitHub Pages chart repository
+- verifies that the packaged chart `appVersion` matches the release tag
+
+The GitHub release page itself does not need binary assets attached to it; the release artifacts are the published images and charts above.
+
+## Monitor the Release
+
+After publishing the release, watch these workflows in GitHub Actions:
+
+- `Release Images`
+- `Helm Chart Publisher`
+
+Both workflows also support `workflow_dispatch` with a `tag` input. Use that to rerun the release jobs for an existing tag when the tagged commit is already correct and you only need to retry the automation.
+
+If the tagged commit itself is wrong, do not force-move the release tag after artifacts have already been published. Fix the issue on a new commit and cut a new release tag instead.
+
+## Verify the Published Artifacts
+
+Once the workflows succeed, verify the release end to end.
+
+### 1. Verify the GitHub Release
+
+- Confirm the release page exists for the tag.
+- Confirm the release notes and prerelease flag are correct.
+
+### 2. Verify the Container Images
+
+Inspect the published image tags:
+
+```bash
+TAG=v0.2.3
+VERSION=${TAG#v}
+
+for image in hub-agent member-agent refresh-token; do
+  docker buildx imagetools inspect "ghcr.io/kubefleet-dev/kubefleet/${image}:${TAG}" >/dev/null
+  docker buildx imagetools inspect "ghcr.io/kubefleet-dev/kubefleet/${image}:${VERSION}" >/dev/null
+done
+```
+
+### 3. Verify the OCI Helm Charts
+
+Check that both charts are available at the expected version and appVersion:
+
+```bash
+TAG=v0.2.3
+VERSION=${TAG#v}
+
+helm show chart "oci://ghcr.io/kubefleet-dev/kubefleet/charts/hub-agent" --version "${VERSION}"
+helm show chart "oci://ghcr.io/kubefleet-dev/kubefleet/charts/member-agent" --version "${VERSION}"
+```
+
+Verify that the output reports:
+
+- `version: ${VERSION}`
+- `appVersion: ${TAG}`
+
+### 4. Verify the GitHub Pages Helm Repository
+
+```bash
+helm repo add kubefleet https://kubefleet-dev.github.io/kubefleet/charts
+helm repo update
+helm search repo kubefleet --versions
+```
+
+Confirm that the new chart version is visible for both `hub-agent` and `member-agent`.
+
+## Release Checklist
+
+- The intended release commit is merged and green.
+- The GitHub release tag uses the `vX.Y.Z` format.
+- `Release Images` succeeded.
+- `Helm Chart Publisher` succeeded.
+- GHCR image tags exist with and without the `v` prefix.
+- OCI charts exist at version `${TAG#v}`.
+- Chart `appVersion` matches the full tag `${TAG}`.
+- The GitHub Pages chart repository shows the new chart version.
+


### PR DESCRIPTION
### Description of your changes

This PR adds a maintainer-facing `RELEASE.md`, links it from `CONTRIBUTING.md`, and aligns the chart publishing workflow with the tagged release path so the documented behavior matches the actual release automation.

Fixes #536

I have:

- [x] Associated this change with a known KubeFleet Issue (Bug, Feature, etc).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- `make reviewable`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/chart.yml"); puts "chart.yml ok"'`
- Simulated the `publish-github-pages` metadata rewrite step on temporary copies of both `Chart.yaml` files to verify the workflow rewrites `version` and `appVersion` to the release values.

### Special notes for your reviewer

- This PR intentionally updates `.github/workflows/chart.yml` in addition to the docs so the release guide matches the tagged release behavior for both OCI charts and the `gh-pages` chart repository content.
- The guide distinguishes between verifying the `gh-pages` branch content and verifying the public GitHub Pages Helm endpoint, which still depends on GitHub Pages being enabled for the repository.
