### PR TITLE
fix: add nil guard for binding map lookup in updaterun execution and stop

### DIFF
--- a/pkg/controllers/updaterun/execution.go
+++ b/pkg/controllers/updaterun/execution.go
@@ -173,7 +173,13 @@ func (r *Reconciler) executeUpdatingStage(
 		}
 		// The cluster needs to be processed.
 		clusterStartedCond := meta.FindStatusCondition(clusterStatus.Conditions, string(placementv1beta1.ClusterUpdatingConditionStarted))
-		binding := toBeUpdatedBindingsMap[clusterStatus.ClusterName]
+		binding, exists := toBeUpdatedBindingsMap[clusterStatus.ClusterName]
+		if !exists || binding == nil {
+			missingBindingErr := controller.NewUnexpectedBehaviorError(fmt.Errorf("the binding for cluster `%s` in stage `%s` is not found in the toBeUpdatedBindings map", clusterStatus.ClusterName, updatingStageStatus.StageName))
+			klog.ErrorS(missingBindingErr, "Cannot find the binding for the cluster in the updating stage", "cluster", clusterStatus.ClusterName, "stage", updatingStageStatus.StageName, "updateRun", updateRunRef)
+			clusterUpdateErrors = append(clusterUpdateErrors, fmt.Errorf("%w: %s", errStagedUpdatedAborted, missingBindingErr.Error()))
+			continue
+		}
 		if !condition.IsConditionStatusTrue(clusterStartedCond, updateRun.GetGeneration()) {
 			// The cluster has not started updating yet.
 			if !isBindingSyncedWithClusterStatus(resourceSnapshotName, updateRun, binding, clusterStatus) {

--- a/pkg/controllers/updaterun/execution_test.go
+++ b/pkg/controllers/updaterun/execution_test.go
@@ -525,6 +525,43 @@ func TestExecuteUpdatingStage_Error(t *testing.T) {
 			wantWaitTime: 0,
 		},
 		{
+			name: "missing binding in map lookup - nil pointer guard",
+			updateRun: &placementv1beta1.ClusterStagedUpdateRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-update-run",
+					Generation: 1,
+				},
+				Spec: placementv1beta1.UpdateRunSpec{
+					PlacementName:         "test-placement",
+					ResourceSnapshotIndex: "1",
+				},
+				Status: placementv1beta1.UpdateRunStatus{
+					StagesStatus: []placementv1beta1.StageUpdatingStatus{
+						{
+							StageName: "test-stage",
+							Clusters: []placementv1beta1.ClusterUpdatingStatus{
+								{
+									ClusterName: "cluster-1",
+								},
+							},
+						},
+					},
+					UpdateStrategySnapshot: &placementv1beta1.UpdateStrategySpec{
+						Stages: []placementv1beta1.StageConfig{
+							{
+								Name:           "test-stage",
+								MaxConcurrency: &intstr.IntOrString{Type: intstr.Int, IntVal: 1},
+							},
+						},
+					},
+				},
+			},
+			bindings:     nil, // No bindings provided, so cluster-1 will not be found in the map.
+			wantErr:      errors.New("the binding for cluster `cluster-1` in stage `test-stage` is not found in the toBeUpdatedBindings map"),
+			wantAbortErr: true,
+			wantWaitTime: 0,
+		},
+		{
 			name: "binding preemption",
 			updateRun: &placementv1beta1.ClusterStagedUpdateRun{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controllers/updaterun/stop.go
+++ b/pkg/controllers/updaterun/stop.go
@@ -92,7 +92,13 @@ func (r *Reconciler) stopUpdatingStage(
 
 		clusterUpdatingCount++
 
-		binding := toBeUpdatedBindingsMap[clusterStatus.ClusterName]
+		binding, exists := toBeUpdatedBindingsMap[clusterStatus.ClusterName]
+		if !exists || binding == nil {
+			missingBindingErr := controller.NewUnexpectedBehaviorError(fmt.Errorf("the binding for cluster `%s` in stage `%s` is not found in the toBeUpdatedBindings map during stopping", clusterStatus.ClusterName, updatingStageStatus.StageName))
+			klog.ErrorS(missingBindingErr, "Cannot find the binding for the cluster in the updating stage during stopping", "cluster", clusterStatus.ClusterName, "stage", updatingStageStatus.StageName, "updateRun", updateRunRef)
+			clusterUpdateErrors = append(clusterUpdateErrors, fmt.Errorf("%w: %s", errStagedUpdatedAborted, missingBindingErr.Error()))
+			continue
+		}
 		finished, updateErr := checkClusterUpdateResult(binding, clusterStatus, updatingStageStatus, updateRun)
 		if updateErr != nil {
 			clusterUpdateErrors = append(clusterUpdateErrors, updateErr)

--- a/pkg/controllers/updaterun/stop_test.go
+++ b/pkg/controllers/updaterun/stop_test.go
@@ -93,6 +93,49 @@ func TestStopUpdatingStage(t *testing.T) {
 			},
 		},
 		{
+			name: "missing binding in map lookup during stopping - nil pointer guard",
+			updateRun: &placementv1beta1.ClusterStagedUpdateRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-update-run",
+					Generation: 1,
+				},
+				Spec: placementv1beta1.UpdateRunSpec{
+					PlacementName:         "test-placement",
+					ResourceSnapshotIndex: "1",
+				},
+				Status: placementv1beta1.UpdateRunStatus{
+					StagesStatus: []placementv1beta1.StageUpdatingStatus{
+						{
+							StageName: "test-stage",
+							Clusters: []placementv1beta1.ClusterUpdatingStatus{
+								{
+									ClusterName: "cluster-1",
+									Conditions: []metav1.Condition{
+										{
+											Type:               string(placementv1beta1.ClusterUpdatingConditionStarted),
+											Status:             metav1.ConditionTrue,
+											ObservedGeneration: 1,
+											Reason:             condition.ClusterUpdatingStartedReason,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			bindings:     nil, // No bindings provided, so cluster-1 will not be found in the map.
+			wantErr:      errors.New("the binding for cluster `cluster-1` in stage `test-stage` is not found in the toBeUpdatedBindings map during stopping"),
+			wantFinished: false,
+			wantWaitTime: 0,
+			wantProgressCond: metav1.Condition{
+				Type:               string(placementv1beta1.StageUpdatingConditionProgressing),
+				Status:             metav1.ConditionUnknown,
+				ObservedGeneration: 1,
+				Reason:             condition.StageUpdatingStoppingReason,
+			},
+		},
+		{
 			name: "binding synced, bound, rolloutStarted true, but binding has failed condition",
 			updateRun: &placementv1beta1.ClusterStagedUpdateRun{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Summary

Fixes #570

- Add nil/existence checks after map lookup of bindings by cluster name in `executeUpdatingStage` and `stopUpdatingStage`
- Return `errStagedUpdatedAborted` when a binding is missing, allowing the controller to abort the stage gracefully instead of panicking with a nil pointer dereference
- Add unit tests covering the missing-binding scenario for both execution and stop paths

## Details

Both `executeUpdatingStage` (execution.go) and `stopUpdatingStage` (stop.go) in the updaterun controller retrieve bindings from a `toBeUpdatedBindingsMap` keyed by cluster name. If a cluster appears in the stage status but its corresponding binding is absent from the map (e.g., due to a race condition between validation and execution, or cache inconsistency), the map lookup returns a nil `BindingObj` interface value. Subsequent method calls on this nil value (`GetBindingSpec()`, `GetCondition()`, etc.) cause a nil pointer dereference panic that crashes the controller.

## Test plan

- [x] Added unit test `missing_binding_in_map_lookup_-_nil_pointer_guard` in `execution_test.go`
- [x] Added unit test `missing_binding_in_map_lookup_during_stopping_-_nil_pointer_guard` in `stop_test.go`
- [x] `go vet ./pkg/controllers/updaterun/...` passes
- [x] `go build ./pkg/controllers/updaterun/...` passes
- [x] All existing unit tests in the package continue to pass