### PR TITLE
feat: add kubebuilder RBAC markers and replace cluster-admin with least-privilege ClusterRoles

### DIFF
--- a/charts/hub-agent/templates/rbac.yaml
+++ b/charts/hub-agent/templates/rbac.yaml
@@ -1,11 +1,190 @@
-kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "hub-agent.fullname" . }}-role
+rules:
+  # User-created placement resources. The hub-agent does not create or delete
+  # these; it only adds/removes its cleanup finalizer via update.
+  - apiGroups: ["placement.kubernetes-fleet.io"]
+    resources:
+      - clusterresourceplacements
+      - resourceplacements
+      - clusterresourceoverrides
+      - resourceoverrides
+      - clusterstagedupdateruns
+      - stagedupdateruns
+      - clusterresourceplacementevictions
+    verbs: ["get", "list", "watch", "update"]
+
+  # User-created placement resources that the hub-agent only reads.
+  - apiGroups: ["placement.kubernetes-fleet.io"]
+    resources:
+      - clusterstagedupdatestrategies
+      - stagedupdatestrategies
+      - clusterresourceplacementdisruptionbudgets
+    verbs: ["get", "list", "watch"]
+
+  # Hub-agent-managed placement resources: snapshots, bindings, status,
+  # generated work objects, and approval requests. deletecollection is
+  # required because snapshot and approval-request cleanup uses
+  # client.DeleteAllOf (see policy_snapshot_resolver.go, resource_snapshot_resolver.go,
+  # overrider/common.go, updaterun/controller.go). The Kubernetes RBAC
+  # authorizer treats deletecollection as a distinct verb from delete.
+  - apiGroups: ["placement.kubernetes-fleet.io"]
+    resources:
+      - clusterresourcebindings
+      - resourcebindings
+      - clusterresourcesnapshots
+      - resourcesnapshots
+      - clusterschedulingpolicysnapshots
+      - schedulingpolicysnapshots
+      - clusterresourceoverridesnapshots
+      - resourceoverridesnapshots
+      - clusterresourceplacementstatuses
+      - works
+      - clusterapprovalrequests
+      - approvalrequests
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"]
+
+  # Fleet placement status subresources. Hub controllers use Status().Update
+  # (never Status().Patch), so patch is intentionally omitted.
+  # schedulingpolicysnapshots/status are written by the scheduler framework
+  # (pkg/scheduler/framework/framework.go — Status().Update on the selected
+  # policy snapshot); they were previously covered by a broad `*/*/status`
+  # wildcard which has since been removed.
+  - apiGroups: ["placement.kubernetes-fleet.io"]
+    resources:
+      - clusterresourceplacements/status
+      - resourceplacements/status
+      - clusterresourcebindings/status
+      - resourcebindings/status
+      - clusterschedulingpolicysnapshots/status
+      - schedulingpolicysnapshots/status
+      - clusterstagedupdateruns/status
+      - stagedupdateruns/status
+      - clusterresourceplacementevictions/status
+      - clusterapprovalrequests/status
+      - approvalrequests/status
+    verbs: ["get", "update"]
+
+  # Fleet cluster APIs. MemberCluster is user-created and user-deleted; the
+  # hub-agent only adds/removes its finalizer (update) and writes status.
+  # InternalMemberCluster is created by the hub-agent and cleaned up via
+  # owner-reference garbage collection, so no explicit delete is issued.
+  - apiGroups: ["cluster.kubernetes-fleet.io"]
+    resources:
+      - memberclusters
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["cluster.kubernetes-fleet.io"]
+    resources:
+      - internalmemberclusters
+    verbs: ["get", "list", "watch", "create", "update"]
+  # Only memberclusters/status is written by the hub-agent. internalmemberclusters/status
+  # is owned by the member-agent (via its per-member Role on the hub cluster) and is
+  # intentionally not granted here.
+  - apiGroups: ["cluster.kubernetes-fleet.io"]
+    resources:
+      - memberclusters/status
+    verbs: ["get", "update"]
+
+  # Cluster inventory API - ClusterProfile generation.
+  - apiGroups: ["multicluster.x-k8s.io"]
+    resources: ["clusterprofiles"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
+  - apiGroups: ["multicluster.x-k8s.io"]
+    resources: ["clusterprofiles/status"]
+    verbs: ["get", "update"]
+
+  # Namespace management for member cluster namespaces. The hub-agent creates
+  # the per-member namespace, patches labels via client.MergeFrom, and deletes
+  # it on MemberCluster removal. list/watch come from the broad */* watch
+  # used for resource-change detection; full Update is not exercised.
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "create", "patch", "delete"]
+
+  # RBAC setup in member cluster namespaces. The hub-agent creates Roles and
+  # RoleBindings that grant each member-agent access to its own namespace.
+  # bind/escalate are required because the per-member Role (built in
+  # pkg/utils/common.go) uses wildcard verbs/resources on fleet API groups
+  # (e.g. verbs=["*"], resources=["*"]). The API server's RBAC escalation
+  # check requires the creator to hold a rule covering every verb/resource
+  # being granted, and an explicit verb list does not cover "*". Without
+  # escalate, the hub-agent cannot create per-member Roles and new member
+  # onboarding fails.
+  # list/watch are required because the cached controller-runtime client
+  # starts an informer on first Get. delete is omitted — the per-member Role
+  # and RoleBinding are owned by the MemberCluster and reaped by owner-ref GC.
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["roles", "rolebindings"]
+    verbs: ["get", "list", "watch", "create", "update", "bind", "escalate"]
+
+  # Webhook configuration management. Split into two rules: reads and creates
+  # must be cluster-wide (list/watch are required because checkMutatingWebhookCABundle
+  # / checkValidatingWebhookCABundle read via the controller-runtime cached
+  # client, which starts an informer on first Get; create cannot be scoped by
+  # resourceNames because the RBAC authorizer sees no name on POST requests),
+  # but delete is scoped to the three fleet-owned webhook configurations. This
+  # prevents a compromised hub-agent from deleting unrelated admission
+  # controllers as a DoS vector. update/patch are intentionally omitted —
+  # webhook configs are always replaced wholesale via delete+create (see
+  # createMutatingWebhookConfiguration), never modified in place.
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
+    verbs: ["get", "list", "watch", "create"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
+    resourceNames:
+      - fleet-mutating-webhook-configuration
+      - fleet-validating-webhook-configuration
+      - fleet-guard-rail-webhook-configuration
+    verbs: ["delete"]
+
+  # Leader election. Split into two rules so that only the hub-agent's own
+  # election lease can be mutated; a compromised hub-agent cannot hijack
+  # another controller's leader election by racing to update its lease.
+  # create cannot be scoped by resourceNames (the RBAC authorizer has no name
+  # on POST requests), so any lease may be created — but stale/orphan leases
+  # without an owning controller have no effect. The lease name matches the
+  # LeaderElectionID configured in cmd/hubagent/main.go.
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "watch", "create"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    resourceNames: ["136224848560.hub.fleet.azure.com"]
+    verbs: ["update", "patch"]
+
+  # Events for controller recording.
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+
+  # CRD discovery for resource change detection.
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "watch"]
+
+  # Broad read access required for resource change detection.
+  # The hub-agent monitors all cluster-scoped and namespaced resources
+  # to detect changes that affect placement decisions.
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+
+  # API discovery for dynamic resource mapping, CRD detection, and health checks.
+  - nonResourceURLs: ["/api", "/api/*", "/apis", "/apis/*", "/version", "/healthz", "/readyz"]
+    verbs: ["get"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
 metadata:
   name: {{ include "hub-agent.fullname" . }}-role-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cluster-admin
+  name: {{ include "hub-agent.fullname" . }}-role
 subjects:
   - kind: ServiceAccount
     name: {{ include "hub-agent.fullname" . }}-sa

--- a/charts/member-agent/templates/rbac.yaml
+++ b/charts/member-agent/templates/rbac.yaml
@@ -1,11 +1,103 @@
-kind: ClusterRoleBinding
+# The member-agent applies arbitrary user-defined resources from Work objects
+# using a dynamic client. Consequences of that design:
+#   - It must hold broad permissions (verbs=["*"] on resources=["*"]) on the
+#     local member cluster, i.e. this ClusterRole is effectively cluster-admin
+#     minus impersonate on its own cluster. Member-agent compromise
+#     approximately equals member-cluster takeover.
+#   - bind/escalate ARE required because user workloads may include RBAC
+#     resources (Roles, RoleBindings, ClusterRoles, ClusterRoleBindings).
+#   - impersonate is NOT granted: prevents a compromised member-agent from
+#     spoofing other identities.
+#   - Hub-side access (Work objects, InternalMemberCluster status) is NOT in
+#     this role. It is granted by the per-member Role the hub-agent creates
+#     on the hub cluster, bound to the identity in MemberCluster.Spec.Identity.
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "member-agent.fullname" . }}-role
+rules:
+  # Fleet placement APIs on the member cluster (spoke client). list/watch are
+  # required because workapplier reads AppliedWork via the cached
+  # controller-runtime client, which starts an informer on first Get. The
+  # spec is never updated (only created and deleted); status is written via
+  # Status().Update.
+  - apiGroups: ["placement.kubernetes-fleet.io"]
+    resources:
+      - appliedworks
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: ["placement.kubernetes-fleet.io"]
+    resources:
+      - appliedworks/status
+    verbs: ["update"]
+
+  # Node, pod, and namespace read access. Consumers:
+  #   - internalmembercluster/v1beta1 lists Nodes and Pods for resource-capacity
+  #     reporting (see updateResourceStats).
+  #   - The Azure property provider (pkg/propertyprovider/azure) runs its own
+  #     controller-runtime manager inside the member-agent pod and watches
+  #     Nodes (always), Pods (when available-resources collection is enabled),
+  #     and Namespaces (when namespace collection is enabled).
+  # list/watch are required because these reads go through cached clients.
+  - apiGroups: [""]
+    resources: ["nodes", "pods", "namespaces"]
+    verbs: ["get", "list", "watch"]
+
+  # Leader election. The member-agent runs two controller-runtime managers
+  # (one hub-client, one member-client) and places both leases on the member
+  # cluster — see the LeaderElectionID values in cmd/memberagent/main.go. Split
+  # into two rules so that only these two leases can be mutated; a compromised
+  # member-agent cannot hijack another controller's leader election by racing
+  # to update its lease. create cannot be scoped by resourceNames (the RBAC
+  # authorizer has no name on POST requests), so any lease may be created —
+  # but stale/orphan leases without an owning controller have no effect.
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "watch", "create"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    resourceNames:
+      - 136224848560.hub.fleet.azure.com
+      - 136224848560.member.fleet.azure.com
+    verbs: ["update", "patch"]
+
+  # Events for controller recording.
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+
+  # Broad resource access for applying arbitrary user workloads from Work
+  # objects. The member-agent uses an uncached dynamic client to read and
+  # mutate any resource type specified in Work manifests, so list/watch are
+  # intentionally omitted — nothing on this path consumes informers.
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["get", "create", "update", "patch", "delete"]
+
+  # User workloads may include RBAC resources. Creating RoleBindings requires
+  # the bind verb, and creating Roles with elevated permissions requires escalate.
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["clusterroles", "roles"]
+    verbs: ["bind", "escalate"]
+
+  # API discovery for dynamic resource mapping and CRD detection.
+  - nonResourceURLs: ["/api", "/api/*", "/apis", "/apis/*", "/version", "/healthz", "/readyz"]
+    verbs: ["get"]
+
+---
+# The metadata.name is kept as "cluster-admin-binding" for Helm upgrade
+# compatibility: renaming would create a new binding without deleting the
+# old one, leaving the old binding (which references cluster-admin) in
+# place and silently reverting this PR's least-privilege hardening for
+# upgrading installs. The roleRef below, not the binding name, determines
+# what this grants.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
 metadata:
   name: {{ include "member-agent.fullname" . }}-cluster-admin-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cluster-admin
