### PR TITLE
feat: auto-add member-cluster-name label to MemberCluster for override selection by cluster name

### DIFF
--- a/apis/placement/v1beta1/commons.go
+++ b/apis/placement/v1beta1/commons.go
@@ -74,6 +74,11 @@ const (
 	// MemberClusterFinalizer is used to make sure that we handle gc of all the member cluster resources on the hub cluster.
 	MemberClusterFinalizer = FleetPrefix + "membercluster-finalizer"
 
+	// MemberClusterNameLabel is a label automatically added to MemberCluster objects
+	// with the value set to the MemberCluster's name. This enables selecting clusters
+	// by name in ResourceOverride and ClusterResourceOverride via labelSelector.
+	MemberClusterNameLabel = FleetPrefix + "member-cluster-name"
+
 	// WorkFinalizer is used by the work generator to make sure that the binding is not deleted until the work objects
 	// it generates are all deleted, or used by the work controller to make sure the work has been deleted in the member
 	// cluster.

--- a/apis/placement/v1beta1/commons.go
+++ b/apis/placement/v1beta1/commons.go
@@ -74,10 +74,10 @@ const (
 	// MemberClusterFinalizer is used to make sure that we handle gc of all the member cluster resources on the hub cluster.
 	MemberClusterFinalizer = FleetPrefix + "membercluster-finalizer"
 
-	// MemberClusterNameLabel is a label automatically added to MemberCluster objects
+	// MemberNameLabel is a label automatically added to MemberCluster objects
 	// with the value set to the MemberCluster's name. This enables selecting clusters
 	// by name in ResourceOverride and ClusterResourceOverride via labelSelector.
-	MemberClusterNameLabel = FleetPrefix + "member-cluster-name"
+	MemberNameLabel = FleetPrefix + "member-name"
 
 	// WorkFinalizer is used by the work generator to make sure that the binding is not deleted until the work objects
 	// it generates are all deleted, or used by the work controller to make sure the work has been deleted in the member

--- a/pkg/controllers/membercluster/v1beta1/membercluster_controller.go
+++ b/pkg/controllers/membercluster/v1beta1/membercluster_controller.go
@@ -106,8 +106,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req runtime.Request) (runtim
 		return runtime.Result{}, err
 	}
 
-	// Ensure the member cluster has the name label for override selection by cluster name.
-	if err := r.ensureMemberClusterNameLabel(ctx, &mc); err != nil {
+	// Ensure the member cluster has the name label for override selection by member name.
+	if err := r.ensureMemberNameLabel(ctx, &mc); err != nil {
 		klog.ErrorS(err, "Failed to ensure the name label on member cluster", "memberCluster", mcObjRef)
 		return runtime.Result{}, err
 	}
@@ -280,17 +280,19 @@ func (r *Reconciler) ensureFinalizer(ctx context.Context, mc *clusterv1beta1.Mem
 	return r.Update(ctx, mc, client.FieldOwner(utils.MCControllerFieldManagerName))
 }
 
-// ensureMemberClusterNameLabel makes sure that the member cluster has a label with its own name.
+// ensureMemberNameLabel makes sure that the member cluster has a label with its own name.
 // This enables selecting clusters by name in ResourceOverride and ClusterResourceOverride via labelSelector.
-func (r *Reconciler) ensureMemberClusterNameLabel(ctx context.Context, mc *clusterv1beta1.MemberCluster) error {
-	if mc.Labels != nil && mc.Labels[placementv1beta1.MemberClusterNameLabel] == mc.Name {
+func (r *Reconciler) ensureMemberNameLabel(ctx context.Context, mc *clusterv1beta1.MemberCluster) error {
+	if mc.Labels != nil && mc.Labels[placementv1beta1.MemberNameLabel] == mc.Name {
 		return nil
 	}
+
 	if mc.Labels == nil {
 		mc.Labels = make(map[string]string)
 	}
-	mc.Labels[placementv1beta1.MemberClusterNameLabel] = mc.Name
-	klog.InfoS("Added the member cluster name label", "memberCluster", klog.KObj(mc))
+	mc.Labels[placementv1beta1.MemberNameLabel] = mc.Name
+
+	klog.InfoS("Ensured the member cluster name label", "memberCluster", klog.KObj(mc))
 	return r.Update(ctx, mc, client.FieldOwner(utils.MCControllerFieldManagerName))
 }
 

--- a/pkg/controllers/membercluster/v1beta1/membercluster_controller.go
+++ b/pkg/controllers/membercluster/v1beta1/membercluster_controller.go
@@ -105,6 +105,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, req runtime.Request) (runtim
 		klog.ErrorS(err, "Failed to add the finalizer to member cluster", "memberCluster", mcObjRef)
 		return runtime.Result{}, err
 	}
+
+	// Ensure the member cluster has the name label for override selection by cluster name.
+	if err := r.ensureMemberClusterNameLabel(ctx, &mc); err != nil {
+		klog.ErrorS(err, "Failed to ensure the name label on member cluster", "memberCluster", mcObjRef)
+		return runtime.Result{}, err
+	}
+
 	currentIMC, err := r.getInternalMemberCluster(ctx, mc.GetName())
 	if err != nil {
 		return runtime.Result{}, err
@@ -270,6 +277,20 @@ func (r *Reconciler) ensureFinalizer(ctx context.Context, mc *clusterv1beta1.Mem
 	}
 	klog.InfoS("Added the member cluster finalizer", "memberCluster", klog.KObj(mc))
 	controllerutil.AddFinalizer(mc, placementv1beta1.MemberClusterFinalizer)
+	return r.Update(ctx, mc, client.FieldOwner(utils.MCControllerFieldManagerName))
+}
+
+// ensureMemberClusterNameLabel makes sure that the member cluster has a label with its own name.
+// This enables selecting clusters by name in ResourceOverride and ClusterResourceOverride via labelSelector.
+func (r *Reconciler) ensureMemberClusterNameLabel(ctx context.Context, mc *clusterv1beta1.MemberCluster) error {
+	if mc.Labels != nil && mc.Labels[placementv1beta1.MemberClusterNameLabel] == mc.Name {
+		return nil
+	}
+	if mc.Labels == nil {
+		mc.Labels = make(map[string]string)
+	}
+	mc.Labels[placementv1beta1.MemberClusterNameLabel] = mc.Name
+	klog.InfoS("Added the member cluster name label", "memberCluster", klog.KObj(mc))
 	return r.Update(ctx, mc, client.FieldOwner(utils.MCControllerFieldManagerName))
 }
 

--- a/pkg/controllers/membercluster/v1beta1/membercluster_controller_integration_test.go
+++ b/pkg/controllers/membercluster/v1beta1/membercluster_controller_integration_test.go
@@ -117,6 +117,28 @@ var _ = Describe("Test MemberCluster Controller", func() {
 			Expect(joinCondition.Reason).To(Equal(reasonMemberClusterJoined))
 		})
 
+		It("should add the member cluster name label", func() {
+			Expect(k8sClient.Get(ctx, memberClusterNamespacedName, &mc)).Should(Succeed())
+			Expect(mc.Labels).NotTo(BeNil())
+			Expect(mc.Labels[placementv1beta1.MemberClusterNameLabel]).To(Equal(memberClusterName))
+		})
+
+		It("should restore the member cluster name label if removed", func() {
+			Expect(k8sClient.Get(ctx, memberClusterNamespacedName, &mc)).Should(Succeed())
+			delete(mc.Labels, placementv1beta1.MemberClusterNameLabel)
+			Expect(k8sClient.Update(ctx, &mc)).Should(Succeed())
+
+			By("trigger reconcile to restore the name label")
+			result, err := r.Reconcile(ctx, ctrl.Request{
+				NamespacedName: memberClusterNamespacedName,
+			})
+			Expect(result).Should(Equal(ctrl.Result{}))
+			Expect(err).Should(Succeed())
+
+			Expect(k8sClient.Get(ctx, memberClusterNamespacedName, &mc)).Should(Succeed())
+			Expect(mc.Labels[placementv1beta1.MemberClusterNameLabel]).To(Equal(memberClusterName))
+		})
+
 		It("should relay cluster resource usage + properties, and property provider conditions", func() {
 			Expect(k8sClient.Get(ctx, memberClusterNamespacedName, &mc)).Should(Succeed())
 

--- a/pkg/controllers/membercluster/v1beta1/membercluster_controller_integration_test.go
+++ b/pkg/controllers/membercluster/v1beta1/membercluster_controller_integration_test.go
@@ -120,12 +120,12 @@ var _ = Describe("Test MemberCluster Controller", func() {
 		It("should add the member cluster name label", func() {
 			Expect(k8sClient.Get(ctx, memberClusterNamespacedName, &mc)).Should(Succeed())
 			Expect(mc.Labels).NotTo(BeNil())
-			Expect(mc.Labels[placementv1beta1.MemberClusterNameLabel]).To(Equal(memberClusterName))
+			Expect(mc.Labels[placementv1beta1.MemberNameLabel]).To(Equal(memberClusterName))
 		})
 
 		It("should restore the member cluster name label if removed", func() {
 			Expect(k8sClient.Get(ctx, memberClusterNamespacedName, &mc)).Should(Succeed())
-			delete(mc.Labels, placementv1beta1.MemberClusterNameLabel)
+			delete(mc.Labels, placementv1beta1.MemberNameLabel)
 			Expect(k8sClient.Update(ctx, &mc)).Should(Succeed())
 
 			By("trigger reconcile to restore the name label")
@@ -136,7 +136,7 @@ var _ = Describe("Test MemberCluster Controller", func() {
 			Expect(err).Should(Succeed())
 
 			Expect(k8sClient.Get(ctx, memberClusterNamespacedName, &mc)).Should(Succeed())
-			Expect(mc.Labels[placementv1beta1.MemberClusterNameLabel]).To(Equal(memberClusterName))
+			Expect(mc.Labels[placementv1beta1.MemberNameLabel]).To(Equal(memberClusterName))
 		})
 
 		It("should relay cluster resource usage + properties, and property provider conditions", func() {

--- a/pkg/controllers/membercluster/v1beta1/membercluster_controller_test.go
+++ b/pkg/controllers/membercluster/v1beta1/membercluster_controller_test.go
@@ -64,7 +64,7 @@ const (
 	propertyProviderConditionMessage2 = "property provider condition 2 message"
 )
 
-func TestEnsureMemberClusterNameLabel(t *testing.T) {
+func TestEnsureMemberNameLabel(t *testing.T) {
 	tests := map[string]struct {
 		r             *Reconciler
 		memberCluster *clusterv1beta1.MemberCluster
@@ -81,12 +81,12 @@ func TestEnsureMemberClusterNameLabel(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "mc1",
 					Labels: map[string]string{
-						placementv1beta1.MemberClusterNameLabel: "mc1",
+						placementv1beta1.MemberNameLabel: "mc1",
 					},
 				},
 			},
 			wantLabels: map[string]string{
-				placementv1beta1.MemberClusterNameLabel: "mc1",
+				placementv1beta1.MemberNameLabel: "mc1",
 			},
 		},
 		"no labels at all": {
@@ -103,7 +103,7 @@ func TestEnsureMemberClusterNameLabel(t *testing.T) {
 				},
 			},
 			wantLabels: map[string]string{
-				placementv1beta1.MemberClusterNameLabel: "mc1",
+				placementv1beta1.MemberNameLabel: "mc1",
 			},
 		},
 		"labels exist but name label is missing": {
@@ -123,8 +123,8 @@ func TestEnsureMemberClusterNameLabel(t *testing.T) {
 				},
 			},
 			wantLabels: map[string]string{
-				"existing-label":                        "value",
-				placementv1beta1.MemberClusterNameLabel: "mc1",
+				"existing-label":                 "value",
+				placementv1beta1.MemberNameLabel: "mc1",
 			},
 		},
 		"label present with wrong value": {
@@ -139,12 +139,12 @@ func TestEnsureMemberClusterNameLabel(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "mc1",
 					Labels: map[string]string{
-						placementv1beta1.MemberClusterNameLabel: "wrong-name",
+						placementv1beta1.MemberNameLabel: "wrong-name",
 					},
 				},
 			},
 			wantLabels: map[string]string{
-				placementv1beta1.MemberClusterNameLabel: "mc1",
+				placementv1beta1.MemberNameLabel: "mc1",
 			},
 		},
 		"update error": {
@@ -166,27 +166,27 @@ func TestEnsureMemberClusterNameLabel(t *testing.T) {
 
 	for testName, tt := range tests {
 		t.Run(testName, func(t *testing.T) {
-			err := tt.r.ensureMemberClusterNameLabel(context.Background(), tt.memberCluster)
+			err := tt.r.ensureMemberNameLabel(context.Background(), tt.memberCluster)
 			if tt.wantErr == "" {
 				if err != nil {
-					t.Errorf("ensureMemberClusterNameLabel() = %v, want nil", err)
+					t.Errorf("ensureMemberNameLabel() = %v, want nil", err)
 				}
 				if diff := cmp.Diff(tt.wantLabels, tt.memberCluster.Labels); diff != "" {
-					t.Errorf("ensureMemberClusterNameLabel() labels mismatch (-want +got):\n%s", diff)
+					t.Errorf("ensureMemberNameLabel() labels mismatch (-want +got):\n%s", diff)
 				}
 			} else {
 				if err == nil {
-					t.Errorf("ensureMemberClusterNameLabel() = nil, want error containing %q", tt.wantErr)
+					t.Errorf("ensureMemberNameLabel() = nil, want error containing %q", tt.wantErr)
 				} else if !strings.Contains(err.Error(), tt.wantErr) {
-					t.Errorf("ensureMemberClusterNameLabel() = %v, want error containing %q", err, tt.wantErr)
+					t.Errorf("ensureMemberNameLabel() = %v, want error containing %q", err, tt.wantErr)
 				}
 			}
 		})
 	}
 }
 
-func TestReconcileEnsureMemberClusterNameLabelError(t *testing.T) {
-	// This test verifies that Reconcile returns an error when ensureMemberClusterNameLabel fails.
+func TestReconcileEnsureMemberNameLabelError(t *testing.T) {
+	// This test verifies that Reconcile returns an error when ensureMemberNameLabel fails.
 	// The MC already has the finalizer (so ensureFinalizer is a no-op) but no label.
 	updateErr := errors.New("update failed")
 	r := &Reconciler{
@@ -195,7 +195,7 @@ func TestReconcileEnsureMemberClusterNameLabelError(t *testing.T) {
 				mc := obj.(*clusterv1beta1.MemberCluster)
 				mc.Name = "mc1"
 				mc.Finalizers = []string{placementv1beta1.MemberClusterFinalizer}
-				// No labels, so ensureMemberClusterNameLabel will attempt an update.
+				// No labels, so ensureMemberNameLabel will attempt an update.
 				return nil
 			},
 			MockUpdate: func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
@@ -210,8 +210,8 @@ func TestReconcileEnsureMemberClusterNameLabelError(t *testing.T) {
 	if result != (ctrl.Result{}) {
 		t.Errorf("Reconcile() result = %v, want %v", result, ctrl.Result{})
 	}
-	if err == nil || !strings.Contains(err.Error(), "update failed") {
-		t.Errorf("Reconcile() error = %v, want error containing %q", err, "update failed")
+	if err == nil || !strings.Contains(err.Error(), updateErr.Error()) {
+		t.Errorf("Reconcile() error = %v, want error containing %q", err, updateErr.Error())
 	}
 }
 

--- a/pkg/controllers/membercluster/v1beta1/membercluster_controller_test.go
+++ b/pkg/controllers/membercluster/v1beta1/membercluster_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -62,6 +63,157 @@ const (
 	propertyProviderConditionReason2  = "ProviderConditionReason2"
 	propertyProviderConditionMessage2 = "property provider condition 2 message"
 )
+
+func TestEnsureMemberClusterNameLabel(t *testing.T) {
+	tests := map[string]struct {
+		r             *Reconciler
+		memberCluster *clusterv1beta1.MemberCluster
+		wantLabels    map[string]string
+		wantErr       string
+	}{
+		"label already present with correct value": {
+			r: &Reconciler{
+				Client: &test.MockClient{
+					MockUpdate: test.NewMockUpdateFn(fmt.Errorf("update should not be called when label is already correct")),
+				},
+			},
+			memberCluster: &clusterv1beta1.MemberCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "mc1",
+					Labels: map[string]string{
+						placementv1beta1.MemberClusterNameLabel: "mc1",
+					},
+				},
+			},
+			wantLabels: map[string]string{
+				placementv1beta1.MemberClusterNameLabel: "mc1",
+			},
+		},
+		"no labels at all": {
+			r: &Reconciler{
+				Client: &test.MockClient{
+					MockUpdate: func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+						return nil
+					},
+				},
+			},
+			memberCluster: &clusterv1beta1.MemberCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "mc1",
+				},
+			},
+			wantLabels: map[string]string{
+				placementv1beta1.MemberClusterNameLabel: "mc1",
+			},
+		},
+		"labels exist but name label is missing": {
+			r: &Reconciler{
+				Client: &test.MockClient{
+					MockUpdate: func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+						return nil
+					},
+				},
+			},
+			memberCluster: &clusterv1beta1.MemberCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "mc1",
+					Labels: map[string]string{
+						"existing-label": "value",
+					},
+				},
+			},
+			wantLabels: map[string]string{
+				"existing-label":                        "value",
+				placementv1beta1.MemberClusterNameLabel: "mc1",
+			},
+		},
+		"label present with wrong value": {
+			r: &Reconciler{
+				Client: &test.MockClient{
+					MockUpdate: func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+						return nil
+					},
+				},
+			},
+			memberCluster: &clusterv1beta1.MemberCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "mc1",
+					Labels: map[string]string{
+						placementv1beta1.MemberClusterNameLabel: "wrong-name",
+					},
+				},
+			},
+			wantLabels: map[string]string{
+				placementv1beta1.MemberClusterNameLabel: "mc1",
+			},
+		},
+		"update error": {
+			r: &Reconciler{
+				Client: &test.MockClient{
+					MockUpdate: func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+						return errors.New("update failed")
+					},
+				},
+			},
+			memberCluster: &clusterv1beta1.MemberCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "mc1",
+				},
+			},
+			wantErr: "update failed",
+		},
+	}
+
+	for testName, tt := range tests {
+		t.Run(testName, func(t *testing.T) {
+			err := tt.r.ensureMemberClusterNameLabel(context.Background(), tt.memberCluster)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("ensureMemberClusterNameLabel() = %v, want nil", err)
+				}
+				if diff := cmp.Diff(tt.wantLabels, tt.memberCluster.Labels); diff != "" {
+					t.Errorf("ensureMemberClusterNameLabel() labels mismatch (-want +got):\n%s", diff)
+				}
+			} else {
+				if err == nil {
+					t.Errorf("ensureMemberClusterNameLabel() = nil, want error containing %q", tt.wantErr)
+				} else if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("ensureMemberClusterNameLabel() = %v, want error containing %q", err, tt.wantErr)
+				}
+			}
+		})
+	}
+}
+
+func TestReconcileEnsureMemberClusterNameLabelError(t *testing.T) {
+	// This test verifies that Reconcile returns an error when ensureMemberClusterNameLabel fails.
+	// The MC already has the finalizer (so ensureFinalizer is a no-op) but no label.
+	updateErr := errors.New("update failed")
+	r := &Reconciler{
+		Client: &test.MockClient{
+			MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+				mc := obj.(*clusterv1beta1.MemberCluster)
+				mc.Name = "mc1"
+				mc.Finalizers = []string{placementv1beta1.MemberClusterFinalizer}
+				// No labels, so ensureMemberClusterNameLabel will attempt an update.
+				return nil
+			},
+			MockUpdate: func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+				return updateErr
+			},
+		},
+		recorder: record.NewFakeRecorder(10),
+	}
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: client.ObjectKey{Name: "mc1"},
+	})
+	if result != (ctrl.Result{}) {
+		t.Errorf("Reconcile() result = %v, want %v", result, ctrl.Result{})
+	}
+	if err == nil || !strings.Contains(err.Error(), "update failed") {
+		t.Errorf("Reconcile() error = %v, want error containing %q", err, "update failed")
+	}
+}
 
 func TestSyncNamespace(t *testing.T) {
 	tests := map[string]struct {

--- a/pkg/controllers/rollout/controller_integration_test.go
+++ b/pkg/controllers/rollout/controller_integration_test.go
@@ -1926,8 +1926,8 @@ func generateResourceSnapshot(namespace, testRPName string, resourceIndex int, i
 
 func generateMemberCluster(idx int, clusterName string) *clusterv1beta1.MemberCluster {
 	clusterLabels := map[string]string{
-		"index":                                 strconv.Itoa(idx),
-		placementv1beta1.MemberClusterNameLabel: clusterName,
+		"index":                          strconv.Itoa(idx),
+		placementv1beta1.MemberNameLabel: clusterName,
 	}
 	return &clusterv1beta1.MemberCluster{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controllers/rollout/controller_integration_test.go
+++ b/pkg/controllers/rollout/controller_integration_test.go
@@ -1926,7 +1926,8 @@ func generateResourceSnapshot(namespace, testRPName string, resourceIndex int, i
 
 func generateMemberCluster(idx int, clusterName string) *clusterv1beta1.MemberCluster {
 	clusterLabels := map[string]string{
-		"index": strconv.Itoa(idx),
+		"index":                                 strconv.Itoa(idx),
+		placementv1beta1.MemberClusterNameLabel: clusterName,
 	}
 	return &clusterv1beta1.MemberCluster{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controllers/workgenerator/controller_integration_test.go
+++ b/pkg/controllers/workgenerator/controller_integration_test.go
@@ -130,8 +130,8 @@ var _ = Describe("Test Work Generator Controller for clusterResourcePlacement", 
 				ObjectMeta: metav1.ObjectMeta{
 					Name: memberClusterName,
 					Labels: map[string]string{
-						"override":                              "true",
-						placementv1beta1.MemberClusterNameLabel: memberClusterName,
+						"override":                       "true",
+						placementv1beta1.MemberNameLabel: memberClusterName,
 					},
 				},
 			}
@@ -1734,7 +1734,7 @@ var _ = Describe("Test Work Generator Controller for clusterResourcePlacement", 
 				ObjectMeta: metav1.ObjectMeta{
 					Name: memberClusterName,
 					Labels: map[string]string{
-						placementv1beta1.MemberClusterNameLabel: memberClusterName,
+						placementv1beta1.MemberNameLabel: memberClusterName,
 					},
 				},
 			}
@@ -1859,7 +1859,7 @@ var _ = Describe("Test Work Generator Controller for clusterResourcePlacement", 
 				ObjectMeta: metav1.ObjectMeta{
 					Name: memberClusterName,
 					Labels: map[string]string{
-						placementv1beta1.MemberClusterNameLabel: memberClusterName,
+						placementv1beta1.MemberNameLabel: memberClusterName,
 					},
 				},
 			}
@@ -1988,7 +1988,7 @@ var _ = Describe("Test Work Generator Controller for clusterResourcePlacement", 
 				ObjectMeta: metav1.ObjectMeta{
 					Name: memberClusterName,
 					Labels: map[string]string{
-						placementv1beta1.MemberClusterNameLabel: memberClusterName,
+						placementv1beta1.MemberNameLabel: memberClusterName,
 					},
 				},
 			}
@@ -2119,7 +2119,7 @@ var _ = Describe("Test Work Generator Controller for clusterResourcePlacement", 
 				ObjectMeta: metav1.ObjectMeta{
 					Name: memberClusterName,
 					Labels: map[string]string{
-						placementv1beta1.MemberClusterNameLabel: memberClusterName,
+						placementv1beta1.MemberNameLabel: memberClusterName,
 					},
 				},
 			}
@@ -2253,7 +2253,7 @@ var _ = Describe("Test Work Generator Controller for clusterResourcePlacement", 
 				ObjectMeta: metav1.ObjectMeta{
 					Name: memberClusterName,
 					Labels: map[string]string{
-						placementv1beta1.MemberClusterNameLabel: memberClusterName,
+						placementv1beta1.MemberNameLabel: memberClusterName,
 					},
 				},
 			}
@@ -2630,7 +2630,7 @@ var _ = Describe("Test Work Generator Controller for clusterResourcePlacement", 
 				ObjectMeta: metav1.ObjectMeta{
 					Name: memberClusterName,
 					Labels: map[string]string{
-						placementv1beta1.MemberClusterNameLabel: memberClusterName,
+						placementv1beta1.MemberNameLabel: memberClusterName,
 					},
 				},
 			}
@@ -4770,8 +4770,8 @@ var _ = Describe("Test Work Generator Controller for ResourcePlacement", func() 
 				ObjectMeta: metav1.ObjectMeta{
 					Name: memberClusterName,
 					Labels: map[string]string{
-						"override":                              "true",
-						placementv1beta1.MemberClusterNameLabel: memberClusterName,
+						"override":                       "true",
+						placementv1beta1.MemberNameLabel: memberClusterName,
 					},
 				},
 			}

--- a/pkg/controllers/workgenerator/controller_integration_test.go
+++ b/pkg/controllers/workgenerator/controller_integration_test.go
@@ -130,7 +130,8 @@ var _ = Describe("Test Work Generator Controller for clusterResourcePlacement", 
 				ObjectMeta: metav1.ObjectMeta{
 					Name: memberClusterName,
 					Labels: map[string]string{
-						"override": "true",
+						"override":                              "true",
+						placementv1beta1.MemberClusterNameLabel: memberClusterName,
 					},
 				},
 			}
@@ -1732,6 +1733,9 @@ var _ = Describe("Test Work Generator Controller for clusterResourcePlacement", 
 			memberCluster := clusterv1beta1.MemberCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: memberClusterName,
+					Labels: map[string]string{
+						placementv1beta1.MemberClusterNameLabel: memberClusterName,
+					},
 				},
 			}
 			Expect(k8sClient.Create(ctx, &memberCluster)).Should(Succeed(), "Failed to create member cluster")
@@ -1854,6 +1858,9 @@ var _ = Describe("Test Work Generator Controller for clusterResourcePlacement", 
 			memberCluster := clusterv1beta1.MemberCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: memberClusterName,
+					Labels: map[string]string{
+						placementv1beta1.MemberClusterNameLabel: memberClusterName,
+					},
 				},
 			}
 			Expect(k8sClient.Create(ctx, &memberCluster)).Should(Succeed(), "Failed to create member cluster")
@@ -1980,6 +1987,9 @@ var _ = Describe("Test Work Generator Controller for clusterResourcePlacement", 
 			memberCluster := clusterv1beta1.MemberCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: memberClusterName,
+					Labels: map[string]string{
+						placementv1beta1.MemberClusterNameLabel: memberClusterName,
+					},
 				},
 			}
 			Expect(k8sClient.Create(ctx, &memberCluster)).Should(Succeed(), "Failed to create member cluster")
@@ -2108,6 +2118,9 @@ var _ = Describe("Test Work Generator Controller for clusterResourcePlacement", 
 			memberCluster := clusterv1beta1.MemberCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: memberClusterName,
+					Labels: map[string]string{
+						placementv1beta1.MemberClusterNameLabel: memberClusterName,
+					},
 				},
 			}
 			Expect(k8sClient.Create(ctx, &memberCluster)).Should(Succeed(), "Failed to create member cluster")
@@ -2239,6 +2252,9 @@ var _ = Describe("Test Work Generator Controller for clusterResourcePlacement", 
 			memberCluster := clusterv1beta1.MemberCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: memberClusterName,
+					Labels: map[string]string{
+						placementv1beta1.MemberClusterNameLabel: memberClusterName,
+					},
 				},
 			}
 			Expect(k8sClient.Create(ctx, &memberCluster)).Should(Succeed(), "Failed to create member cluster")
@@ -2613,6 +2629,9 @@ var _ = Describe("Test Work Generator Controller for clusterResourcePlacement", 
 			memberCluster := clusterv1beta1.MemberCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: memberClusterName,
+					Labels: map[string]string{
+						placementv1beta1.MemberClusterNameLabel: memberClusterName,
+					},
 				},
 			}
 			Expect(k8sClient.Create(ctx, &memberCluster)).Should(Succeed(), "Failed to create member cluster")
@@ -4751,7 +4770,8 @@ var _ = Describe("Test Work Generator Controller for ResourcePlacement", func() 
 				ObjectMeta: metav1.ObjectMeta{
 					Name: memberClusterName,
 					Labels: map[string]string{
-						"override": "true",
+						"override":                              "true",
+						placementv1beta1.MemberClusterNameLabel: memberClusterName,
 					},
 				},
 			}

--- a/pkg/scheduler/watchers/membercluster/suite_test.go
+++ b/pkg/scheduler/watchers/membercluster/suite_test.go
@@ -67,7 +67,7 @@ var (
 			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 				Labels: map[string]string{
-					placementv1beta1.MemberClusterNameLabel: name,
+					placementv1beta1.MemberNameLabel: name,
 				},
 			},
 		}

--- a/pkg/scheduler/watchers/membercluster/suite_test.go
+++ b/pkg/scheduler/watchers/membercluster/suite_test.go
@@ -66,6 +66,9 @@ var (
 		memberCluster := &clusterv1beta1.MemberCluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
+				Labels: map[string]string{
+					placementv1beta1.MemberClusterNameLabel: name,
+				},
 			},
 		}
 		controllerutil.AddFinalizer(memberCluster, placementv1beta1.MemberClusterFinalizer)

