### PR TITLE
feat: pin distroless base image by digest and add Docker Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,13 @@ updates:
     commit-message:
       prefix: "chore"
 
+  - package-ecosystem: "docker"
+    directory: "/docker"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:

--- a/docker/hub-agent.Dockerfile
+++ b/docker/hub-agent.Dockerfile
@@ -23,7 +23,7 @@ RUN CGO_ENABLED=1 GOOS=$GOOS GOARCH=$GOARCH GOEXPERIMENT=systemcrypto GO111MODUL
 
 # Use distroless as minimal base image to package the hubagent binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/base:nonroot
+FROM gcr.io/distroless/base:nonroot@sha256:a696c7c8545ba9b2b2807ee60b8538d049622f0addd85aee8cec3ec1910de1f9
 WORKDIR /
 COPY --from=builder /workspace/hubagent .
 USER 65532:65532

--- a/docker/member-agent.Dockerfile
+++ b/docker/member-agent.Dockerfile
@@ -23,7 +23,7 @@ RUN CGO_ENABLED=1 GOOS=$GOOS GOARCH=$GOARCH GOEXPERIMENT=systemcrypto GO111MODUL
 
 # Use distroless as minimal base image to package the memberagent binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/base:nonroot
+FROM gcr.io/distroless/base:nonroot@sha256:a696c7c8545ba9b2b2807ee60b8538d049622f0addd85aee8cec3ec1910de1f9
 WORKDIR /
 COPY --from=builder /workspace/memberagent .
 USER 65532:65532

--- a/docker/refresh-token.Dockerfile
+++ b/docker/refresh-token.Dockerfile
@@ -24,7 +24,7 @@ RUN CGO_ENABLED=1 GOOS=$GOOS GOARCH=$GOARCH GOEXPERIMENT=systemcrypto GO111MODUL
 
 # Use distroless as minimal base image to package the refreshtoken binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/base:nonroot
+FROM gcr.io/distroless/base:nonroot@sha256:a696c7c8545ba9b2b2807ee60b8538d049622f0addd85aee8cec3ec1910de1f9
 WORKDIR /
 COPY --from=builder /workspace/refreshtoken .
 USER 65532:65532


### PR DESCRIPTION
### Description of your changes

This pull request introduces improvements to Docker image management and updates the base image used for building several Dockerfiles to a specific, hashed version for enhanced security and reproducibility.

**Docker image management:**

* Added Dependabot configuration to enable automated updates for Docker dependencies in the `/docker` directory, scheduled weekly.

**Docker base image updates:**

* Updated the base image in `docker/hub-agent.Dockerfile`, `docker/member-agent.Dockerfile`, and `docker/refresh-token.Dockerfile` to use a specific SHA256-pinned version of `gcr.io/distroless/base:nonroot` for improved security and consistency. [[1]](diffhunk://#diff-c2e6f1e8064d6bace444944421bdcadb12a2df4b3e39c5cf501e19c70cc107adL26-R26) [[2]](diffhunk://#diff-14352685a541af951862563391cd758bf3dc2bd245808c8c1bde617e6d894297L26-R26) [[3]](diffhunk://#diff-f5cde71b235942dca59a5cb63041e21d8d01bb8f7ccf8bdeef8aecf73e8d73a5L27-R27)

Fixes #

I have:

- [ ] Associated this change with a known KubeFleet Issue (Bug, Feature, etc).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
By locally building images. CI/CD will run in PR.

### Special notes for your reviewer
N/A