+  name: {{ include "member-agent.fullname" . }}-role
 subjects:
   - kind: ServiceAccount
     name: {{ include "member-agent.fullname" . }}-sa


### PR DESCRIPTION
### Description of your changes

This pull request refactors the RBAC (Role-Based Access Control) configuration for both the `hub-agent` and `member-agent` Helm charts. Instead of binding the agents to the broad `cluster-admin` role, it introduces custom `ClusterRole` definitions that grant only the specific permissions required for each agent's operation. This change improves security by following the principle of least privilege and provides clearer documentation of required permissions.

Key changes by theme:

**RBAC Role Refinement and Security Hardening**

* Replaces the use of the `cluster-admin` role with custom `ClusterRole` resources for both `hub-agent` and `member-agent`, granting only the necessary permissions for each agent’s responsibilities. This minimizes excessive privilege and reduces the risk surface in case of compromise. [[1]](diffhunk://#diff-66d418f7fcd53ce24a214aaa25832762dc7dcea48697697a2a397a0928fc1ea3L1-R165) [[2]](diffhunk://#diff-7320198a179a8fc48283f2cd443ef0deaed6937d6e90d5201a8437983dcf799bL1-R79)
* Updates `ClusterRoleBinding` resources to reference the newly defined custom roles instead of the generic `cluster-admin` role, ensuring that agents are bound to their least-privilege roles. [[1]](diffhunk://#diff-66d418f7fcd53ce24a214aaa25832762dc7dcea48697697a2a397a0928fc1ea3L1-R165) [[2]](diffhunk://#diff-7320198a179a8fc48283f2cd443ef0deaed6937d6e90d5201a8437983dcf799bL1-R79)

**Documentation and Clarity**

* Adds detailed comments in both RBAC YAML files explaining the rationale behind each permission, including why certain verbs like `bind` and `escalate` are required, and why `impersonate` is intentionally omitted. This improves maintainability and auditability of the RBAC policy. [[1]](diffhunk://#diff-66d418f7fcd53ce24a214aaa25832762dc7dcea48697697a2a397a0928fc1ea3L1-R165) [[2]](diffhunk://#diff-7320198a179a8fc48283f2cd443ef0deaed6937d6e90d5201a8437983dcf799bL1-R79)

**Agent-Specific Permission Scoping**

* For `hub-agent`, defines granular rules for managing Fleet placement resources, member cluster lifecycle, webhook configurations, leader election, and event recording, with tight scoping on sensitive operations like webhook deletion and lease updates.
* For `member-agent`, grants broad permissions necessary for applying arbitrary user workloads via Work objects, but restricts impersonation and carefully scopes RBAC escalation verbs to only what is operationally required.

Fixes #

I have:

- [ ] Associated this change with a known KubeFleet Issue (Bug, Feature, etc).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
N/A

### Special notes for your reviewer
N/A