--- a/test/e2e/actuals_test.go
+++ b/test/e2e/actuals_test.go
@@ -1256,8 +1256,30 @@ func crpStatusWithOverrideUpdatedActual(
 	wantClusterResourceOverrides []string,
 	wantResourceOverrides []placementv1beta1.NamespacedName) func() error {
 	crpKey := types.NamespacedName{Name: fmt.Sprintf(crpNameTemplate, GinkgoParallelProcess())}
+	croMap := make(map[string][]string, len(wantSelectedClusters))
+	roMap := make(map[string][]placementv1beta1.NamespacedName, len(wantSelectedClusters))
+	for _, name := range wantSelectedClusters {
+		croMap[name] = wantClusterResourceOverrides
+		roMap[name] = wantResourceOverrides
+	}
 	return placementStatusWithOverrideUpdatedActual(crpKey, wantSelectedResourceIdentifiers, wantSelectedClusters,
-		wantObservedResourceIndex, wantClusterResourceOverrides, wantResourceOverrides)
+		wantObservedResourceIndex, croMap, roMap)
+}
+
+// crpStatusWithSingleClusterOverrideUpdatedActual is like crpStatusWithOverrideUpdatedActual but
+// applies the override only to overrideCluster while other selected clusters receive no override.
+func crpStatusWithSingleClusterOverrideUpdatedActual(
+	wantSelectedResourceIdentifiers []placementv1beta1.ResourceIdentifier,
+	wantSelectedClusters []string,
+	wantObservedResourceIndex string,
+	overrideCluster string,
+	wantClusterResourceOverrides []string,
+	wantResourceOverrides []placementv1beta1.NamespacedName) func() error {
+	crpKey := types.NamespacedName{Name: fmt.Sprintf(crpNameTemplate, GinkgoParallelProcess())}
+	croMap := map[string][]string{overrideCluster: wantClusterResourceOverrides}
+	roMap := map[string][]placementv1beta1.NamespacedName{overrideCluster: wantResourceOverrides}
+	return placementStatusWithOverrideUpdatedActual(crpKey, wantSelectedResourceIdentifiers, wantSelectedClusters,
+		wantObservedResourceIndex, croMap, roMap)
 }
 
 func rpStatusWithOverrideUpdatedActual(
@@ -1267,8 +1289,14 @@ func rpStatusWithOverrideUpdatedActual(
 	wantClusterResourceOverrides []string,
 	wantResourceOverrides []placementv1beta1.NamespacedName) func() error {
 	rpKey := types.NamespacedName{Name: fmt.Sprintf(rpNameTemplate, GinkgoParallelProcess()), Namespace: appNamespace().Name}
+	croMap := make(map[string][]string, len(wantSelectedClusters))
+	roMap := make(map[string][]placementv1beta1.NamespacedName, len(wantSelectedClusters))
+	for _, name := range wantSelectedClusters {
+		croMap[name] = wantClusterResourceOverrides
+		roMap[name] = wantResourceOverrides
+	}
 	return placementStatusWithOverrideUpdatedActual(rpKey, wantSelectedResourceIdentifiers, wantSelectedClusters,
-		wantObservedResourceIndex, wantClusterResourceOverrides, wantResourceOverrides)
+		wantObservedResourceIndex, croMap, roMap)
 }
 
 func placementStatusWithOverrideUpdatedActual(
@@ -1276,22 +1304,24 @@ func placementStatusWithOverrideUpdatedActual(
 	wantSelectedResourceIdentifiers []placementv1beta1.ResourceIdentifier,
 	wantSelectedClusters []string,
 	wantObservedResourceIndex string,
-	wantClusterResourceOverrides []string,
-	wantResourceOverrides []placementv1beta1.NamespacedName,
+	wantClusterResourceOverrides map[string][]string,
+	wantResourceOverrides map[string][]placementv1beta1.NamespacedName,
 ) func() error {
 	return func() error {
 		placement, err := retrievePlacement(placementKey)
 		if err != nil {
 			return err
 		}
-		hasOverride := len(wantResourceOverrides) > 0 || len(wantClusterResourceOverrides) > 0
+		hasOverride := false
 		var wantPlacementStatus []placementv1beta1.PerClusterPlacementStatus
 		for _, name := range wantSelectedClusters {
+			perClusterHasOverride := len(wantClusterResourceOverrides[name]) > 0 || len(wantResourceOverrides[name]) > 0
+			hasOverride = hasOverride || perClusterHasOverride
 			wantPlacementStatus = append(wantPlacementStatus, placementv1beta1.PerClusterPlacementStatus{
 				ClusterName:                        name,
-				Conditions:                         perClusterRolloutCompletedConditions(placement.GetGeneration(), true, hasOverride),
-				ApplicableResourceOverrides:        wantResourceOverrides,
-				ApplicableClusterResourceOverrides: wantClusterResourceOverrides,
+				Conditions:                         perClusterRolloutCompletedConditions(placement.GetGeneration(), true, perClusterHasOverride),
+				ApplicableResourceOverrides:        wantResourceOverrides[name],
+				ApplicableClusterResourceOverrides: wantClusterResourceOverrides[name],
 				ObservedResourceIndex:              wantObservedResourceIndex,
 			})
 		}

--- a/test/e2e/placement_cro_test.go
+++ b/test/e2e/placement_cro_test.go
@@ -18,7 +18,6 @@ package e2e
 import (
 	"fmt"
 
-	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -955,9 +954,9 @@ var _ = Context("creating clusterResourceOverride for a namespace-only CRP", Ord
 	})
 })
 
-// This test verifies that the automatic member-cluster-name label can be used to target
+// This test verifies that the automatic member-name label can be used to target
 // a specific cluster by name in a ClusterResourceOverride via labelSelector.
-var _ = Context("creating clusterResourceOverride selecting a single cluster by the member-cluster-name label", Ordered, func() {
+var _ = Context("creating clusterResourceOverride selecting a single cluster by the member-name label", Ordered, func() {
 	crpName := fmt.Sprintf(crpNameTemplate, GinkgoParallelProcess())
 	croName := fmt.Sprintf(croNameTemplate, GinkgoParallelProcess())
 	croSnapShotName := fmt.Sprintf(placementv1beta1.OverrideSnapshotNameFmt, croName, 0)
@@ -971,7 +970,7 @@ var _ = Context("creating clusterResourceOverride selecting a single cluster by 
 		By("creating work resources")
 		createWorkResources()
 
-		// Create the CRO that selects a single cluster using the member-cluster-name label.
+		// Create the CRO that selects a single cluster using the member-name label.
 		cro := &placementv1beta1.ClusterResourceOverride{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: croName,
@@ -986,7 +985,7 @@ var _ = Context("creating clusterResourceOverride selecting a single cluster by 
 									{
 										LabelSelector: &metav1.LabelSelector{
 											MatchLabels: map[string]string{
-												placementv1beta1.MemberClusterNameLabel: targetCluster.ClusterName,
+												placementv1beta1.MemberNameLabel: targetCluster.ClusterName,
 											},
 										},
 									},
@@ -1027,39 +1026,11 @@ var _ = Context("creating clusterResourceOverride selecting a single cluster by 
 
 	It("should update CRP status as expected", func() {
 		wantCRONames := []string{croSnapShotName}
-		crpKey := types.NamespacedName{Name: crpName}
 		// The CRO targets only one cluster via clusterSelector, so only the targeted
 		// cluster should have ApplicableClusterResourceOverrides set.
-		crpStatusUpdatedActual := func() error {
-			crp := &placementv1beta1.ClusterResourcePlacement{}
-			if err := hubClient.Get(ctx, crpKey, crp); err != nil {
-				return err
-			}
-			var wantPerClusterStatuses []placementv1beta1.PerClusterPlacementStatus
-			for _, name := range allMemberClusterNames {
-				status := placementv1beta1.PerClusterPlacementStatus{
-					ClusterName:           name,
-					ObservedResourceIndex: "0",
-				}
-				if name == targetCluster.ClusterName {
-					status.ApplicableClusterResourceOverrides = wantCRONames
-					status.Conditions = perClusterRolloutCompletedConditions(crp.Generation, true, true)
-				} else {
-					status.Conditions = perClusterRolloutCompletedConditions(crp.Generation, true, false)
-				}
-				wantPerClusterStatuses = append(wantPerClusterStatuses, status)
-			}
-			wantStatus := &placementv1beta1.PlacementStatus{
-				Conditions:                  crpRolloutCompletedConditions(crp.Generation, true),
-				PerClusterPlacementStatuses: wantPerClusterStatuses,
-				SelectedResources:           workResourceIdentifiers(),
-				ObservedResourceIndex:       "0",
-			}
-			if diff := cmp.Diff(crp.GetPlacementStatus(), wantStatus, placementStatusCmpOptions...); diff != "" {
-				return fmt.Errorf("Placement status diff (-got, +want): %s", diff)
-			}
-			return nil
-		}
+		crpStatusUpdatedActual := crpStatusWithSingleClusterOverrideUpdatedActual(
+			workResourceIdentifiers(), allMemberClusterNames, "0",
+			targetCluster.ClusterName, wantCRONames, nil)
 		Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update CRP %s status as expected", crpName)
 	})
 
@@ -1067,12 +1038,10 @@ var _ = Context("creating clusterResourceOverride selecting a single cluster by 
 
 	It("should have override annotation only on the targeted cluster", func() {
 		wantAnnotations := map[string]string{croTestAnnotationKey: croTestAnnotationValue}
-		Eventually(func() error {
-			return validateAnnotationOfWorkNamespaceOnCluster(targetCluster, wantAnnotations)
-		}, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to override annotation on targeted cluster %s", targetCluster.ClusterName)
-		Eventually(func() error {
-			return validateAnnotationOfConfigMapOnCluster(targetCluster, wantAnnotations)
-		}, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to override configmap annotation on targeted cluster %s", targetCluster.ClusterName)
+		Expect(validateAnnotationOfWorkNamespaceOnCluster(targetCluster, wantAnnotations)).Should(Succeed(),
+			"Failed to override annotation on targeted cluster %s", targetCluster.ClusterName)
+		Expect(validateAnnotationOfConfigMapOnCluster(targetCluster, wantAnnotations)).Should(Succeed(),
+			"Failed to override configmap annotation on targeted cluster %s", targetCluster.ClusterName)
 	})
 
 	It("should not have override annotation on other clusters", func() {
@@ -1080,9 +1049,13 @@ var _ = Context("creating clusterResourceOverride selecting a single cluster by 
 			if cluster.ClusterName == targetCluster.ClusterName {
 				continue
 			}
-			Expect(validateNamespaceNoAnnotationOnCluster(cluster, croTestAnnotationKey)).Should(Succeed(),
+			Consistently(func() error {
+				return validateNamespaceNoAnnotationOnCluster(cluster, croTestAnnotationKey)
+			}, consistentlyDuration, consistentlyInterval).Should(Succeed(),
 				"Override annotation should not be present on non-targeted cluster %s", cluster.ClusterName)
-			Expect(validateConfigMapNoAnnotationKeyOnCluster(cluster, croTestAnnotationKey)).Should(Succeed(),
+			Consistently(func() error {
+				return validateConfigMapNoAnnotationKeyOnCluster(cluster, croTestAnnotationKey)
+			}, consistentlyDuration, consistentlyInterval).Should(Succeed(),
 				"Override annotation should not be present on non-targeted cluster %s", cluster.ClusterName)
 		}
 	})

--- a/test/e2e/placement_cro_test.go
+++ b/test/e2e/placement_cro_test.go
@@ -18,6 +18,7 @@ package e2e
 import (
 	"fmt"
 
+	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -27,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	placementv1beta1 "github.com/kubefleet-dev/kubefleet/apis/placement/v1beta1"
+	"github.com/kubefleet-dev/kubefleet/test/e2e/framework"
 )
 
 // TODO: Add more tests to cover the negative cases that override failed, need to make sure
@@ -949,6 +951,139 @@ var _ = Context("creating clusterResourceOverride for a namespace-only CRP", Ord
 				err := memberCluster.KubeClient.Get(ctx, types.NamespacedName{Namespace: workNamespaceName, Name: configMapName}, configMap)
 				return errors.IsNotFound(err)
 			}, consistentlyDuration, eventuallyInterval).Should(BeTrue(), "ConfigMap should not be placed on member cluster %s", memberCluster.ClusterName)
+		}
+	})
+})
+
+// This test verifies that the automatic member-cluster-name label can be used to target
+// a specific cluster by name in a ClusterResourceOverride via labelSelector.
+var _ = Context("creating clusterResourceOverride selecting a single cluster by the member-cluster-name label", Ordered, func() {
+	crpName := fmt.Sprintf(crpNameTemplate, GinkgoParallelProcess())
+	croName := fmt.Sprintf(croNameTemplate, GinkgoParallelProcess())
+	croSnapShotName := fmt.Sprintf(placementv1beta1.OverrideSnapshotNameFmt, croName, 0)
+
+	// Target only the first member cluster by its name label.
+	var targetCluster *framework.Cluster
+
+	BeforeAll(func() {
+		targetCluster = allMemberClusters[0]
+
+		By("creating work resources")
+		createWorkResources()
+
+		// Create the CRO that selects a single cluster using the member-cluster-name label.
+		cro := &placementv1beta1.ClusterResourceOverride{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: croName,
+			},
+			Spec: placementv1beta1.ClusterResourceOverrideSpec{
+				ClusterResourceSelectors: workResourceSelector(),
+				Policy: &placementv1beta1.OverridePolicy{
+					OverrideRules: []placementv1beta1.OverrideRule{
+						{
+							ClusterSelector: &placementv1beta1.ClusterSelector{
+								ClusterSelectorTerms: []placementv1beta1.ClusterSelectorTerm{
+									{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												placementv1beta1.MemberClusterNameLabel: targetCluster.ClusterName,
+											},
+										},
+									},
+								},
+							},
+							JSONPatchOverrides: []placementv1beta1.JSONPatchOverride{
+								{
+									Operator: placementv1beta1.JSONPatchOverrideOpAdd,
+									Path:     "/metadata/annotations",
+									Value:    apiextensionsv1.JSON{Raw: []byte(fmt.Sprintf(`{"%s": "%s"}`, croTestAnnotationKey, croTestAnnotationValue))},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		By(fmt.Sprintf("creating clusterResourceOverride %s targeting cluster %s", croName, targetCluster.ClusterName))
+		Expect(hubClient.Create(ctx, cro)).To(Succeed(), "Failed to create clusterResourceOverride %s", croName)
+
+		// Wait for the CRO snapshot to be created before the CRP.
+		Eventually(func() error {
+			croSnap := &placementv1beta1.ClusterResourceOverrideSnapshot{}
+			return hubClient.Get(ctx, types.NamespacedName{Name: croSnapShotName}, croSnap)
+		}, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to create CRO snapshot")
+
+		// Create the CRP.
+		createCRP(crpName)
+	})
+
+	AfterAll(func() {
+		By(fmt.Sprintf("deleting placement %s and related resources", crpName))
+		ensureCRPAndRelatedResourcesDeleted(crpName, allMemberClusters)
+
+		By(fmt.Sprintf("deleting clusterResourceOverride %s", croName))
+		cleanupClusterResourceOverride(croName)
+	})
+
+	It("should update CRP status as expected", func() {
+		wantCRONames := []string{croSnapShotName}
+		crpKey := types.NamespacedName{Name: crpName}
+		// The CRO targets only one cluster via clusterSelector, so only the targeted
+		// cluster should have ApplicableClusterResourceOverrides set.
+		crpStatusUpdatedActual := func() error {
+			crp := &placementv1beta1.ClusterResourcePlacement{}
+			if err := hubClient.Get(ctx, crpKey, crp); err != nil {
+				return err
+			}
+			var wantPerClusterStatuses []placementv1beta1.PerClusterPlacementStatus
+			for _, name := range allMemberClusterNames {
+				status := placementv1beta1.PerClusterPlacementStatus{
+					ClusterName:           name,
+					ObservedResourceIndex: "0",
+				}
+				if name == targetCluster.ClusterName {
+					status.ApplicableClusterResourceOverrides = wantCRONames
+					status.Conditions = perClusterRolloutCompletedConditions(crp.Generation, true, true)
+				} else {
+					status.Conditions = perClusterRolloutCompletedConditions(crp.Generation, true, false)
+				}
+				wantPerClusterStatuses = append(wantPerClusterStatuses, status)
+			}
+			wantStatus := &placementv1beta1.PlacementStatus{
+				Conditions:                  crpRolloutCompletedConditions(crp.Generation, true),
+				PerClusterPlacementStatuses: wantPerClusterStatuses,
+				SelectedResources:           workResourceIdentifiers(),
+				ObservedResourceIndex:       "0",
+			}
+			if diff := cmp.Diff(crp.GetPlacementStatus(), wantStatus, placementStatusCmpOptions...); diff != "" {
+				return fmt.Errorf("Placement status diff (-got, +want): %s", diff)
+			}
+			return nil
+		}
+		Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update CRP %s status as expected", crpName)
+	})
+
+	It("should place the selected resources on all member clusters", checkIfPlacedWorkResourcesOnAllMemberClusters)
+
+	It("should have override annotation only on the targeted cluster", func() {
+		wantAnnotations := map[string]string{croTestAnnotationKey: croTestAnnotationValue}
+		Eventually(func() error {
+			return validateAnnotationOfWorkNamespaceOnCluster(targetCluster, wantAnnotations)
+		}, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to override annotation on targeted cluster %s", targetCluster.ClusterName)
+		Eventually(func() error {
+			return validateAnnotationOfConfigMapOnCluster(targetCluster, wantAnnotations)
+		}, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to override configmap annotation on targeted cluster %s", targetCluster.ClusterName)
+	})
+
+	It("should not have override annotation on other clusters", func() {
+		for _, cluster := range allMemberClusters {
+			if cluster.ClusterName == targetCluster.ClusterName {
+				continue
+			}
+			Expect(validateNamespaceNoAnnotationOnCluster(cluster, croTestAnnotationKey)).Should(Succeed(),
+				"Override annotation should not be present on non-targeted cluster %s", cluster.ClusterName)
+			Expect(validateConfigMapNoAnnotationKeyOnCluster(cluster, croTestAnnotationKey)).Should(Succeed(),
+				"Override annotation should not be present on non-targeted cluster %s", cluster.ClusterName)
 		}
 	})
 })

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -285,6 +285,11 @@ func checkIfMemberClusterHasJoined(memberCluster *framework.Cluster) {
 			return fmt.Errorf("agent status diff (-got, +want): %s", diff)
 		}
 
+		// Verify the member cluster name label is set.
+		if mcObj.Labels[placementv1beta1.MemberClusterNameLabel] != memberCluster.ClusterName {
+			return fmt.Errorf("member cluster name label = %q, want %q", mcObj.Labels[placementv1beta1.MemberClusterNameLabel], memberCluster.ClusterName)
+		}
+
 		return nil
 	}, longEventuallyDuration, eventuallyInterval).Should(Succeed(), "Member cluster has not joined yet")
 }

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -286,8 +286,8 @@ func checkIfMemberClusterHasJoined(memberCluster *framework.Cluster) {
 		}
 
 		// Verify the member cluster name label is set.
-		if mcObj.Labels[placementv1beta1.MemberClusterNameLabel] != memberCluster.ClusterName {
-			return fmt.Errorf("member cluster name label = %q, want %q", mcObj.Labels[placementv1beta1.MemberClusterNameLabel], memberCluster.ClusterName)
+		if mcObj.Labels[placementv1beta1.MemberNameLabel] != memberCluster.ClusterName {
+			return fmt.Errorf("member cluster name label = %q, want %q", mcObj.Labels[placementv1beta1.MemberNameLabel], memberCluster.ClusterName)
 		}
 
 		return nil

--- a/test/scheduler/utils_test.go
+++ b/test/scheduler/utils_test.go
@@ -217,6 +217,9 @@ func createMemberCluster(name string, taints []clusterv1beta1.Taint) {
 	memberCluster := clusterv1beta1.MemberCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
+			Labels: map[string]string{
+				placementv1beta1.MemberClusterNameLabel: name,
+			},
 		},
 		Spec: clusterv1beta1.MemberClusterSpec{
 			Identity: rbacv1.Subject{

--- a/test/scheduler/utils_test.go
+++ b/test/scheduler/utils_test.go
@@ -218,7 +218,7 @@ func createMemberCluster(name string, taints []clusterv1beta1.Taint) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 			Labels: map[string]string{
-				placementv1beta1.MemberClusterNameLabel: name,
+				placementv1beta1.MemberNameLabel: name,
 			},
 		},
 		Spec: clusterv1beta1.MemberClusterSpec{


### PR DESCRIPTION
### Description of your changes

Automatically adds a kubernetes-fleet.io/member-cluster-name label to MemberCluster objects during reconciliation, enabling users to select clusters by name in ResourceOverride and ClusterResourceOverride via labelSelector.

- **New clusters**: Label is added on first reconcile (same mechanism as the finalizer)
- **Existing clusters after upgrade**: Label is added on the next heartbeat-triggered reconcile — no manual action, no downtime
- **Self-healing**: If removed, the next reconcile restores it
- **No infinite reconcile loop**: GenerationChangedPredicate filters out metadata-only updates

Fixes #101 

I have:

- [x] Associated this change with a known KubeFleet Issue (Bug, Feature, etc).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
Locally, yes. Also added necessary tests and updated existing ones.

### Special notes for your reviewer
N/A
