### PR TITLE
feat: add make join-members target to join member clusters to hub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ HUB_SERVER_URL ?= https://172.19.0.2:6443
 HUB_KIND_CLUSTER_NAME = hub-testing
 MEMBER_KIND_CLUSTER_NAME = member-testing
 MEMBER_CLUSTER_COUNT ?= 3
+JOIN_MEMBERS ?= false
 
 # Directories
 ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
@@ -175,6 +176,18 @@ e2e-tests-custom: setup-clusters ## Run custom E2E tests with labels
 .PHONY: setup-clusters
 setup-clusters: ## Set up Kind clusters for E2E testing
 	cd ./test/e2e && chmod +x ./setup.sh && ./setup.sh $(MEMBER_CLUSTER_COUNT)
+ifeq ($(JOIN_MEMBERS),true)
+	$(MAKE) join-members
+else
+	@echo ""
+	@echo "Clusters are ready but member clusters have not been joined to the hub."
+	@echo "To join them, run: make join-members"
+	@echo "Or re-run with: JOIN_MEMBERS=true make setup-clusters"
+endif
+
+.PHONY: join-members
+join-members: ## Join member clusters to the hub cluster (run after setup-clusters)
+	cd ./test/e2e && chmod +x ./join.sh && ./join.sh $(MEMBER_CLUSTER_COUNT)
 
 .PHONY: collect-e2e-logs
 collect-e2e-logs: ## Collect logs from hub and member agent pods after e2e tests

--- a/test/e2e/join.sh
+++ b/test/e2e/join.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+# This script joins member clusters to the hub cluster by creating MemberCluster CRs.
+# It should be run after setup.sh has completed.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
+MEMBER_CLUSTER_COUNT=$1
+
+HUB_CLUSTER="hub"
+declare -a MEMBER_CLUSTERS=()
+
+for (( i=1;i<=MEMBER_CLUSTER_COUNT;i++ ))
+do
+  MEMBER_CLUSTERS+=("cluster-$i")
+done
+
+# Verify that the hub cluster exists.
+if ! kind get clusters 2>/dev/null | grep -q "^${HUB_CLUSTER}$"; then
+    echo "Error: Hub cluster '${HUB_CLUSTER}' not found. Run 'make setup-clusters' first."
+    exit 1
+fi
+
+# Verify that the member clusters exist.
+for i in "${MEMBER_CLUSTERS[@]}"
+do
+    if ! kind get clusters 2>/dev/null | grep -q "^${i}$"; then
+        echo "Error: Member cluster '${i}' not found. Run 'make setup-clusters' first."
+        exit 1
+    fi
+done
+
+# Switch to the hub cluster context.
+kind export kubeconfig --name "$HUB_CLUSTER"
+
+# Verify that fleet-system namespace exists on the hub cluster.
+if ! kubectl get namespace fleet-system &>/dev/null; then
+    echo "Error: Namespace 'fleet-system' not found on hub cluster. Run 'make setup-clusters' first."
+    exit 1
+fi
+
+# Create MemberCluster CRs for each member cluster.
+echo "Creating MemberCluster CRs on the hub cluster..."
+
+for i in "${MEMBER_CLUSTERS[@]}"
+do
+    echo "Creating MemberCluster CR for kind-${i}..."
+    cat <<EOF | kubectl apply -f -
+apiVersion: cluster.kubernetes-fleet.io/v1beta1
+kind: MemberCluster
+metadata:
+  name: kind-${i}
+spec:
+  identity:
+    name: fleet-member-agent-${i}
+    kind: ServiceAccount
+    namespace: fleet-system
+    apiGroup: ""
+  heartbeatPeriodSeconds: 15
+EOF
+done
+
+# Wait for all member clusters to reach Joined state.
+echo "Waiting for member clusters to join..."
+
+TIMEOUT=120
+for i in "${MEMBER_CLUSTERS[@]}"
+do
+    echo "Waiting for kind-${i} to join..."
+    SECONDS=0
+    while true; do
+        JOINED=$(kubectl get membercluster "kind-${i}" -o jsonpath='{.status.conditions[?(@.type=="Joined")].status}' 2>/dev/null || echo "")
+        if [ "$JOINED" = "True" ]; then
+            echo "kind-${i} has joined successfully."
+            break
+        fi
+        if [ $SECONDS -ge $TIMEOUT ]; then
+            echo "Error: Timed out waiting for kind-${i} to join after ${TIMEOUT}s."
+            kubectl get membercluster "kind-${i}" -o yaml 2>/dev/null || true
+            exit 1
+        fi
+        sleep 2
+    done
+done
+
+echo "All member clusters have joined the hub cluster."


### PR DESCRIPTION
### Description of your changes

This pull request enhances the E2E testing workflow by making the process of joining member clusters to the hub cluster more flexible and explicit. It introduces a new script to handle the joining process and updates the `Makefile` to allow users to control when member clusters are joined, improving usability and transparency.

**E2E Cluster Joining Improvements:**

* Added a new `join.sh` script (`test/e2e/join.sh`) that automates the process of creating `MemberCluster` custom resources for each member cluster, verifies cluster existence, and waits for each member to reach the "Joined" state.
* Updated the `Makefile` to introduce the `JOIN_MEMBERS` variable, allowing users to control whether member clusters are joined to the hub during setup. Users are informed how to join clusters if they are not joined automatically. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R43) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R179-R190)
* Added a new `join-members` Makefile target that runs the new join script, enabling joining to be performed as a separate, explicit step after cluster setup.

Fixes #555 

I have:

- [x] Associated this change with a known KubeFleet Issue (Bug, Feature, etc).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
N/A

### Special notes for your reviewer
N/A