### PR TITLE
feat: have update run skip a stage with no clusters 

### DIFF
--- a/pkg/controllers/updaterun/controller_integration_test.go
+++ b/pkg/controllers/updaterun/controller_integration_test.go
@@ -975,6 +975,12 @@ func generateFalseConditionWithReason(obj client.Object, condType any, reason st
 	return falseCond
 }
 
+func generateTrueConditionWithReason(obj client.Object, condType any, reason string) metav1.Condition {
+	falseCond := generateTrueCondition(obj, condType)
+	falseCond.Reason = reason
+	return falseCond
+}
+
 func generateProgressingUnknownConditionWithReason(obj client.Object, reason string) metav1.Condition {
 	return metav1.Condition{
 		Status:             metav1.ConditionUnknown,

--- a/pkg/controllers/updaterun/controller_integration_test.go
+++ b/pkg/controllers/updaterun/controller_integration_test.go
@@ -976,9 +976,9 @@ func generateFalseConditionWithReason(obj client.Object, condType any, reason st
 }
 
 func generateTrueConditionWithReason(obj client.Object, condType any, reason string) metav1.Condition {
-	falseCond := generateTrueCondition(obj, condType)
-	falseCond.Reason = reason
-	return falseCond
+	trueCond := generateTrueCondition(obj, condType)
+	trueCond.Reason = reason
+	return trueCond
 }
 
 func generateProgressingUnknownConditionWithReason(obj client.Object, reason string) metav1.Condition {

--- a/pkg/controllers/updaterun/controller_integration_test.go
+++ b/pkg/controllers/updaterun/controller_integration_test.go
@@ -963,12 +963,6 @@ func generateFalseCondition(obj client.Object, condType any) metav1.Condition {
 	}
 }
 
-func generateFalseProgressingCondition(obj client.Object, condType any, reason string) metav1.Condition {
-	falseCond := generateFalseCondition(obj, condType)
-	falseCond.Reason = reason
-	return falseCond
-}
-
 func generateFalseConditionWithReason(obj client.Object, condType any, reason string) metav1.Condition {
 	falseCond := generateFalseCondition(obj, condType)
 	falseCond.Reason = reason

--- a/pkg/controllers/updaterun/execution.go
+++ b/pkg/controllers/updaterun/execution.go
@@ -76,6 +76,13 @@ func (r *Reconciler) execute(
 	markUpdateRunProgressingIfNotWaitingOrStuck(updateRun)
 	if updatingStageIndex < len(updateRunStatus.StagesStatus) {
 		updatingStageStatus = &updateRunStatus.StagesStatus[updatingStageIndex]
+		// Skip the entire stage when there are 0 clusters.
+		if len(updatingStageStatus.Clusters) == 0 {
+			klog.V(2).InfoS("The stage has 0 clusters, skipping the entire stage", "stage", updatingStageStatus.StageName, "updateRun", klog.KObj(updateRun))
+			markStageUpdatingSkippedNoClusters(updatingStageStatus, updateRun.GetGeneration())
+			// No need to wait to get to the next stage.
+			return false, 0, nil
+		}
 		approved, err := r.checkBeforeStageTasksStatus(ctx, updatingStageIndex, updateRun)
 		if err != nil {
 			return false, 0, err
@@ -770,6 +777,25 @@ func markStageUpdatingSucceeded(stageUpdatingStatus *placementv1beta1.StageUpdat
 		ObservedGeneration: generation,
 		Reason:             condition.StageUpdatingSucceededReason,
 		Message:            "Stage update completed successfully",
+	})
+}
+
+// markStageUpdatingSkippedNoClusters marks the stage updating status as skipped due to no clusters in memory.
+// Note: StartTime and EndTime are not set because the stage never actually ran.
+func markStageUpdatingSkippedNoClusters(stageUpdatingStatus *placementv1beta1.StageUpdatingStatus, generation int64) {
+	meta.SetStatusCondition(&stageUpdatingStatus.Conditions, metav1.Condition{
+		Type:               string(placementv1beta1.StageUpdatingConditionProgressing),
+		Status:             metav1.ConditionFalse,
+		ObservedGeneration: generation,
+		Reason:             condition.StageUpdatingSkippedNoClustersReason,
+		Message:            "Stage skipped because it has no clusters",
+	})
+	meta.SetStatusCondition(&stageUpdatingStatus.Conditions, metav1.Condition{
+		Type:               string(placementv1beta1.StageUpdatingConditionSucceeded),
+		Status:             metav1.ConditionTrue,
+		ObservedGeneration: generation,
+		Reason:             condition.StageUpdatingSkippedNoClustersReason,
+		Message:            "Stage skipped because it has no clusters",
 	})
 }
 

--- a/pkg/controllers/updaterun/execution.go
+++ b/pkg/controllers/updaterun/execution.go
@@ -79,7 +79,7 @@ func (r *Reconciler) execute(
 		// Skip the entire stage when there are 0 clusters.
 		if len(updatingStageStatus.Clusters) == 0 {
 			klog.V(2).InfoS("The stage has 0 clusters, skipping the entire stage", "stage", updatingStageStatus.StageName, "updateRun", klog.KObj(updateRun))
-			markStageUpdatingSkippedNoClusters(updatingStageStatus, updateRun.GetGeneration())
+			markStageUpdatingSkippedNoClusters(updatingStageStatus, updateRun.GetGeneration(), "Stage skipped because it has no clusters")
 			// No need to wait to get to the next stage.
 			return false, 0, nil
 		}
@@ -781,21 +781,26 @@ func markStageUpdatingSucceeded(stageUpdatingStatus *placementv1beta1.StageUpdat
 }
 
 // markStageUpdatingSkippedNoClusters marks the stage updating status as skipped due to no clusters in memory.
-// Note: StartTime and EndTime are not set because the stage never actually ran.
-func markStageUpdatingSkippedNoClusters(stageUpdatingStatus *placementv1beta1.StageUpdatingStatus, generation int64) {
+func markStageUpdatingSkippedNoClusters(stageUpdatingStatus *placementv1beta1.StageUpdatingStatus, generation int64, message string) {
+	if stageUpdatingStatus.StartTime == nil {
+		stageUpdatingStatus.StartTime = &metav1.Time{Time: time.Now()}
+	}
+	if stageUpdatingStatus.EndTime == nil {
+		stageUpdatingStatus.EndTime = &metav1.Time{Time: time.Now()}
+	}
 	meta.SetStatusCondition(&stageUpdatingStatus.Conditions, metav1.Condition{
 		Type:               string(placementv1beta1.StageUpdatingConditionProgressing),
 		Status:             metav1.ConditionFalse,
 		ObservedGeneration: generation,
 		Reason:             condition.StageUpdatingSkippedNoClustersReason,
-		Message:            "Stage skipped because it has no clusters",
+		Message:            message,
 	})
 	meta.SetStatusCondition(&stageUpdatingStatus.Conditions, metav1.Condition{
 		Type:               string(placementv1beta1.StageUpdatingConditionSucceeded),
 		Status:             metav1.ConditionTrue,
 		ObservedGeneration: generation,
 		Reason:             condition.StageUpdatingSkippedNoClustersReason,
-		Message:            "Stage skipped because it has no clusters",
+		Message:            message,
 	})
 }
 

--- a/pkg/controllers/updaterun/execution_integration_test.go
+++ b/pkg/controllers/updaterun/execution_integration_test.go
@@ -103,6 +103,9 @@ var _ = Describe("UpdateRun execution tests - double stages", func() {
 
 		By("Creating a new resource snapshot")
 		Expect(k8sClient.Create(ctx, resourceSnapshot)).To(Succeed())
+
+		By("Creating a new cluster resource override")
+		Expect(k8sClient.Create(ctx, clusterResourceOverride)).To(Succeed())
 	})
 
 	AfterEach(OncePerOrdered, func() {
@@ -154,14 +157,11 @@ var _ = Describe("UpdateRun execution tests - double stages", func() {
 	Context("Cluster staged update run should update clusters one by one", Ordered, func() {
 		var wantApprovalRequest *placementv1beta1.ClusterApprovalRequest
 		BeforeAll(func() {
-			By("Creating a new cluster resource override")
-			Expect(k8sClient.Create(ctx, clusterResourceOverride)).To(Succeed())
-
 			By("Creating a new clusterStagedUpdateRun")
 			Expect(k8sClient.Create(ctx, updateRun)).To(Succeed())
 
 			By("Validating the initialization succeeded and the execution has not started")
-			initialized := generateSucceededInitializationStatus(crp, updateRun, testResourceSnapshotIndex, policySnapshot, updateStrategy, clusterResourceOverride)
+			initialized := generateInitializedStatus(crp, updateRun, testResourceSnapshotIndex, policySnapshot, updateStrategy, 10, generateTenClusterStagesStatus(clusterResourceOverride), generateTenClusterDeletionStageStatus())
 			wantStatus = generateExecutionNotStartedStatus(updateRun, initialized)
 			validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus, "")
 
@@ -220,7 +220,7 @@ var _ = Describe("UpdateRun execution tests - double stages", func() {
 		It("Should mark the 1st cluster in the 1st stage as succeeded after marking the binding available", func() {
 			By("Validating the 1st clusterResourceBinding is updated to Bound")
 			binding := resourceBindings[numTargetClusters-1] // cluster-9
-			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, 0)
+			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, &updateRun.Status.StagesStatus[0].Clusters[0])
 
 			By("Updating the 1st clusterResourceBinding to Available")
 			meta.SetStatusCondition(&binding.Status.Conditions, generateTrueCondition(binding, placementv1beta1.ResourceBindingAvailable))
@@ -245,7 +245,7 @@ var _ = Describe("UpdateRun execution tests - double stages", func() {
 		It("Should mark the 2nd cluster in the 1st stage as succeeded after marking the binding available", func() {
 			By("Validating the 2nd clusterResourceBinding is updated to Bound")
 			binding := resourceBindings[numTargetClusters-3] // cluster-7
-			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, 0)
+			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, &updateRun.Status.StagesStatus[0].Clusters[1])
 
 			By("Updating the 2nd clusterResourceBinding to Available")
 			meta.SetStatusCondition(&binding.Status.Conditions, generateTrueCondition(binding, placementv1beta1.ResourceBindingAvailable))
@@ -264,7 +264,7 @@ var _ = Describe("UpdateRun execution tests - double stages", func() {
 		It("Should mark the 3rd cluster in the 1st stage as succeeded after marking the binding available", func() {
 			By("Validating the 3rd clusterResourceBinding is updated to Bound")
 			binding := resourceBindings[numTargetClusters-5] // cluster-5
-			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, 0)
+			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, &updateRun.Status.StagesStatus[0].Clusters[2])
 
 			By("Updating the 3rd clusterResourceBinding to Available")
 			meta.SetStatusCondition(&binding.Status.Conditions, generateTrueCondition(binding, placementv1beta1.ResourceBindingAvailable))
@@ -283,7 +283,7 @@ var _ = Describe("UpdateRun execution tests - double stages", func() {
 		It("Should mark the 4th cluster in the 1st stage as succeeded after marking the binding available", func() {
 			By("Validating the 4th clusterResourceBinding is updated to Bound")
 			binding := resourceBindings[numTargetClusters-7] // cluster-3
-			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, 0)
+			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, &updateRun.Status.StagesStatus[0].Clusters[3])
 
 			By("Updating the 4th clusterResourceBinding to Available")
 			meta.SetStatusCondition(&binding.Status.Conditions, generateTrueCondition(binding, placementv1beta1.ResourceBindingAvailable))
@@ -302,7 +302,7 @@ var _ = Describe("UpdateRun execution tests - double stages", func() {
 		It("Should mark the 5th cluster in the 1st stage as succeeded after marking the binding available", func() {
 			By("Validating the 5th clusterResourceBinding is updated to Bound")
 			binding := resourceBindings[numTargetClusters-9] // cluster-1
-			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, 0)
+			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, &updateRun.Status.StagesStatus[0].Clusters[4])
 
 			By("Updating the 5th clusterResourceBinding to Available")
 			meta.SetStatusCondition(&binding.Status.Conditions, generateTrueCondition(binding, placementv1beta1.ResourceBindingAvailable))
@@ -352,7 +352,7 @@ var _ = Describe("UpdateRun execution tests - double stages", func() {
 			wantStatus.StagesStatus[0].AfterStageTaskStatus[1].Conditions = append(wantStatus.StagesStatus[0].AfterStageTaskStatus[1].Conditions,
 				generateTrueCondition(updateRun, placementv1beta1.StageTaskConditionApprovalRequestApproved))
 			// 1st stage completed, mark progressing condition reason as succeeded and add succeeded condition.
-			wantStatus.StagesStatus[0].Conditions[0] = generateFalseProgressingCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSucceededReason)
+			wantStatus.StagesStatus[0].Conditions[0] = generateFalseConditionWithReason(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSucceededReason)
 			wantStatus.StagesStatus[0].Conditions = append(wantStatus.StagesStatus[0].Conditions, generateTrueCondition(updateRun, placementv1beta1.StageUpdatingConditionSucceeded))
 			// 2nd stage waiting for before stage tasks.
 			wantStatus.StagesStatus[1].Conditions = append(wantStatus.StagesStatus[1].Conditions, generateFalseCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing))
@@ -435,7 +435,7 @@ var _ = Describe("UpdateRun execution tests - double stages", func() {
 		It("Should mark the 1st cluster in the 2nd stage as succeeded after approving request and marking the binding available", func() {
 			By("Validating the 1st clusterResourceBinding is updated to Bound")
 			binding := resourceBindings[0] // cluster-0
-			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, 1)
+			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, &updateRun.Status.StagesStatus[1].Clusters[0])
 
 			By("Updating the 1st clusterResourceBinding to Available")
 			meta.SetStatusCondition(&binding.Status.Conditions, generateTrueCondition(binding, placementv1beta1.ResourceBindingAvailable))
@@ -462,7 +462,7 @@ var _ = Describe("UpdateRun execution tests - double stages", func() {
 		It("Should mark the 2nd cluster in the 2nd stage as succeeded after marking the binding available", func() {
 			By("Validating the 2nd clusterResourceBinding is updated to Bound")
 			binding := resourceBindings[2] // cluster-2
-			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, 1)
+			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, &updateRun.Status.StagesStatus[1].Clusters[1])
 
 			By("Updating the 2nd clusterResourceBinding to Available")
 			meta.SetStatusCondition(&binding.Status.Conditions, generateTrueCondition(binding, placementv1beta1.ResourceBindingAvailable))
@@ -481,7 +481,7 @@ var _ = Describe("UpdateRun execution tests - double stages", func() {
 		It("Should mark the 3rd cluster in the 2nd stage as succeeded after marking the binding available", func() {
 			By("Validating the 3rd clusterResourceBinding is updated to Bound")
 			binding := resourceBindings[4] // cluster-4
-			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, 1)
+			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, &updateRun.Status.StagesStatus[1].Clusters[2])
 
 			By("Updating the 3rd clusterResourceBinding to Available")
 			meta.SetStatusCondition(&binding.Status.Conditions, generateTrueCondition(binding, placementv1beta1.ResourceBindingAvailable))
@@ -500,7 +500,7 @@ var _ = Describe("UpdateRun execution tests - double stages", func() {
 		It("Should mark the 4th cluster in the 2nd stage as succeeded after marking the binding available", func() {
 			By("Validating the 4th clusterResourceBinding is updated to Bound")
 			binding := resourceBindings[6] // cluster-6
-			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, 1)
+			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, &updateRun.Status.StagesStatus[1].Clusters[3])
 
 			By("Updating the 4th clusterResourceBinding to Available")
 			meta.SetStatusCondition(&binding.Status.Conditions, generateTrueCondition(binding, placementv1beta1.ResourceBindingAvailable))
@@ -519,7 +519,7 @@ var _ = Describe("UpdateRun execution tests - double stages", func() {
 		It("Should mark the 5th cluster in the 2nd stage as succeeded after marking the binding available", func() {
 			By("Validating the 5th clusterResourceBinding is updated to Bound")
 			binding := resourceBindings[8] // cluster-8
-			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, 1)
+			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, &updateRun.Status.StagesStatus[1].Clusters[4])
 
 			By("Updating the 5th clusterResourceBinding to Available")
 			meta.SetStatusCondition(&binding.Status.Conditions, generateTrueCondition(binding, placementv1beta1.ResourceBindingAvailable))
@@ -565,7 +565,7 @@ var _ = Describe("UpdateRun execution tests - double stages", func() {
 				generateTrueCondition(updateRun, placementv1beta1.StageTaskConditionApprovalRequestApproved))
 			wantStatus.StagesStatus[1].AfterStageTaskStatus[1].Conditions = append(wantStatus.StagesStatus[1].AfterStageTaskStatus[1].Conditions,
 				generateTrueCondition(updateRun, placementv1beta1.StageTaskConditionWaitTimeElapsed))
-			wantStatus.StagesStatus[1].Conditions[0] = generateFalseProgressingCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSucceededReason)
+			wantStatus.StagesStatus[1].Conditions[0] = generateFalseConditionWithReason(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSucceededReason)
 			wantStatus.StagesStatus[1].Conditions = append(wantStatus.StagesStatus[1].Conditions, generateTrueCondition(updateRun, placementv1beta1.StageUpdatingConditionSucceeded))
 			meta.SetStatusCondition(&wantStatus.Conditions, generateTrueCondition(updateRun, placementv1beta1.StagedUpdateRunConditionProgressing))
 
@@ -623,10 +623,10 @@ var _ = Describe("UpdateRun execution tests - double stages", func() {
 				wantStatus.DeletionStageStatus.Clusters[i].Conditions = append(wantStatus.DeletionStageStatus.Clusters[i].Conditions, generateTrueCondition(updateRun, placementv1beta1.ClusterUpdatingConditionSucceeded))
 			}
 			// Mark the stage progressing condition as false with succeeded reason and add succeeded condition.
-			wantStatus.DeletionStageStatus.Conditions[0] = generateFalseProgressingCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSucceededReason)
+			wantStatus.DeletionStageStatus.Conditions[0] = generateFalseConditionWithReason(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSucceededReason)
 			wantStatus.DeletionStageStatus.Conditions = append(wantStatus.DeletionStageStatus.Conditions, generateTrueCondition(updateRun, placementv1beta1.StageUpdatingConditionSucceeded))
 			// Mark updateRun progressing condition as false with succeeded reason and add succeeded condition.
-			meta.SetStatusCondition(&wantStatus.Conditions, generateFalseProgressingCondition(updateRun, placementv1beta1.StagedUpdateRunConditionProgressing, condition.UpdateRunSucceededReason))
+			meta.SetStatusCondition(&wantStatus.Conditions, generateFalseConditionWithReason(updateRun, placementv1beta1.StagedUpdateRunConditionProgressing, condition.UpdateRunSucceededReason))
 			wantStatus.Conditions = append(wantStatus.Conditions, generateTrueCondition(updateRun, placementv1beta1.StagedUpdateRunConditionSucceeded))
 			validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus, "")
 
@@ -640,9 +640,6 @@ var _ = Describe("UpdateRun execution tests - double stages", func() {
 	Context("Cluster staged update run should abort the execution within a failed updating stage", Ordered, func() {
 		var oldUpdateRunStuckThreshold time.Duration
 		BeforeAll(func() {
-			By("Creating a new cluster resource override")
-			Expect(k8sClient.Create(ctx, clusterResourceOverride)).To(Succeed())
-
 			// Set the updateRunStuckThreshold to 1 second for this test.
 			oldUpdateRunStuckThreshold = updateRunStuckThreshold
 			updateRunStuckThreshold = 1 * time.Second
@@ -651,7 +648,7 @@ var _ = Describe("UpdateRun execution tests - double stages", func() {
 			Expect(k8sClient.Create(ctx, updateRun)).To(Succeed())
 
 			By("Validating the initialization succeeded and the execution has not started")
-			initialized := generateSucceededInitializationStatus(crp, updateRun, testResourceSnapshotIndex, policySnapshot, updateStrategy, clusterResourceOverride)
+			initialized := generateInitializedStatus(crp, updateRun, testResourceSnapshotIndex, policySnapshot, updateStrategy, 10, generateTenClusterStagesStatus(clusterResourceOverride), generateTenClusterDeletionStageStatus())
 			wantStatus = generateExecutionNotStartedStatus(updateRun, initialized)
 			validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus, "")
 
@@ -685,7 +682,7 @@ var _ = Describe("UpdateRun execution tests - double stages", func() {
 
 			By("Validating the 1st clusterResourceBinding is updated to Bound")
 			binding := resourceBindings[numTargetClusters-1] // cluster-9
-			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, 0)
+			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, &updateRun.Status.StagesStatus[0].Clusters[0])
 
 			By("Updating the 1st clusterResourceBinding to ApplyFailed")
 			meta.SetStatusCondition(&binding.Status.Conditions, generateFalseCondition(binding, placementv1beta1.ResourceBindingApplied))
@@ -706,7 +703,7 @@ var _ = Describe("UpdateRun execution tests - double stages", func() {
 		It("Should abort the execution if the binding has unexpected state", func() {
 			By("Validating the 1st clusterResourceBinding is updated to Bound")
 			binding := resourceBindings[numTargetClusters-1] // cluster-9
-			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, 0)
+			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, &updateRun.Status.StagesStatus[0].Clusters[0])
 
 			By("Updating the 1st clusterResourceBinding's state to Scheduled (from Bound)")
 			binding.Spec.State = placementv1beta1.BindingStateScheduled
@@ -714,9 +711,9 @@ var _ = Describe("UpdateRun execution tests - double stages", func() {
 
 			By("Validating the updateRun has failed")
 			wantStatus.StagesStatus[0].Clusters[0].Conditions = append(wantStatus.StagesStatus[0].Clusters[0].Conditions, generateFalseCondition(updateRun, placementv1beta1.ClusterUpdatingConditionSucceeded))
-			wantStatus.StagesStatus[0].Conditions[0] = generateFalseProgressingCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingFailedReason)
+			wantStatus.StagesStatus[0].Conditions[0] = generateFalseConditionWithReason(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingFailedReason)
 			wantStatus.StagesStatus[0].Conditions = append(wantStatus.StagesStatus[0].Conditions, generateFalseCondition(updateRun, placementv1beta1.StageUpdatingConditionSucceeded))
-			meta.SetStatusCondition(&wantStatus.Conditions, generateFalseProgressingCondition(updateRun, placementv1beta1.StagedUpdateRunConditionProgressing, condition.UpdateRunFailedReason))
+			meta.SetStatusCondition(&wantStatus.Conditions, generateFalseConditionWithReason(updateRun, placementv1beta1.StagedUpdateRunConditionProgressing, condition.UpdateRunFailedReason))
 			wantStatus.Conditions = append(wantStatus.Conditions, generateFalseCondition(updateRun, placementv1beta1.StagedUpdateRunConditionSucceeded))
 			validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus, "")
 
@@ -729,10 +726,12 @@ var _ = Describe("UpdateRun execution tests - double stages", func() {
 		var wantApprovalRequest *placementv1beta1.ClusterApprovalRequest
 		BeforeAll(func() {
 			By("Reassigning the strategy to have 2 stages: one selecting all clusters and one empty")
+			sortingKey := "index"
 			updateStrategy.Spec.Stages = []placementv1beta1.StageConfig{
 				{
-					Name:          "stage1",
-					LabelSelector: &metav1.LabelSelector{}, // Empty label selector selects all clusters.
+					Name:            "stage1",
+					LabelSelector:   &metav1.LabelSelector{}, // Empty label selector selects all clusters.
+					SortingLabelKey: &sortingKey,
 					AfterStageTasks: []placementv1beta1.StageTask{
 						{
 							Type: placementv1beta1.StageTaskTypeApproval,
@@ -740,12 +739,8 @@ var _ = Describe("UpdateRun execution tests - double stages", func() {
 					},
 				},
 				{
-					Name: "stage2",
-					LabelSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{
-							"group": "nonexistent",
-						},
-					},
+					Name:          "stage2",
+					LabelSelector: nil,
 					BeforeStageTasks: []placementv1beta1.StageTask{
 						{
 							Type: placementv1beta1.StageTaskTypeApproval,
@@ -770,26 +765,9 @@ var _ = Describe("UpdateRun execution tests - double stages", func() {
 			Expect(k8sClient.Create(ctx, updateRun)).To(Succeed())
 
 			By("Validating the initialization succeeded")
-			// Build stage1 clusters (all target clusters)
-			stage1Clusters := make([]placementv1beta1.ClusterUpdatingStatus, numTargetClusters)
-			for i := 0; i < numTargetClusters; i++ {
-				stage1Clusters[i] = placementv1beta1.ClusterUpdatingStatus{ClusterName: fmt.Sprintf("cluster-%d", i)}
-			}
-			stagesStatus := []placementv1beta1.StageUpdatingStatus{
-				{StageName: "stage1", Clusters: stage1Clusters},
-				{StageName: "stage2", Clusters: []placementv1beta1.ClusterUpdatingStatus{}},
-			}
-			deletionStageStatus := &placementv1beta1.StageUpdatingStatus{
-				StageName: "kubernetes-fleet.io/deleteStage",
-				Clusters: []placementv1beta1.ClusterUpdatingStatus{
-					{ClusterName: "unscheduled-cluster-0"},
-					{ClusterName: "unscheduled-cluster-1"},
-					{ClusterName: "unscheduled-cluster-2"},
-				},
-			}
-			initialized := generateInitializedStatusWithCustomStages(
-				crp, updateRun, testResourceSnapshotIndex, policySnapshot, updateStrategy,
-				stagesStatus, deletionStageStatus,
+			initialized := generateInitializedStatus(
+				crp, updateRun, testResourceSnapshotIndex, policySnapshot, updateStrategy, 10,
+				generateTenClusterSingleStageStatus(clusterResourceOverride), generateTenClusterDeletionStageStatus(),
 			)
 			wantStatus = generateExecutionStartedStatus(updateRun, initialized)
 			validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus, "")
@@ -805,20 +783,17 @@ var _ = Describe("UpdateRun execution tests - double stages", func() {
 			By("Validating the 1st stage has startTime set")
 			Expect(updateRun.Status.StagesStatus[0].StartTime).ShouldNot(BeNil())
 
-			By("Marking all bindings in the first stage as available")
+			By("Marking all bindings in the first stage as available and validating all clusters have completed")
 			for i := 0; i < numTargetClusters; i++ {
-				binding := resourceBindings[i]
-				validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, 0)
+				binding := resourceBindings[numTargetClusters-1-i]
+				validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, &updateRun.Status.StagesStatus[0].Clusters[i])
 				meta.SetStatusCondition(&binding.Status.Conditions, generateTrueCondition(binding, placementv1beta1.ResourceBindingAvailable))
 				Expect(k8sClient.Status().Update(ctx, binding)).Should(Succeed(), "failed to update the binding status")
-			}
 
-			By("Validating all cluster have completed")
-			// Stage 0: all clusters succeeded, stage completed.
-			for i := 0; i < numTargetClusters; i++ {
 				meta.SetStatusCondition(&wantStatus.StagesStatus[0].Clusters[i].Conditions, generateTrueCondition(updateRun, placementv1beta1.ClusterUpdatingConditionStarted))
 				meta.SetStatusCondition(&wantStatus.StagesStatus[0].Clusters[i].Conditions, generateTrueCondition(updateRun, placementv1beta1.ClusterUpdatingConditionSucceeded))
 			}
+
 			wantStatus.StagesStatus[0].Conditions[0] = generateFalseCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing) // The progressing condition now becomes false with waiting reason.
 			wantStatus.StagesStatus[0].AfterStageTaskStatus[0].Conditions = append(wantStatus.StagesStatus[0].AfterStageTaskStatus[0].Conditions,
 				generateTrueCondition(updateRun, placementv1beta1.StageTaskConditionApprovalRequestCreated))
@@ -866,14 +841,14 @@ var _ = Describe("UpdateRun execution tests - double stages", func() {
 
 		It("Should skip the entire empty stage (stage2) and complete update run", func() {
 			// 1st stage completed, mark progressing condition reason as succeeded and add succeeded condition.
-			wantStatus.StagesStatus[0].Conditions[0] = generateFalseProgressingCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSucceededReason)
+			wantStatus.StagesStatus[0].Conditions[0] = generateFalseConditionWithReason(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSucceededReason)
 			wantStatus.StagesStatus[0].Conditions = append(wantStatus.StagesStatus[0].Conditions, generateTrueCondition(updateRun, placementv1beta1.StageUpdatingConditionSucceeded))
 
 			By("Validating the 2nd stage has been skipped and the update run completed")
 			// 2nd stage will not have before-stage or after-stage conditions.
 			// 2nd stage will not have any clusters.
 			// 2nd stage conditions should populate as skipped.
-			wantStatus.StagesStatus[1].Conditions = append(wantStatus.StagesStatus[1].Conditions, generateFalseProgressingCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSkippedNoClustersReason))
+			wantStatus.StagesStatus[1].Conditions = append(wantStatus.StagesStatus[1].Conditions, generateFalseConditionWithReason(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSkippedNoClustersReason))
 			wantStatus.StagesStatus[1].Conditions = append(wantStatus.StagesStatus[1].Conditions, generateTrueConditionWithReason(updateRun, placementv1beta1.StageUpdatingConditionSucceeded, condition.StageUpdatingSkippedNoClustersReason))
 			meta.SetStatusCondition(&wantStatus.Conditions, generateTrueCondition(updateRun, placementv1beta1.StagedUpdateRunConditionProgressing))
 
@@ -881,10 +856,10 @@ var _ = Describe("UpdateRun execution tests - double stages", func() {
 				wantStatus.DeletionStageStatus.Clusters[i].Conditions = append(wantStatus.DeletionStageStatus.Clusters[i].Conditions, generateTrueCondition(updateRun, placementv1beta1.ClusterUpdatingConditionStarted))
 				wantStatus.DeletionStageStatus.Clusters[i].Conditions = append(wantStatus.DeletionStageStatus.Clusters[i].Conditions, generateTrueCondition(updateRun, placementv1beta1.ClusterUpdatingConditionSucceeded))
 			}
-			wantStatus.DeletionStageStatus.Conditions = append(wantStatus.DeletionStageStatus.Conditions, generateFalseProgressingCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSucceededReason))
+			wantStatus.DeletionStageStatus.Conditions = append(wantStatus.DeletionStageStatus.Conditions, generateFalseConditionWithReason(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSucceededReason))
 			wantStatus.DeletionStageStatus.Conditions = append(wantStatus.DeletionStageStatus.Conditions, generateTrueCondition(updateRun, placementv1beta1.StageUpdatingConditionSucceeded))
 			// Complete update run.
-			meta.SetStatusCondition(&wantStatus.Conditions, generateFalseProgressingCondition(updateRun, placementv1beta1.StagedUpdateRunConditionProgressing, condition.UpdateRunSucceededReason))
+			meta.SetStatusCondition(&wantStatus.Conditions, generateFalseConditionWithReason(updateRun, placementv1beta1.StagedUpdateRunConditionProgressing, condition.UpdateRunSucceededReason))
 			meta.SetStatusCondition(&wantStatus.Conditions, generateTrueCondition(updateRun, placementv1beta1.StagedUpdateRunConditionSucceeded))
 			validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus, "")
 
@@ -892,8 +867,8 @@ var _ = Describe("UpdateRun execution tests - double stages", func() {
 			Expect(updateRun.Status.StagesStatus[0].EndTime).ShouldNot(BeNil())
 
 			By("Validating the 2nd stage has no startTime or endTime set")
-			Expect(updateRun.Status.StagesStatus[1].StartTime).Should(BeNil())
-			Expect(updateRun.Status.StagesStatus[1].EndTime).Should(BeNil())
+			Expect(updateRun.Status.StagesStatus[1].StartTime).ShouldNot(BeNil())
+			Expect(updateRun.Status.StagesStatus[1].EndTime).ShouldNot(BeNil())
 
 			By("Checking update run status metrics are emitted")
 			validateUpdateRunMetricsEmitted(generateWaitingMetric(placementv1beta1.StateRun, updateRun), generateProgressingMetric(placementv1beta1.StateRun, updateRun), generateSucceededMetric(placementv1beta1.StateRun, updateRun))
@@ -1004,7 +979,7 @@ var _ = Describe("UpdateRun execution tests - single stage", func() {
 			Expect(k8sClient.Create(ctx, updateRun)).To(Succeed())
 
 			By("Validating the initialization succeeded and the execution started")
-			initialized := generateSucceededInitializationStatusForSmallClusters(crp, updateRun, testResourceSnapshotIndex, policySnapshot, updateStrategy, 0)
+			initialized := generateInitializedStatus(crp, updateRun, testResourceSnapshotIndex, policySnapshot, updateStrategy, 3, generateThreeClusterStagesStatus(), generateDeletionStageStatus(0))
 			wantStatus = generateExecutionStartedStatus(updateRun, initialized)
 			validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus, "")
 
@@ -1015,7 +990,7 @@ var _ = Describe("UpdateRun execution tests - single stage", func() {
 		It("Should mark the 1st cluster in the 1st stage as succeeded after marking the binding available", func() {
 			By("Validating the 1st clusterResourceBinding is updated to Bound")
 			binding := resourceBindings[0] // cluster-0
-			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, 0)
+			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, &updateRun.Status.StagesStatus[0].Clusters[0])
 
 			By("Updating the 1st clusterResourceBinding to Available")
 			meta.SetStatusCondition(&binding.Status.Conditions, generateTrueCondition(binding, placementv1beta1.ResourceBindingAvailable))
@@ -1036,7 +1011,7 @@ var _ = Describe("UpdateRun execution tests - single stage", func() {
 		It("Should mark the 2nd cluster in the 1st stage as succeeded after marking the binding available", func() {
 			By("Validating the 2nd clusterResourceBinding is updated to Bound")
 			binding := resourceBindings[1] // cluster-1
-			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, 0)
+			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, &updateRun.Status.StagesStatus[0].Clusters[1])
 
 			By("Updating the 2nd clusterResourceBinding to Available")
 			meta.SetStatusCondition(&binding.Status.Conditions, generateTrueCondition(binding, placementv1beta1.ResourceBindingAvailable))
@@ -1054,7 +1029,7 @@ var _ = Describe("UpdateRun execution tests - single stage", func() {
 		It("Should mark the 3rd cluster in the 1st stage as succeeded after marking the binding available and complete the updateRun", func() {
 			By("Validating the 3rd clusterResourceBinding is updated to Bound")
 			binding := resourceBindings[2] // cluster-2
-			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, 0)
+			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, &updateRun.Status.StagesStatus[0].Clusters[2])
 
 			By("Updating the 3rd clusterResourceBinding to Available")
 			meta.SetStatusCondition(&binding.Status.Conditions, generateTrueCondition(binding, placementv1beta1.ResourceBindingAvailable))
@@ -1063,13 +1038,13 @@ var _ = Describe("UpdateRun execution tests - single stage", func() {
 			By("Validating the 3rd cluster has succeeded and stage waiting for AfterStageTasks")
 			wantStatus.StagesStatus[0].Clusters[2].Conditions = append(wantStatus.StagesStatus[0].Clusters[2].Conditions, generateTrueCondition(updateRun, placementv1beta1.ClusterUpdatingConditionSucceeded))
 			// 1st stage completed.
-			wantStatus.StagesStatus[0].Conditions[0] = generateFalseProgressingCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSucceededReason)
+			wantStatus.StagesStatus[0].Conditions[0] = generateFalseConditionWithReason(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSucceededReason)
 			wantStatus.StagesStatus[0].Conditions = append(wantStatus.StagesStatus[0].Conditions, generateTrueCondition(updateRun, placementv1beta1.StageUpdatingConditionSucceeded))
 			// Mark the deletion stage progressing condition as false with succeeded reason and add succeeded condition.
-			wantStatus.DeletionStageStatus.Conditions = append(wantStatus.DeletionStageStatus.Conditions, generateFalseProgressingCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSucceededReason))
+			wantStatus.DeletionStageStatus.Conditions = append(wantStatus.DeletionStageStatus.Conditions, generateFalseConditionWithReason(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSucceededReason))
 			wantStatus.DeletionStageStatus.Conditions = append(wantStatus.DeletionStageStatus.Conditions, generateTrueCondition(updateRun, placementv1beta1.StageUpdatingConditionSucceeded))
 			// Mark updateRun progressing condition as false with succeeded reason and add succeeded condition.
-			meta.SetStatusCondition(&wantStatus.Conditions, generateFalseProgressingCondition(updateRun, placementv1beta1.StagedUpdateRunConditionProgressing, condition.UpdateRunSucceededReason))
+			meta.SetStatusCondition(&wantStatus.Conditions, generateFalseConditionWithReason(updateRun, placementv1beta1.StagedUpdateRunConditionProgressing, condition.UpdateRunSucceededReason))
 			wantStatus.Conditions = append(wantStatus.Conditions, generateTrueCondition(updateRun, placementv1beta1.StagedUpdateRunConditionSucceeded))
 			validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus, "")
 
@@ -1098,7 +1073,7 @@ var _ = Describe("UpdateRun execution tests - single stage", func() {
 			Expect(k8sClient.Create(ctx, updateRun)).To(Succeed())
 
 			By("Validating the initialization succeeded and the execution started")
-			initialized := generateSucceededInitializationStatusForSmallClusters(crp, updateRun, testResourceSnapshotIndex, policySnapshot, updateStrategy, 0)
+			initialized := generateInitializedStatus(crp, updateRun, testResourceSnapshotIndex, policySnapshot, updateStrategy, 3, generateThreeClusterStagesStatus(), generateDeletionStageStatus(0))
 			wantStatus = generateExecutionNotStartedStatus(updateRun, initialized)
 			validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus, "")
 
@@ -1157,7 +1132,7 @@ var _ = Describe("UpdateRun execution tests - single stage", func() {
 		It("Should mark the 1st cluster in the 1st stage as succeeded after marking the binding available", func() {
 			By("Validating the 1st clusterResourceBinding is updated to Bound")
 			binding := resourceBindings[0] // cluster-0
-			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, 0)
+			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, &updateRun.Status.StagesStatus[0].Clusters[0])
 
 			By("Updating the 1st clusterResourceBinding to Available")
 			meta.SetStatusCondition(&binding.Status.Conditions, generateTrueCondition(binding, placementv1beta1.ResourceBindingAvailable))
@@ -1178,7 +1153,7 @@ var _ = Describe("UpdateRun execution tests - single stage", func() {
 		It("Should mark the 2nd cluster in the 1st stage as succeeded after marking the binding available", func() {
 			By("Validating the 2nd clusterResourceBinding is updated to Bound")
 			binding := resourceBindings[1] // cluster-1
-			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, 0)
+			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, &updateRun.Status.StagesStatus[0].Clusters[1])
 
 			By("Updating the 2nd clusterResourceBinding to Available")
 			meta.SetStatusCondition(&binding.Status.Conditions, generateTrueCondition(binding, placementv1beta1.ResourceBindingAvailable))
@@ -1196,7 +1171,7 @@ var _ = Describe("UpdateRun execution tests - single stage", func() {
 		It("Should Should complete the 1st stage and complete the updateRun after the 3rd cluster succeeds", func() {
 			By("Validating the 3rd clusterResourceBinding is updated to Bound")
 			binding := resourceBindings[2] // cluster-2
-			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, 0)
+			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, &updateRun.Status.StagesStatus[0].Clusters[2])
 
 			By("Updating the 3rd clusterResourceBinding to Available")
 			meta.SetStatusCondition(&binding.Status.Conditions, generateTrueCondition(binding, placementv1beta1.ResourceBindingAvailable))
@@ -1204,17 +1179,17 @@ var _ = Describe("UpdateRun execution tests - single stage", func() {
 
 			By("Validating the 3rd cluster has succeeded")
 			wantStatus.StagesStatus[0].Clusters[2].Conditions = append(wantStatus.StagesStatus[0].Clusters[2].Conditions, generateTrueCondition(updateRun, placementv1beta1.ClusterUpdatingConditionSucceeded))
-			meta.SetStatusCondition(&wantStatus.StagesStatus[0].Conditions, generateFalseProgressingCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSucceededReason))
+			meta.SetStatusCondition(&wantStatus.StagesStatus[0].Conditions, generateFalseConditionWithReason(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSucceededReason))
 
 			By("Validating the 1st stage has completed and the updateRun has completed")
 			// 1st stage completed.
-			wantStatus.StagesStatus[0].Conditions[0] = generateFalseProgressingCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSucceededReason)
+			wantStatus.StagesStatus[0].Conditions[0] = generateFalseConditionWithReason(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSucceededReason)
 			wantStatus.StagesStatus[0].Conditions = append(wantStatus.StagesStatus[0].Conditions, generateTrueCondition(updateRun, placementv1beta1.StageUpdatingConditionSucceeded))
 			// Mark the deletion stage progressing condition as false with succeeded reason and add succeeded condition.
-			wantStatus.DeletionStageStatus.Conditions = append(wantStatus.DeletionStageStatus.Conditions, generateFalseProgressingCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSucceededReason))
+			wantStatus.DeletionStageStatus.Conditions = append(wantStatus.DeletionStageStatus.Conditions, generateFalseConditionWithReason(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSucceededReason))
 			wantStatus.DeletionStageStatus.Conditions = append(wantStatus.DeletionStageStatus.Conditions, generateTrueCondition(updateRun, placementv1beta1.StageUpdatingConditionSucceeded))
 			// Mark updateRun progressing condition as false with succeeded reason and add succeeded condition.
-			meta.SetStatusCondition(&wantStatus.Conditions, generateFalseProgressingCondition(updateRun, placementv1beta1.StagedUpdateRunConditionProgressing, condition.UpdateRunSucceededReason))
+			meta.SetStatusCondition(&wantStatus.Conditions, generateFalseConditionWithReason(updateRun, placementv1beta1.StagedUpdateRunConditionProgressing, condition.UpdateRunSucceededReason))
 			wantStatus.Conditions = append(wantStatus.Conditions, generateTrueCondition(updateRun, placementv1beta1.StagedUpdateRunConditionSucceeded))
 			validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus, "")
 
@@ -1245,7 +1220,7 @@ var _ = Describe("UpdateRun execution tests - single stage", func() {
 			Expect(k8sClient.Create(ctx, updateRun)).To(Succeed())
 
 			By("Validating the initialization succeeded and the execution started")
-			initialized := generateSucceededInitializationStatusForSmallClusters(crp, updateRun, testResourceSnapshotIndex, policySnapshot, updateStrategy, 0)
+			initialized := generateInitializedStatus(crp, updateRun, testResourceSnapshotIndex, policySnapshot, updateStrategy, 3, generateThreeClusterStagesStatus(), generateDeletionStageStatus(0))
 			wantStatus = generateExecutionStartedStatus(updateRun, initialized)
 			validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus, "")
 
@@ -1256,7 +1231,7 @@ var _ = Describe("UpdateRun execution tests - single stage", func() {
 		It("Should mark the 1st cluster in the 1st stage as succeeded after marking the binding available", func() {
 			By("Validating the 1st clusterResourceBinding is updated to Bound")
 			binding := resourceBindings[0] // cluster-0
-			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, 0)
+			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, &updateRun.Status.StagesStatus[0].Clusters[0])
 
 			By("Updating the 1st clusterResourceBinding to Available")
 			meta.SetStatusCondition(&binding.Status.Conditions, generateTrueCondition(binding, placementv1beta1.ResourceBindingAvailable))
@@ -1277,7 +1252,7 @@ var _ = Describe("UpdateRun execution tests - single stage", func() {
 		It("Should mark the 2nd cluster in the 1st stage as succeeded after marking the binding available", func() {
 			By("Validating the 2nd clusterResourceBinding is updated to Bound")
 			binding := resourceBindings[1] // cluster-1
-			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, 0)
+			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, &updateRun.Status.StagesStatus[0].Clusters[1])
 
 			By("Updating the 2nd clusterResourceBinding to Available")
 			meta.SetStatusCondition(&binding.Status.Conditions, generateTrueCondition(binding, placementv1beta1.ResourceBindingAvailable))
@@ -1295,7 +1270,7 @@ var _ = Describe("UpdateRun execution tests - single stage", func() {
 		It("Should mark the 3rd cluster in the 1st stage as succeeded after marking the binding available", func() {
 			By("Validating the 3rd clusterResourceBinding is updated to Bound")
 			binding := resourceBindings[2] // cluster-2
-			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, 0)
+			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, &updateRun.Status.StagesStatus[0].Clusters[2])
 
 			By("Updating the 3rd clusterResourceBinding to Available")
 			meta.SetStatusCondition(&binding.Status.Conditions, generateTrueCondition(binding, placementv1beta1.ResourceBindingAvailable))
@@ -1316,13 +1291,13 @@ var _ = Describe("UpdateRun execution tests - single stage", func() {
 			wantStatus.StagesStatus[0].AfterStageTaskStatus[0].Conditions = append(wantStatus.StagesStatus[0].AfterStageTaskStatus[0].Conditions,
 				generateTrueCondition(updateRun, placementv1beta1.StageTaskConditionWaitTimeElapsed))
 			// 1st stage completed.
-			wantStatus.StagesStatus[0].Conditions[0] = generateFalseProgressingCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSucceededReason)
+			wantStatus.StagesStatus[0].Conditions[0] = generateFalseConditionWithReason(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSucceededReason)
 			wantStatus.StagesStatus[0].Conditions = append(wantStatus.StagesStatus[0].Conditions, generateTrueCondition(updateRun, placementv1beta1.StageUpdatingConditionSucceeded))
 			// Mark the deletion stage progressing condition as false with succeeded reason and add succeeded condition.
-			wantStatus.DeletionStageStatus.Conditions = append(wantStatus.DeletionStageStatus.Conditions, generateFalseProgressingCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSucceededReason))
+			wantStatus.DeletionStageStatus.Conditions = append(wantStatus.DeletionStageStatus.Conditions, generateFalseConditionWithReason(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSucceededReason))
 			wantStatus.DeletionStageStatus.Conditions = append(wantStatus.DeletionStageStatus.Conditions, generateTrueCondition(updateRun, placementv1beta1.StageUpdatingConditionSucceeded))
 			// Mark updateRun progressing condition as false with succeeded reason and add succeeded condition.
-			meta.SetStatusCondition(&wantStatus.Conditions, generateFalseProgressingCondition(updateRun, placementv1beta1.StagedUpdateRunConditionProgressing, condition.UpdateRunSucceededReason))
+			meta.SetStatusCondition(&wantStatus.Conditions, generateFalseConditionWithReason(updateRun, placementv1beta1.StagedUpdateRunConditionProgressing, condition.UpdateRunSucceededReason))
 			wantStatus.Conditions = append(wantStatus.Conditions, generateTrueCondition(updateRun, placementv1beta1.StagedUpdateRunConditionSucceeded))
 			validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus, "")
 
@@ -1355,7 +1330,7 @@ var _ = Describe("UpdateRun execution tests - single stage", func() {
 			Expect(k8sClient.Create(ctx, updateRun)).To(Succeed())
 
 			By("Validating the initialization succeeded and the execution started")
-			initialized := generateSucceededInitializationStatusForSmallClusters(crp, updateRun, testResourceSnapshotIndex, policySnapshot, updateStrategy, 0)
+			initialized := generateInitializedStatus(crp, updateRun, testResourceSnapshotIndex, policySnapshot, updateStrategy, 3, generateThreeClusterStagesStatus(), generateDeletionStageStatus(0))
 			wantStatus = generateExecutionStartedStatus(updateRun, initialized)
 			validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus, "")
 
@@ -1366,7 +1341,7 @@ var _ = Describe("UpdateRun execution tests - single stage", func() {
 		It("Should mark the 1st cluster in the 1st stage as succeeded after marking the binding available", func() {
 			By("Validating the 1st clusterResourceBinding is updated to Bound")
 			binding := resourceBindings[0] // cluster-0
-			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, 0)
+			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, &updateRun.Status.StagesStatus[0].Clusters[0])
 
 			By("Updating the 1st clusterResourceBinding to Available")
 			meta.SetStatusCondition(&binding.Status.Conditions, generateTrueCondition(binding, placementv1beta1.ResourceBindingAvailable))
@@ -1387,7 +1362,7 @@ var _ = Describe("UpdateRun execution tests - single stage", func() {
 		It("Should mark the 2nd cluster in the 1st stage as succeeded after marking the binding available", func() {
 			By("Validating the 2nd clusterResourceBinding is updated to Bound")
 			binding := resourceBindings[1] // cluster-1
-			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, 0)
+			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, &updateRun.Status.StagesStatus[0].Clusters[1])
 
 			By("Updating the 2nd clusterResourceBinding to Available")
 			meta.SetStatusCondition(&binding.Status.Conditions, generateTrueCondition(binding, placementv1beta1.ResourceBindingAvailable))
@@ -1405,7 +1380,7 @@ var _ = Describe("UpdateRun execution tests - single stage", func() {
 		It("Should mark the 3rd cluster in the 1st stage as succeeded after marking the binding available", func() {
 			By("Validating the 3rd clusterResourceBinding is updated to Bound")
 			binding := resourceBindings[2] // cluster-2
-			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, 0)
+			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, &updateRun.Status.StagesStatus[0].Clusters[2])
 
 			By("Updating the 3rd clusterResourceBinding to Available")
 			meta.SetStatusCondition(&binding.Status.Conditions, generateTrueCondition(binding, placementv1beta1.ResourceBindingAvailable))
@@ -1450,13 +1425,13 @@ var _ = Describe("UpdateRun execution tests - single stage", func() {
 			wantStatus.StagesStatus[0].AfterStageTaskStatus[0].Conditions = append(wantStatus.StagesStatus[0].AfterStageTaskStatus[0].Conditions,
 				generateTrueCondition(updateRun, placementv1beta1.StageTaskConditionApprovalRequestApproved))
 			// 1st stage completed.
-			wantStatus.StagesStatus[0].Conditions[0] = generateFalseProgressingCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSucceededReason)
+			wantStatus.StagesStatus[0].Conditions[0] = generateFalseConditionWithReason(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSucceededReason)
 			wantStatus.StagesStatus[0].Conditions = append(wantStatus.StagesStatus[0].Conditions, generateTrueCondition(updateRun, placementv1beta1.StageUpdatingConditionSucceeded))
 			// Mark the deletion stage progressing condition as false with succeeded reason and add succeeded condition.
-			wantStatus.DeletionStageStatus.Conditions = append(wantStatus.DeletionStageStatus.Conditions, generateFalseProgressingCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSucceededReason))
+			wantStatus.DeletionStageStatus.Conditions = append(wantStatus.DeletionStageStatus.Conditions, generateFalseConditionWithReason(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSucceededReason))
 			wantStatus.DeletionStageStatus.Conditions = append(wantStatus.DeletionStageStatus.Conditions, generateTrueCondition(updateRun, placementv1beta1.StageUpdatingConditionSucceeded))
 			// Mark updateRun progressing condition as false with succeeded reason and add succeeded condition.
-			meta.SetStatusCondition(&wantStatus.Conditions, generateFalseProgressingCondition(updateRun, placementv1beta1.StagedUpdateRunConditionProgressing, condition.UpdateRunSucceededReason))
+			meta.SetStatusCondition(&wantStatus.Conditions, generateFalseConditionWithReason(updateRun, placementv1beta1.StagedUpdateRunConditionProgressing, condition.UpdateRunSucceededReason))
 			wantStatus.Conditions = append(wantStatus.Conditions, generateTrueCondition(updateRun, placementv1beta1.StagedUpdateRunConditionSucceeded))
 			validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus, "")
 
@@ -1489,7 +1464,7 @@ var _ = Describe("UpdateRun execution tests - single stage", func() {
 			Expect(k8sClient.Create(ctx, updateRun)).To(Succeed())
 
 			By("Validating the initialization succeeded and the execution started")
-			initialized := generateSucceededInitializationStatusForSmallClusters(crp, updateRun, testResourceSnapshotIndex, policySnapshot, updateStrategy, 0)
+			initialized := generateInitializedStatus(crp, updateRun, testResourceSnapshotIndex, policySnapshot, updateStrategy, 3, generateThreeClusterStagesStatus(), generateDeletionStageStatus(0))
 			wantStatus = generateExecutionStartedStatus(updateRun, initialized)
 			validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus, "")
 
@@ -1497,10 +1472,10 @@ var _ = Describe("UpdateRun execution tests - single stage", func() {
 			validateUpdateRunMetricsEmitted(generateProgressingMetric(placementv1beta1.StateRun, updateRun))
 		})
 
-		It("Should mark the 1st cluster in the 1st stage as succeeded after marking the binding diff reported", func() {
+		It("Should mark the 1st cluster in the 1st stage as succeeded after marking the binding available", func() {
 			By("Validating the 1st clusterResourceBinding is updated to Bound")
 			binding := resourceBindings[0] // cluster-0
-			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, 0)
+			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, &updateRun.Status.StagesStatus[0].Clusters[0])
 
 			By("Updating the 1st clusterResourceBinding to Diff Reported")
 			meta.SetStatusCondition(&binding.Status.Conditions, generateTrueCondition(binding, placementv1beta1.ResourceBindingDiffReported))
@@ -1521,7 +1496,7 @@ var _ = Describe("UpdateRun execution tests - single stage", func() {
 		It("Should mark the 2nd cluster in the 1st stage as succeeded after marking the binding diff reported", func() {
 			By("Validating the 2nd clusterResourceBinding is updated to Bound")
 			binding := resourceBindings[1] // cluster-1
-			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, 0)
+			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, &updateRun.Status.StagesStatus[0].Clusters[1])
 
 			By("Updating the 2nd clusterResourceBinding to Diff Reported")
 			meta.SetStatusCondition(&binding.Status.Conditions, generateTrueCondition(binding, placementv1beta1.ResourceBindingDiffReported))
@@ -1539,7 +1514,7 @@ var _ = Describe("UpdateRun execution tests - single stage", func() {
 		It("Should mark the 3rd cluster in the 1st stage as succeeded after marking the binding diff reported and complete the updateRun", func() {
 			By("Validating the 3rd clusterResourceBinding is updated to Bound")
 			binding := resourceBindings[2] // cluster-2
-			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, 0)
+			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, &updateRun.Status.StagesStatus[0].Clusters[2])
 
 			By("Updating the 3rd clusterResourceBinding to Diff Reported")
 			meta.SetStatusCondition(&binding.Status.Conditions, generateTrueCondition(binding, placementv1beta1.ResourceBindingDiffReported))
@@ -1548,13 +1523,13 @@ var _ = Describe("UpdateRun execution tests - single stage", func() {
 			By("Validating the 3rd cluster has succeeded and stage waiting for AfterStageTasks")
 			wantStatus.StagesStatus[0].Clusters[2].Conditions = append(wantStatus.StagesStatus[0].Clusters[2].Conditions, generateTrueCondition(updateRun, placementv1beta1.ClusterUpdatingConditionSucceeded))
 			// 1st stage completed.
-			wantStatus.StagesStatus[0].Conditions[0] = generateFalseProgressingCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSucceededReason)
+			wantStatus.StagesStatus[0].Conditions[0] = generateFalseConditionWithReason(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSucceededReason)
 			wantStatus.StagesStatus[0].Conditions = append(wantStatus.StagesStatus[0].Conditions, generateTrueCondition(updateRun, placementv1beta1.StageUpdatingConditionSucceeded))
 			// Mark the deletion stage progressing condition as false with succeeded reason and add succeeded condition.
-			wantStatus.DeletionStageStatus.Conditions = append(wantStatus.DeletionStageStatus.Conditions, generateFalseProgressingCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSucceededReason))
+			wantStatus.DeletionStageStatus.Conditions = append(wantStatus.DeletionStageStatus.Conditions, generateFalseConditionWithReason(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSucceededReason))
 			wantStatus.DeletionStageStatus.Conditions = append(wantStatus.DeletionStageStatus.Conditions, generateTrueCondition(updateRun, placementv1beta1.StageUpdatingConditionSucceeded))
 			// Mark updateRun progressing condition as false with succeeded reason and add succeeded condition.
-			meta.SetStatusCondition(&wantStatus.Conditions, generateFalseProgressingCondition(updateRun, placementv1beta1.StagedUpdateRunConditionProgressing, condition.UpdateRunSucceededReason))
+			meta.SetStatusCondition(&wantStatus.Conditions, generateFalseConditionWithReason(updateRun, placementv1beta1.StagedUpdateRunConditionProgressing, condition.UpdateRunSucceededReason))
 			wantStatus.Conditions = append(wantStatus.Conditions, generateTrueCondition(updateRun, placementv1beta1.StagedUpdateRunConditionSucceeded))
 			validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus, "")
 
@@ -1582,7 +1557,7 @@ var _ = Describe("UpdateRun execution tests - single stage", func() {
 			Expect(k8sClient.Create(ctx, updateRun)).To(Succeed())
 
 			By("Validating the initialization succeeded and the execution started")
-			initialized := generateSucceededInitializationStatusForSmallClusters(crp, updateRun, testResourceSnapshotIndex, policySnapshot, updateStrategy, 0)
+			initialized := generateInitializedStatus(crp, updateRun, testResourceSnapshotIndex, policySnapshot, updateStrategy, 3, generateThreeClusterStagesStatus(), generateDeletionStageStatus(0))
 			wantStatus = generateExecutionStartedStatus(updateRun, initialized)
 			validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus, "")
 
@@ -1598,7 +1573,7 @@ var _ = Describe("UpdateRun execution tests - single stage", func() {
 		It("Should become stuck if the binding diff reporting fails", func() {
 			By("Validating the 1st clusterResourceBinding is updated to Bound")
 			binding := resourceBindings[0] // cluster-0
-			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, 0)
+			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, &updateRun.Status.StagesStatus[0].Clusters[0])
 
 			By("Updating the 1st clusterResourceBinding to diff reported failed")
 			meta.SetStatusCondition(&binding.Status.Conditions, generateFalseCondition(binding, placementv1beta1.ResourceBindingDiffReported))
@@ -1645,7 +1620,7 @@ var _ = Describe("UpdateRun execution tests - single stage", func() {
 			Expect(k8sClient.Create(ctx, updateRun)).To(Succeed())
 
 			By("Validating the initialization succeeded and the execution has not started")
-			initialized := generateSucceededInitializationStatusForSmallClusters(crp, updateRun, testResourceSnapshotIndex, policySnapshot, updateStrategy, 0)
+			initialized := generateInitializedStatus(crp, updateRun, testResourceSnapshotIndex, policySnapshot, updateStrategy, 3, generateThreeClusterStagesStatus(), generateDeletionStageStatus(0))
 			wantStatus = generateExecutionNotStartedStatus(updateRun, initialized)
 			validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus, "")
 
@@ -1736,7 +1711,7 @@ var _ = Describe("UpdateRun execution tests - single stage", func() {
 		It("Should mark the 1st cluster in the 1st stage as succeeded after marking the binding available", func() {
 			By("Validating the 1st clusterResourceBinding is updated to Bound")
 			binding := resourceBindings[0] // cluster-0
-			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, 0)
+			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, &updateRun.Status.StagesStatus[0].Clusters[0])
 
 			By("Updating the 1st clusterResourceBinding to Available")
 			meta.SetStatusCondition(&binding.Status.Conditions, generateTrueCondition(binding, placementv1beta1.ResourceBindingAvailable))
@@ -1754,7 +1729,7 @@ var _ = Describe("UpdateRun execution tests - single stage", func() {
 		It("Should mark the 2nd cluster in the 1st stage as succeeded after marking the binding available", func() {
 			By("Validating the 2nd clusterResourceBinding is updated to Bound")
 			binding := resourceBindings[1] // cluster-1
-			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, 0)
+			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, &updateRun.Status.StagesStatus[0].Clusters[1])
 
 			By("Updating the 2nd clusterResourceBinding to Available")
 			meta.SetStatusCondition(&binding.Status.Conditions, generateTrueCondition(binding, placementv1beta1.ResourceBindingAvailable))
@@ -1769,7 +1744,7 @@ var _ = Describe("UpdateRun execution tests - single stage", func() {
 		It("Should mark the 3rd cluster in the 1st stage as succeeded after marking the binding available", func() {
 			By("Validating the 3rd clusterResourceBinding is updated to Bound")
 			binding := resourceBindings[2] // cluster-3
-			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, 0)
+			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, &updateRun.Status.StagesStatus[0].Clusters[2])
 
 			By("Updating the 3rd clusterResourceBinding to Available")
 			meta.SetStatusCondition(&binding.Status.Conditions, generateTrueCondition(binding, placementv1beta1.ResourceBindingAvailable))
@@ -1837,13 +1812,13 @@ var _ = Describe("UpdateRun execution tests - single stage", func() {
 			By("Validating the 1st stage has completed")
 			wantStatus.StagesStatus[0].AfterStageTaskStatus[1].Conditions = append(wantStatus.StagesStatus[0].AfterStageTaskStatus[1].Conditions,
 				generateTrueCondition(updateRun, placementv1beta1.StageTaskConditionWaitTimeElapsed))
-			wantStatus.StagesStatus[0].Conditions[0] = generateFalseProgressingCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSucceededReason)
+			wantStatus.StagesStatus[0].Conditions[0] = generateFalseConditionWithReason(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSucceededReason)
 			wantStatus.StagesStatus[0].Conditions = append(wantStatus.StagesStatus[0].Conditions, generateTrueCondition(updateRun, placementv1beta1.StageUpdatingConditionSucceeded))
 			// Mark the deletion stage progressing condition as false with succeeded reason and add succeeded condition.
-			wantStatus.DeletionStageStatus.Conditions = append(wantStatus.DeletionStageStatus.Conditions, generateFalseProgressingCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSucceededReason))
+			wantStatus.DeletionStageStatus.Conditions = append(wantStatus.DeletionStageStatus.Conditions, generateFalseConditionWithReason(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSucceededReason))
 			wantStatus.DeletionStageStatus.Conditions = append(wantStatus.DeletionStageStatus.Conditions, generateTrueCondition(updateRun, placementv1beta1.StageUpdatingConditionSucceeded))
 			// Mark updateRun progressing condition as false with succeeded reason and add succeeded condition.
-			meta.SetStatusCondition(&wantStatus.Conditions, generateFalseProgressingCondition(updateRun, placementv1beta1.StagedUpdateRunConditionProgressing, condition.UpdateRunSucceededReason))
+			meta.SetStatusCondition(&wantStatus.Conditions, generateFalseConditionWithReason(updateRun, placementv1beta1.StagedUpdateRunConditionProgressing, condition.UpdateRunSucceededReason))
 			wantStatus.Conditions = append(wantStatus.Conditions, generateTrueCondition(updateRun, placementv1beta1.StagedUpdateRunConditionSucceeded))
 			// Need to have a longer wait time for the test to pass, because of the long wait time specified in the update strategy.
 			timeout = time.Second * 90
@@ -1878,7 +1853,7 @@ var _ = Describe("UpdateRun execution tests - single stage", func() {
 			Expect(k8sClient.Create(ctx, updateRun)).To(Succeed())
 
 			By("Validating the initialization succeeded and but not execution started")
-			wantStatus = generateSucceededInitializationStatusForSmallClusters(crp, updateRun, testResourceSnapshotIndex, policySnapshot, updateStrategy, 0)
+			wantStatus = generateInitializedStatus(crp, updateRun, testResourceSnapshotIndex, policySnapshot, updateStrategy, 3, generateThreeClusterStagesStatus(), generateDeletionStageStatus(0))
 			validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus, "")
 
 			By("Checking update run status metrics are emitted")
@@ -1918,7 +1893,7 @@ var _ = Describe("UpdateRun execution tests - single stage", func() {
 		It("Should mark the 1st cluster in the 1st stage as succeeded after marking the binding available", func() {
 			By("Validating the 1st clusterResourceBinding is updated to Bound")
 			binding := resourceBindings[0] // cluster-0
-			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, 0)
+			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, &updateRun.Status.StagesStatus[0].Clusters[0])
 
 			By("Updating the 1st clusterResourceBinding to Available")
 			meta.SetStatusCondition(&binding.Status.Conditions, generateTrueCondition(binding, placementv1beta1.ResourceBindingAvailable))
@@ -1939,7 +1914,7 @@ var _ = Describe("UpdateRun execution tests - single stage", func() {
 		It("Should mark the 2nd cluster in the 1st stage as succeeded after marking the binding available", func() {
 			By("Validating the 2nd clusterResourceBinding is updated to Bound")
 			binding := resourceBindings[1] // cluster-1
-			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, 0)
+			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, &updateRun.Status.StagesStatus[0].Clusters[1])
 
 			By("Updating the 2nd clusterResourceBinding to Available")
 			meta.SetStatusCondition(&binding.Status.Conditions, generateTrueCondition(binding, placementv1beta1.ResourceBindingAvailable))
@@ -1957,7 +1932,7 @@ var _ = Describe("UpdateRun execution tests - single stage", func() {
 		It("Should mark the 3rd cluster in the 1st stage as succeeded after marking the binding available and complete the updateRun", func() {
 			By("Validating the 3rd clusterResourceBinding is updated to Bound")
 			binding := resourceBindings[2] // cluster-2
-			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, 0)
+			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, &updateRun.Status.StagesStatus[0].Clusters[2])
 
 			By("Updating the 3rd clusterResourceBinding to Available")
 			meta.SetStatusCondition(&binding.Status.Conditions, generateTrueCondition(binding, placementv1beta1.ResourceBindingAvailable))
@@ -1966,13 +1941,13 @@ var _ = Describe("UpdateRun execution tests - single stage", func() {
 			By("Validating the 3rd cluster has succeeded and stage waiting for AfterStageTasks")
 			wantStatus.StagesStatus[0].Clusters[2].Conditions = append(wantStatus.StagesStatus[0].Clusters[2].Conditions, generateTrueCondition(updateRun, placementv1beta1.ClusterUpdatingConditionSucceeded))
 			// 1st stage completed.
-			wantStatus.StagesStatus[0].Conditions[0] = generateFalseProgressingCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSucceededReason)
+			wantStatus.StagesStatus[0].Conditions[0] = generateFalseConditionWithReason(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSucceededReason)
 			wantStatus.StagesStatus[0].Conditions = append(wantStatus.StagesStatus[0].Conditions, generateTrueCondition(updateRun, placementv1beta1.StageUpdatingConditionSucceeded))
 			// Mark the deletion stage progressing condition as false with succeeded reason and add succeeded condition.
-			wantStatus.DeletionStageStatus.Conditions = append(wantStatus.DeletionStageStatus.Conditions, generateFalseProgressingCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSucceededReason))
+			wantStatus.DeletionStageStatus.Conditions = append(wantStatus.DeletionStageStatus.Conditions, generateFalseConditionWithReason(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSucceededReason))
 			wantStatus.DeletionStageStatus.Conditions = append(wantStatus.DeletionStageStatus.Conditions, generateTrueCondition(updateRun, placementv1beta1.StageUpdatingConditionSucceeded))
 			// Mark updateRun progressing condition as false with succeeded reason and add succeeded condition.
-			wantStatus.Conditions[1] = generateFalseProgressingCondition(updateRun, placementv1beta1.StagedUpdateRunConditionProgressing, condition.UpdateRunSucceededReason)
+			wantStatus.Conditions[1] = generateFalseConditionWithReason(updateRun, placementv1beta1.StagedUpdateRunConditionProgressing, condition.UpdateRunSucceededReason)
 			wantStatus.Conditions = append(wantStatus.Conditions, generateTrueCondition(updateRun, placementv1beta1.StagedUpdateRunConditionSucceeded))
 			validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus, "")
 
@@ -1986,7 +1961,7 @@ var _ = Describe("UpdateRun execution tests - single stage", func() {
 	})
 })
 
-func validateBindingState(ctx context.Context, binding *placementv1beta1.ClusterResourceBinding, resourceSnapshotName string, updateRun *placementv1beta1.ClusterStagedUpdateRun, stage int) {
+func validateBindingState(ctx context.Context, binding *placementv1beta1.ClusterResourceBinding, resourceSnapshotName string, updateRun *placementv1beta1.ClusterStagedUpdateRun, clusterStatus *placementv1beta1.ClusterUpdatingStatus) {
 	Eventually(func() error {
 		if err := k8sClient.Get(ctx, types.NamespacedName{Name: binding.Name}, binding); err != nil {
 			return err
@@ -1998,10 +1973,10 @@ func validateBindingState(ctx context.Context, binding *placementv1beta1.Cluster
 		if binding.Spec.ResourceSnapshotName != resourceSnapshotName {
 			return fmt.Errorf("binding %s has different resourceSnapshot name, got %s, want %s", binding.Name, binding.Spec.ResourceSnapshotName, resourceSnapshotName)
 		}
-		if diff := cmp.Diff(binding.Spec.ResourceOverrideSnapshots, updateRun.Status.StagesStatus[stage].Clusters[0].ResourceOverrideSnapshots); diff != "" {
+		if diff := cmp.Diff(binding.Spec.ResourceOverrideSnapshots, clusterStatus.ResourceOverrideSnapshots); diff != "" {
 			return fmt.Errorf("binding %s has different resourceOverrideSnapshots (-want +got):\n%s", binding.Name, diff)
 		}
-		if diff := cmp.Diff(binding.Spec.ClusterResourceOverrideSnapshots, updateRun.Status.StagesStatus[stage].Clusters[0].ClusterResourceOverrideSnapshots); diff != "" {
+		if diff := cmp.Diff(binding.Spec.ClusterResourceOverrideSnapshots, clusterStatus.ClusterResourceOverrideSnapshots); diff != "" {
 			return fmt.Errorf("binding %s has different clusterResourceOverrideSnapshots(-want +got):\n%s", binding.Name, diff)
 		}
 		if diff := cmp.Diff(binding.Spec.ApplyStrategy, updateRun.Status.ApplyStrategy); diff != "" {
@@ -2013,7 +1988,7 @@ func validateBindingState(ctx context.Context, binding *placementv1beta1.Cluster
 			return fmt.Errorf("binding %s does not have RolloutStarted condition", binding.Name)
 		}
 		return nil
-	}, timeout, interval).Should(Succeed(), "failed to validate the binding state")
+	}, timeout*3, interval).Should(Succeed(), "failed to validate the binding state")
 }
 
 func validateNotBoundBindingState(ctx context.Context, binding *placementv1beta1.ClusterResourceBinding) {

--- a/pkg/controllers/updaterun/execution_integration_test.go
+++ b/pkg/controllers/updaterun/execution_integration_test.go
@@ -837,6 +837,9 @@ var _ = Describe("UpdateRun execution tests - double stages", func() {
 			// Approval task has been approved.
 			wantStatus.StagesStatus[0].AfterStageTaskStatus[0].Conditions = append(wantStatus.StagesStatus[0].AfterStageTaskStatus[0].Conditions,
 				generateTrueCondition(updateRun, placementv1beta1.StageTaskConditionApprovalRequestApproved))
+
+			By("Checking update run status metrics are emitted")
+			validateUpdateRunApprovalStageTaskMetric(generateApprovalStageTaskMetric(updateRun, placementv1beta1.AfterStageTaskLabelValue, 1))
 		})
 
 		It("Should skip the entire empty stage (stage2) and complete update run", func() {
@@ -872,6 +875,7 @@ var _ = Describe("UpdateRun execution tests - double stages", func() {
 
 			By("Checking update run status metrics are emitted")
 			validateUpdateRunMetricsEmitted(generateWaitingMetric(placementv1beta1.StateRun, updateRun), generateProgressingMetric(placementv1beta1.StateRun, updateRun), generateSucceededMetric(placementv1beta1.StateRun, updateRun))
+			validateUpdateRunApprovalStageTaskMetric(generateApprovalStageTaskMetric(updateRun, placementv1beta1.AfterStageTaskLabelValue, 1))
 		})
 
 	})

--- a/pkg/controllers/updaterun/execution_integration_test.go
+++ b/pkg/controllers/updaterun/execution_integration_test.go
@@ -103,9 +103,6 @@ var _ = Describe("UpdateRun execution tests - double stages", func() {
 
 		By("Creating a new resource snapshot")
 		Expect(k8sClient.Create(ctx, resourceSnapshot)).To(Succeed())
-
-		By("Creating a new cluster resource override")
-		Expect(k8sClient.Create(ctx, clusterResourceOverride)).To(Succeed())
 	})
 
 	AfterEach(OncePerOrdered, func() {
@@ -157,6 +154,9 @@ var _ = Describe("UpdateRun execution tests - double stages", func() {
 	Context("Cluster staged update run should update clusters one by one", Ordered, func() {
 		var wantApprovalRequest *placementv1beta1.ClusterApprovalRequest
 		BeforeAll(func() {
+			By("Creating a new cluster resource override")
+			Expect(k8sClient.Create(ctx, clusterResourceOverride)).To(Succeed())
+
 			By("Creating a new clusterStagedUpdateRun")
 			Expect(k8sClient.Create(ctx, updateRun)).To(Succeed())
 
@@ -640,6 +640,9 @@ var _ = Describe("UpdateRun execution tests - double stages", func() {
 	Context("Cluster staged update run should abort the execution within a failed updating stage", Ordered, func() {
 		var oldUpdateRunStuckThreshold time.Duration
 		BeforeAll(func() {
+			By("Creating a new cluster resource override")
+			Expect(k8sClient.Create(ctx, clusterResourceOverride)).To(Succeed())
+
 			// Set the updateRunStuckThreshold to 1 second for this test.
 			oldUpdateRunStuckThreshold = updateRunStuckThreshold
 			updateRunStuckThreshold = 1 * time.Second
@@ -720,6 +723,182 @@ var _ = Describe("UpdateRun execution tests - double stages", func() {
 			By("Checking update run status metrics are emitted")
 			validateUpdateRunMetricsEmitted(generateWaitingMetric(placementv1beta1.StateRun, updateRun), generateProgressingMetric(placementv1beta1.StateRun, updateRun), generateStuckMetric(placementv1beta1.StateRun, updateRun), generateFailedMetric(placementv1beta1.StateRun, updateRun))
 		})
+	})
+
+	Context("Cluster staged update run should skip entire stage with zero clusters", Ordered, func() {
+		var wantApprovalRequest *placementv1beta1.ClusterApprovalRequest
+		BeforeAll(func() {
+			By("Reassigning the strategy to have 2 stages: one selecting all clusters and one empty")
+			updateStrategy.Spec.Stages = []placementv1beta1.StageConfig{
+				{
+					Name:          "stage1",
+					LabelSelector: &metav1.LabelSelector{}, // Empty label selector selects all clusters.
+					AfterStageTasks: []placementv1beta1.StageTask{
+						{
+							Type: placementv1beta1.StageTaskTypeApproval,
+						},
+					},
+				},
+				{
+					Name: "stage2",
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"group": "nonexistent",
+						},
+					},
+					BeforeStageTasks: []placementv1beta1.StageTask{
+						{
+							Type: placementv1beta1.StageTaskTypeApproval,
+						},
+					},
+					AfterStageTasks: []placementv1beta1.StageTask{
+						{
+							Type: placementv1beta1.StageTaskTypeTimedWait,
+							WaitTime: &metav1.Duration{
+								Duration: time.Second * 10,
+							},
+						},
+						{
+							Type: placementv1beta1.StageTaskTypeApproval,
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Update(ctx, updateStrategy)).To(Succeed())
+
+			By("Creating a new clusterStagedUpdateRun")
+			Expect(k8sClient.Create(ctx, updateRun)).To(Succeed())
+
+			By("Validating the initialization succeeded")
+			// Build stage1 clusters (all target clusters)
+			stage1Clusters := make([]placementv1beta1.ClusterUpdatingStatus, numTargetClusters)
+			for i := 0; i < numTargetClusters; i++ {
+				stage1Clusters[i] = placementv1beta1.ClusterUpdatingStatus{ClusterName: fmt.Sprintf("cluster-%d", i)}
+			}
+			stagesStatus := []placementv1beta1.StageUpdatingStatus{
+				{StageName: "stage1", Clusters: stage1Clusters},
+				{StageName: "stage2", Clusters: []placementv1beta1.ClusterUpdatingStatus{}},
+			}
+			deletionStageStatus := &placementv1beta1.StageUpdatingStatus{
+				StageName: "kubernetes-fleet.io/deleteStage",
+				Clusters: []placementv1beta1.ClusterUpdatingStatus{
+					{ClusterName: "unscheduled-cluster-0"},
+					{ClusterName: "unscheduled-cluster-1"},
+					{ClusterName: "unscheduled-cluster-2"},
+				},
+			}
+			initialized := generateInitializedStatusWithCustomStages(
+				crp, updateRun, testResourceSnapshotIndex, policySnapshot, updateStrategy,
+				stagesStatus, deletionStageStatus,
+			)
+			wantStatus = generateExecutionStartedStatus(updateRun, initialized)
+			validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus, "")
+
+			// Build wantStatus based on the current updateRun status after initialization.
+			wantStatus = updateRun.Status.DeepCopy()
+
+			By("Checking update run status metrics are emitted")
+			validateUpdateRunMetricsEmitted(generateProgressingMetric(placementv1beta1.StateRun, updateRun))
+		})
+
+		It("Should complete executing the clusters in the first stage and wait for after-stage tasks", func() {
+			By("Validating the 1st stage has startTime set")
+			Expect(updateRun.Status.StagesStatus[0].StartTime).ShouldNot(BeNil())
+
+			By("Marking all bindings in the first stage as available")
+			for i := 0; i < numTargetClusters; i++ {
+				binding := resourceBindings[i]
+				validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, 0)
+				meta.SetStatusCondition(&binding.Status.Conditions, generateTrueCondition(binding, placementv1beta1.ResourceBindingAvailable))
+				Expect(k8sClient.Status().Update(ctx, binding)).Should(Succeed(), "failed to update the binding status")
+			}
+
+			By("Validating all cluster have completed")
+			// Stage 0: all clusters succeeded, stage completed.
+			for i := 0; i < numTargetClusters; i++ {
+				meta.SetStatusCondition(&wantStatus.StagesStatus[0].Clusters[i].Conditions, generateTrueCondition(updateRun, placementv1beta1.ClusterUpdatingConditionStarted))
+				meta.SetStatusCondition(&wantStatus.StagesStatus[0].Clusters[i].Conditions, generateTrueCondition(updateRun, placementv1beta1.ClusterUpdatingConditionSucceeded))
+			}
+			wantStatus.StagesStatus[0].Conditions[0] = generateFalseCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing) // The progressing condition now becomes false with waiting reason.
+			wantStatus.StagesStatus[0].AfterStageTaskStatus[0].Conditions = append(wantStatus.StagesStatus[0].AfterStageTaskStatus[0].Conditions,
+				generateTrueCondition(updateRun, placementv1beta1.StageTaskConditionApprovalRequestCreated))
+			meta.SetStatusCondition(&wantStatus.Conditions, generateFalseCondition(updateRun, placementv1beta1.StagedUpdateRunConditionProgressing))
+			validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus, "")
+
+			By("Validating the approvalRequest has been created")
+			wantApprovalRequest = &placementv1beta1.ClusterApprovalRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: updateRun.Status.StagesStatus[0].AfterStageTaskStatus[0].ApprovalRequestName,
+					Labels: map[string]string{
+						placementv1beta1.TargetUpdatingStageNameLabel:   updateRun.Status.StagesStatus[0].StageName,
+						placementv1beta1.TargetUpdateRunLabel:           updateRun.Name,
+						placementv1beta1.TaskTypeLabel:                  placementv1beta1.AfterStageTaskLabelValue,
+						placementv1beta1.IsLatestUpdateRunApprovalLabel: "true",
+					},
+				},
+				Spec: placementv1beta1.ApprovalRequestSpec{
+					TargetUpdateRun: updateRun.Name,
+					TargetStage:     updateRun.Status.StagesStatus[0].StageName,
+				},
+			}
+			validateApprovalRequestCreated(wantApprovalRequest)
+
+			By("Checking update run status metrics are emitted")
+			validateUpdateRunMetricsEmitted(generateProgressingMetric(placementv1beta1.StateRun, updateRun), generateWaitingMetric(placementv1beta1.StateRun, updateRun))
+		})
+
+		It("Should accept the approval request", func() {
+			By("Approving the approvalRequest")
+			approveClusterApprovalRequest(ctx, wantApprovalRequest.Name)
+
+			By("Validating the approvalRequest has ApprovalAccepted status")
+			Eventually(func() (bool, error) {
+				var approvalRequest placementv1beta1.ClusterApprovalRequest
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: wantApprovalRequest.Name}, &approvalRequest); err != nil {
+					return false, err
+				}
+				return condition.IsConditionStatusTrue(meta.FindStatusCondition(approvalRequest.Status.Conditions, string(placementv1beta1.ApprovalRequestConditionApprovalAccepted)), approvalRequest.Generation), nil
+			}, timeout, interval).Should(BeTrue(), "failed to validate the approvalRequest approval accepted")
+			// Approval task has been approved.
+			wantStatus.StagesStatus[0].AfterStageTaskStatus[0].Conditions = append(wantStatus.StagesStatus[0].AfterStageTaskStatus[0].Conditions,
+				generateTrueCondition(updateRun, placementv1beta1.StageTaskConditionApprovalRequestApproved))
+		})
+
+		It("Should skip the entire empty stage (stage2) and complete update run", func() {
+			// 1st stage completed, mark progressing condition reason as succeeded and add succeeded condition.
+			wantStatus.StagesStatus[0].Conditions[0] = generateFalseProgressingCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSucceededReason)
+			wantStatus.StagesStatus[0].Conditions = append(wantStatus.StagesStatus[0].Conditions, generateTrueCondition(updateRun, placementv1beta1.StageUpdatingConditionSucceeded))
+
+			By("Validating the 2nd stage has been skipped and the update run completed")
+			// 2nd stage will not have before-stage or after-stage conditions.
+			// 2nd stage will not have any clusters.
+			// 2nd stage conditions should populate as skipped.
+			wantStatus.StagesStatus[1].Conditions = append(wantStatus.StagesStatus[1].Conditions, generateFalseProgressingCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSkippedNoClustersReason))
+			wantStatus.StagesStatus[1].Conditions = append(wantStatus.StagesStatus[1].Conditions, generateTrueConditionWithReason(updateRun, placementv1beta1.StageUpdatingConditionSucceeded, condition.StageUpdatingSkippedNoClustersReason))
+			meta.SetStatusCondition(&wantStatus.Conditions, generateTrueCondition(updateRun, placementv1beta1.StagedUpdateRunConditionProgressing))
+
+			for i := range wantStatus.DeletionStageStatus.Clusters {
+				wantStatus.DeletionStageStatus.Clusters[i].Conditions = append(wantStatus.DeletionStageStatus.Clusters[i].Conditions, generateTrueCondition(updateRun, placementv1beta1.ClusterUpdatingConditionStarted))
+				wantStatus.DeletionStageStatus.Clusters[i].Conditions = append(wantStatus.DeletionStageStatus.Clusters[i].Conditions, generateTrueCondition(updateRun, placementv1beta1.ClusterUpdatingConditionSucceeded))
+			}
+			wantStatus.DeletionStageStatus.Conditions = append(wantStatus.DeletionStageStatus.Conditions, generateFalseProgressingCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSucceededReason))
+			wantStatus.DeletionStageStatus.Conditions = append(wantStatus.DeletionStageStatus.Conditions, generateTrueCondition(updateRun, placementv1beta1.StageUpdatingConditionSucceeded))
+			// Complete update run.
+			meta.SetStatusCondition(&wantStatus.Conditions, generateFalseProgressingCondition(updateRun, placementv1beta1.StagedUpdateRunConditionProgressing, condition.UpdateRunSucceededReason))
+			meta.SetStatusCondition(&wantStatus.Conditions, generateTrueCondition(updateRun, placementv1beta1.StagedUpdateRunConditionSucceeded))
+			validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus, "")
+
+			By("Validating the 1st stage has endTime set")
+			Expect(updateRun.Status.StagesStatus[0].EndTime).ShouldNot(BeNil())
+
+			By("Validating the 2nd stage has no startTime or endTime set")
+			Expect(updateRun.Status.StagesStatus[1].StartTime).Should(BeNil())
+			Expect(updateRun.Status.StagesStatus[1].EndTime).Should(BeNil())
+
+			By("Checking update run status metrics are emitted")
+			validateUpdateRunMetricsEmitted(generateWaitingMetric(placementv1beta1.StateRun, updateRun), generateProgressingMetric(placementv1beta1.StateRun, updateRun), generateSucceededMetric(placementv1beta1.StateRun, updateRun))
+		})
+
 	})
 })
 

--- a/pkg/controllers/updaterun/execution_test.go
+++ b/pkg/controllers/updaterun/execution_test.go
@@ -1426,62 +1426,6 @@ func TestExecute_ZeroClustersSkipsEntireStage(t *testing.T) {
 				},
 			},
 		},
-		{
-			name: "non-zero clusters should wait for before-stage approval task",
-			updateRun: &placementv1beta1.ClusterStagedUpdateRun{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:       "test-update-run",
-					Generation: 1,
-				},
-				Spec: placementv1beta1.UpdateRunSpec{
-					PlacementName:         "test-placement",
-					ResourceSnapshotIndex: "1",
-					State:                 placementv1beta1.StateRun,
-				},
-				Status: placementv1beta1.UpdateRunStatus{
-					ResourceSnapshotIndexUsed: "1",
-					StagesStatus: []placementv1beta1.StageUpdatingStatus{
-						{
-							StageName: "non-empty-stage",
-							Clusters: []placementv1beta1.ClusterUpdatingStatus{
-								{ClusterName: "cluster-1"},
-							},
-							BeforeStageTaskStatus: []placementv1beta1.StageTaskStatus{
-								{
-									Type:                placementv1beta1.StageTaskTypeApproval,
-									ApprovalRequestName: "test-update-run-non-empty-stage-before",
-								},
-							},
-						},
-					},
-					UpdateStrategySnapshot: &placementv1beta1.UpdateStrategySpec{
-						Stages: []placementv1beta1.StageConfig{
-							{
-								Name:           "non-empty-stage",
-								MaxConcurrency: &intstr.IntOrString{Type: intstr.Int, IntVal: 1},
-								BeforeStageTasks: []placementv1beta1.StageTask{
-									{
-										Type: placementv1beta1.StageTaskTypeApproval,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			stageIndex:   0,
-			wantWaitTime: stageUpdatingWaitTime, // Should wait for before-stage task.
-			wantErr:      false,
-			wantConditions: []metav1.Condition{
-				{
-					Type:               string(placementv1beta1.StageUpdatingConditionProgressing),
-					Status:             metav1.ConditionFalse,
-					ObservedGeneration: 1,
-					Reason:             condition.StageUpdatingWaitingReason,
-					Message:            "Not all before-stage tasks are completed, waiting for approval",
-				},
-			},
-		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/controllers/updaterun/execution_test.go
+++ b/pkg/controllers/updaterun/execution_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -1282,6 +1283,235 @@ func TestGenerateStuckClustersString(t *testing.T) {
 
 			if got != tt.wantClusterString {
 				t.Fatalf("generateStuckClustersString() = %v, want %v", got, tt.wantClusterString)
+			}
+		})
+	}
+}
+
+func TestExecute_ZeroClustersSkipsEntireStage(t *testing.T) {
+	tests := []struct {
+		name           string
+		updateRun      *placementv1beta1.ClusterStagedUpdateRun
+		stageIndex     int
+		wantWaitTime   time.Duration
+		wantErr        bool
+		wantConditions []metav1.Condition
+	}{
+		{
+			name: "zero clusters should skip entire stage including before-stage tasks",
+			updateRun: &placementv1beta1.ClusterStagedUpdateRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-update-run",
+					Generation: 1,
+				},
+				Spec: placementv1beta1.UpdateRunSpec{
+					PlacementName:         "test-placement",
+					ResourceSnapshotIndex: "1",
+					State:                 placementv1beta1.StateRun,
+				},
+				Status: placementv1beta1.UpdateRunStatus{
+					ResourceSnapshotIndexUsed: "1",
+					StagesStatus: []placementv1beta1.StageUpdatingStatus{
+						{
+							StageName: "empty-stage",
+							Clusters:  []placementv1beta1.ClusterUpdatingStatus{}, // Zero clusters.
+							BeforeStageTaskStatus: []placementv1beta1.StageTaskStatus{
+								{
+									Type:                placementv1beta1.StageTaskTypeApproval,
+									ApprovalRequestName: "test-update-run-empty-stage-before",
+								},
+							},
+						},
+					},
+					UpdateStrategySnapshot: &placementv1beta1.UpdateStrategySpec{
+						Stages: []placementv1beta1.StageConfig{
+							{
+								Name:           "empty-stage",
+								MaxConcurrency: &intstr.IntOrString{Type: intstr.Int, IntVal: 1},
+								BeforeStageTasks: []placementv1beta1.StageTask{
+									{
+										Type: placementv1beta1.StageTaskTypeApproval,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			stageIndex:   0,
+			wantWaitTime: 0, // No wait time, stage is skipped.
+			wantErr:      false,
+			wantConditions: []metav1.Condition{
+				{
+					Type:               string(placementv1beta1.StageUpdatingConditionProgressing),
+					Status:             metav1.ConditionFalse,
+					ObservedGeneration: 1,
+					Reason:             condition.StageUpdatingSkippedNoClustersReason,
+					Message:            "Stage skipped because it has no clusters",
+				},
+				{
+					Type:               string(placementv1beta1.StageUpdatingConditionSucceeded),
+					Status:             metav1.ConditionTrue,
+					ObservedGeneration: 1,
+					Reason:             condition.StageUpdatingSkippedNoClustersReason,
+					Message:            "Stage skipped because it has no clusters",
+				},
+			},
+		},
+		{
+			name: "zero clusters should skip entire stage including after-stage tasks",
+			updateRun: &placementv1beta1.ClusterStagedUpdateRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-update-run",
+					Generation: 1,
+				},
+				Spec: placementv1beta1.UpdateRunSpec{
+					PlacementName:         "test-placement",
+					ResourceSnapshotIndex: "1",
+					State:                 placementv1beta1.StateRun,
+				},
+				Status: placementv1beta1.UpdateRunStatus{
+					ResourceSnapshotIndexUsed: "1",
+					StagesStatus: []placementv1beta1.StageUpdatingStatus{
+						{
+							StageName: "empty-stage",
+							Clusters:  []placementv1beta1.ClusterUpdatingStatus{}, // Zero clusters.
+							AfterStageTaskStatus: []placementv1beta1.StageTaskStatus{
+								{
+									Type: placementv1beta1.StageTaskTypeTimedWait,
+								},
+								{
+									Type:                placementv1beta1.StageTaskTypeApproval,
+									ApprovalRequestName: "test-update-run-empty-stage-after",
+								},
+							},
+						},
+					},
+					UpdateStrategySnapshot: &placementv1beta1.UpdateStrategySpec{
+						Stages: []placementv1beta1.StageConfig{
+							{
+								Name:           "empty-stage",
+								MaxConcurrency: &intstr.IntOrString{Type: intstr.Int, IntVal: 1},
+								AfterStageTasks: []placementv1beta1.StageTask{
+									{
+										Type:     placementv1beta1.StageTaskTypeTimedWait,
+										WaitTime: &metav1.Duration{Duration: 5 * time.Minute},
+									},
+									{
+										Type: placementv1beta1.StageTaskTypeApproval,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			stageIndex:   0,
+			wantWaitTime: 0, // No wait time, stage is skipped.
+			wantErr:      false,
+			wantConditions: []metav1.Condition{
+				{
+					Type:               string(placementv1beta1.StageUpdatingConditionProgressing),
+					Status:             metav1.ConditionFalse,
+					ObservedGeneration: 1,
+					Reason:             condition.StageUpdatingSkippedNoClustersReason,
+					Message:            "Stage skipped because it has no clusters",
+				},
+				{
+					Type:               string(placementv1beta1.StageUpdatingConditionSucceeded),
+					Status:             metav1.ConditionTrue,
+					ObservedGeneration: 1,
+					Reason:             condition.StageUpdatingSkippedNoClustersReason,
+					Message:            "Stage skipped because it has no clusters",
+				},
+			},
+		},
+		{
+			name: "non-zero clusters should wait for before-stage approval task",
+			updateRun: &placementv1beta1.ClusterStagedUpdateRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-update-run",
+					Generation: 1,
+				},
+				Spec: placementv1beta1.UpdateRunSpec{
+					PlacementName:         "test-placement",
+					ResourceSnapshotIndex: "1",
+					State:                 placementv1beta1.StateRun,
+				},
+				Status: placementv1beta1.UpdateRunStatus{
+					ResourceSnapshotIndexUsed: "1",
+					StagesStatus: []placementv1beta1.StageUpdatingStatus{
+						{
+							StageName: "non-empty-stage",
+							Clusters: []placementv1beta1.ClusterUpdatingStatus{
+								{ClusterName: "cluster-1"},
+							},
+							BeforeStageTaskStatus: []placementv1beta1.StageTaskStatus{
+								{
+									Type:                placementv1beta1.StageTaskTypeApproval,
+									ApprovalRequestName: "test-update-run-non-empty-stage-before",
+								},
+							},
+						},
+					},
+					UpdateStrategySnapshot: &placementv1beta1.UpdateStrategySpec{
+						Stages: []placementv1beta1.StageConfig{
+							{
+								Name:           "non-empty-stage",
+								MaxConcurrency: &intstr.IntOrString{Type: intstr.Int, IntVal: 1},
+								BeforeStageTasks: []placementv1beta1.StageTask{
+									{
+										Type: placementv1beta1.StageTaskTypeApproval,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			stageIndex:   0,
+			wantWaitTime: stageUpdatingWaitTime, // Should wait for before-stage task.
+			wantErr:      false,
+			wantConditions: []metav1.Condition{
+				{
+					Type:               string(placementv1beta1.StageUpdatingConditionProgressing),
+					Status:             metav1.ConditionFalse,
+					ObservedGeneration: 1,
+					Reason:             condition.StageUpdatingWaitingReason,
+					Message:            "Not all before-stage tasks are completed, waiting for approval",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			_ = placementv1beta1.AddToScheme(scheme)
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(tt.updateRun).
+				WithStatusSubresource(tt.updateRun).
+				Build()
+			r := Reconciler{
+				Client: fakeClient,
+			}
+			ctx := context.Background()
+
+			_, waitTime, gotErr := r.execute(ctx, tt.updateRun, tt.stageIndex, nil, nil)
+
+			if (gotErr != nil) != tt.wantErr {
+				t.Fatalf("execute() error = %v, wantErr %v", gotErr, tt.wantErr)
+			}
+
+			if waitTime != tt.wantWaitTime {
+				t.Fatalf("execute() waitTime = %v, want %v", waitTime, tt.wantWaitTime)
+			}
+
+			// Compare conditions using cmp.Diff, ignoring LastTransitionTime.
+			gotConditions := tt.updateRun.Status.StagesStatus[tt.stageIndex].Conditions
+			if diff := cmp.Diff(tt.wantConditions, gotConditions, cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime")); diff != "" {
+				t.Fatalf("execute() conditions mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/controllers/updaterun/execution_test.go
+++ b/pkg/controllers/updaterun/execution_test.go
@@ -1290,12 +1290,12 @@ func TestGenerateStuckClustersString(t *testing.T) {
 
 func TestExecute_ZeroClustersSkipsEntireStage(t *testing.T) {
 	tests := []struct {
-		name           string
-		updateRun      *placementv1beta1.ClusterStagedUpdateRun
-		stageIndex     int
-		wantWaitTime   time.Duration
-		wantErr        bool
-		wantConditions []metav1.Condition
+		name            string
+		updateRun       *placementv1beta1.ClusterStagedUpdateRun
+		stageIndex      int
+		wantWaitTime    time.Duration
+		wantErr         bool
+		wantStageStatus placementv1beta1.StageUpdatingStatus
 	}{
 		{
 			name: "zero clusters should skip entire stage including before-stage tasks",
@@ -1318,7 +1318,16 @@ func TestExecute_ZeroClustersSkipsEntireStage(t *testing.T) {
 							BeforeStageTaskStatus: []placementv1beta1.StageTaskStatus{
 								{
 									Type:                placementv1beta1.StageTaskTypeApproval,
-									ApprovalRequestName: "test-update-run-empty-stage-before",
+									ApprovalRequestName: "test-update-run-empty-before-stage",
+								},
+							},
+							AfterStageTaskStatus: []placementv1beta1.StageTaskStatus{
+								{
+									Type: placementv1beta1.StageTaskTypeTimedWait,
+								},
+								{
+									Type:                placementv1beta1.StageTaskTypeApproval,
+									ApprovalRequestName: "test-update-run-after-empty-stage",
 								},
 							},
 						},
@@ -1333,65 +1342,6 @@ func TestExecute_ZeroClustersSkipsEntireStage(t *testing.T) {
 										Type: placementv1beta1.StageTaskTypeApproval,
 									},
 								},
-							},
-						},
-					},
-				},
-			},
-			stageIndex:   0,
-			wantWaitTime: 0, // No wait time, stage is skipped.
-			wantErr:      false,
-			wantConditions: []metav1.Condition{
-				{
-					Type:               string(placementv1beta1.StageUpdatingConditionProgressing),
-					Status:             metav1.ConditionFalse,
-					ObservedGeneration: 1,
-					Reason:             condition.StageUpdatingSkippedNoClustersReason,
-					Message:            "Stage skipped because it has no clusters",
-				},
-				{
-					Type:               string(placementv1beta1.StageUpdatingConditionSucceeded),
-					Status:             metav1.ConditionTrue,
-					ObservedGeneration: 1,
-					Reason:             condition.StageUpdatingSkippedNoClustersReason,
-					Message:            "Stage skipped because it has no clusters",
-				},
-			},
-		},
-		{
-			name: "zero clusters should skip entire stage including after-stage tasks",
-			updateRun: &placementv1beta1.ClusterStagedUpdateRun{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:       "test-update-run",
-					Generation: 1,
-				},
-				Spec: placementv1beta1.UpdateRunSpec{
-					PlacementName:         "test-placement",
-					ResourceSnapshotIndex: "1",
-					State:                 placementv1beta1.StateRun,
-				},
-				Status: placementv1beta1.UpdateRunStatus{
-					ResourceSnapshotIndexUsed: "1",
-					StagesStatus: []placementv1beta1.StageUpdatingStatus{
-						{
-							StageName: "empty-stage",
-							Clusters:  []placementv1beta1.ClusterUpdatingStatus{}, // Zero clusters.
-							AfterStageTaskStatus: []placementv1beta1.StageTaskStatus{
-								{
-									Type: placementv1beta1.StageTaskTypeTimedWait,
-								},
-								{
-									Type:                placementv1beta1.StageTaskTypeApproval,
-									ApprovalRequestName: "test-update-run-empty-stage-after",
-								},
-							},
-						},
-					},
-					UpdateStrategySnapshot: &placementv1beta1.UpdateStrategySpec{
-						Stages: []placementv1beta1.StageConfig{
-							{
-								Name:           "empty-stage",
-								MaxConcurrency: &intstr.IntOrString{Type: intstr.Int, IntVal: 1},
 								AfterStageTasks: []placementv1beta1.StageTask{
 									{
 										Type:     placementv1beta1.StageTaskTypeTimedWait,
@@ -1409,20 +1359,41 @@ func TestExecute_ZeroClustersSkipsEntireStage(t *testing.T) {
 			stageIndex:   0,
 			wantWaitTime: 0, // No wait time, stage is skipped.
 			wantErr:      false,
-			wantConditions: []metav1.Condition{
-				{
-					Type:               string(placementv1beta1.StageUpdatingConditionProgressing),
-					Status:             metav1.ConditionFalse,
-					ObservedGeneration: 1,
-					Reason:             condition.StageUpdatingSkippedNoClustersReason,
-					Message:            "Stage skipped because it has no clusters",
+			wantStageStatus: placementv1beta1.StageUpdatingStatus{
+				StageName: "empty-stage",
+				Clusters:  []placementv1beta1.ClusterUpdatingStatus{}, // Zero clusters.
+				BeforeStageTaskStatus: []placementv1beta1.StageTaskStatus{
+					{
+						Type:                placementv1beta1.StageTaskTypeApproval,
+						ApprovalRequestName: "test-update-run-empty-before-stage",
+					},
 				},
-				{
-					Type:               string(placementv1beta1.StageUpdatingConditionSucceeded),
-					Status:             metav1.ConditionTrue,
-					ObservedGeneration: 1,
-					Reason:             condition.StageUpdatingSkippedNoClustersReason,
-					Message:            "Stage skipped because it has no clusters",
+				AfterStageTaskStatus: []placementv1beta1.StageTaskStatus{
+					{
+						Type: placementv1beta1.StageTaskTypeTimedWait,
+					},
+					{
+						Type:                placementv1beta1.StageTaskTypeApproval,
+						ApprovalRequestName: "test-update-run-after-empty-stage",
+					},
+				},
+				StartTime: &metav1.Time{Time: time.Now()},
+				EndTime:   &metav1.Time{Time: time.Now()},
+				Conditions: []metav1.Condition{
+					{
+						Type:               string(placementv1beta1.StageUpdatingConditionProgressing),
+						Status:             metav1.ConditionFalse,
+						ObservedGeneration: 1,
+						Reason:             condition.StageUpdatingSkippedNoClustersReason,
+						Message:            "Stage skipped because it has no clusters",
+					},
+					{
+						Type:               string(placementv1beta1.StageUpdatingConditionSucceeded),
+						Status:             metav1.ConditionTrue,
+						ObservedGeneration: 1,
+						Reason:             condition.StageUpdatingSkippedNoClustersReason,
+						Message:            "Stage skipped because it has no clusters",
+					},
 				},
 			},
 		},
@@ -1452,10 +1423,22 @@ func TestExecute_ZeroClustersSkipsEntireStage(t *testing.T) {
 				t.Fatalf("execute() waitTime = %v, want %v", waitTime, tt.wantWaitTime)
 			}
 
-			// Compare conditions using cmp.Diff, ignoring LastTransitionTime.
-			gotConditions := tt.updateRun.Status.StagesStatus[tt.stageIndex].Conditions
-			if diff := cmp.Diff(tt.wantConditions, gotConditions, cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime")); diff != "" {
-				t.Fatalf("execute() conditions mismatch (-want +got):\n%s", diff)
+			gotStageStatus := tt.updateRun.Status.StagesStatus[tt.stageIndex]
+
+			// Verify StartTime and EndTime are set for skipped stages.
+			if gotStageStatus.StartTime == nil {
+				t.Fatal("execute() StartTime should be set for skipped stage")
+			}
+			if gotStageStatus.EndTime == nil {
+				t.Fatal("execute() EndTime should be set for skipped stage")
+			}
+
+			// Compare stage status using cmp.Diff, ignoring time fields.
+			if diff := cmp.Diff(tt.wantStageStatus, gotStageStatus,
+				cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime"),
+				cmpopts.IgnoreFields(placementv1beta1.StageUpdatingStatus{}, "StartTime", "EndTime"),
+			); diff != "" {
+				t.Fatalf("execute() stage status mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/controllers/updaterun/initialization_integration_test.go
+++ b/pkg/controllers/updaterun/initialization_integration_test.go
@@ -1097,6 +1097,50 @@ func validateFailedInitCondition(ctx context.Context, updateRun *placementv1beta
 	}, timeout, interval).Should(Succeed(), "failed to validate the failed initialization condition")
 }
 
+// populateStageTaskStatuses populates the BeforeStageTaskStatus and AfterStageTaskStatus
+// for all stages in the status based on the strategy configuration.
+func populateStageTaskStatuses(
+	status *placementv1beta1.UpdateRunStatus,
+	updateRunName string,
+	stages []placementv1beta1.StageConfig,
+) {
+	for i := range status.StagesStatus {
+		status.StagesStatus[i].BeforeStageTaskStatus = buildTaskStatuses(
+			stages[i].BeforeStageTasks,
+			placementv1beta1.BeforeStageApprovalTaskNameFmt,
+			updateRunName,
+			status.StagesStatus[i].StageName,
+		)
+		status.StagesStatus[i].AfterStageTaskStatus = buildTaskStatuses(
+			stages[i].AfterStageTasks,
+			placementv1beta1.AfterStageApprovalTaskNameFmt,
+			updateRunName,
+			status.StagesStatus[i].StageName,
+		)
+	}
+}
+
+// buildTaskStatuses creates StageTaskStatus slice from StageTask configuration.
+func buildTaskStatuses(
+	tasks []placementv1beta1.StageTask,
+	approvalNameFmt string,
+	updateRunName string,
+	stageName string,
+) []placementv1beta1.StageTaskStatus {
+	if len(tasks) == 0 {
+		return nil
+	}
+	taskStatuses := make([]placementv1beta1.StageTaskStatus, 0, len(tasks))
+	for _, task := range tasks {
+		taskStatus := placementv1beta1.StageTaskStatus{Type: task.Type}
+		if task.Type == placementv1beta1.StageTaskTypeApproval {
+			taskStatus.ApprovalRequestName = fmt.Sprintf(approvalNameFmt, updateRunName, stageName)
+		}
+		taskStatuses = append(taskStatuses, taskStatus)
+	}
+	return taskStatuses
+}
+
 func generateSucceededInitializationStatus(
 	crp *placementv1beta1.ClusterResourcePlacement,
 	updateRun *placementv1beta1.ClusterStagedUpdateRun,
@@ -1146,27 +1190,7 @@ func generateSucceededInitializationStatus(
 			generateTrueCondition(updateRun, placementv1beta1.StagedUpdateRunConditionInitialized),
 		},
 	}
-	for i := range status.StagesStatus {
-		var beforeTasks []placementv1beta1.StageTaskStatus
-		for _, task := range updateStrategy.Spec.Stages[i].BeforeStageTasks {
-			taskStatus := placementv1beta1.StageTaskStatus{Type: task.Type}
-			if task.Type == placementv1beta1.StageTaskTypeApproval {
-				taskStatus.ApprovalRequestName = fmt.Sprintf(placementv1beta1.BeforeStageApprovalTaskNameFmt, updateRun.Name, status.StagesStatus[i].StageName)
-			}
-			beforeTasks = append(beforeTasks, taskStatus)
-		}
-		status.StagesStatus[i].BeforeStageTaskStatus = beforeTasks
-
-		var afterTasks []placementv1beta1.StageTaskStatus
-		for _, task := range updateStrategy.Spec.Stages[i].AfterStageTasks {
-			taskStatus := placementv1beta1.StageTaskStatus{Type: task.Type}
-			if task.Type == placementv1beta1.StageTaskTypeApproval {
-				taskStatus.ApprovalRequestName = fmt.Sprintf(placementv1beta1.AfterStageApprovalTaskNameFmt, updateRun.Name, status.StagesStatus[i].StageName)
-			}
-			afterTasks = append(afterTasks, taskStatus)
-		}
-		status.StagesStatus[i].AfterStageTaskStatus = afterTasks
-	}
+	populateStageTaskStatuses(status, updateRun.Name, updateStrategy.Spec.Stages)
 	return status
 }
 
@@ -1207,27 +1231,35 @@ func generateSucceededInitializationStatusForSmallClusters(
 		status.DeletionStageStatus.Clusters = append(status.DeletionStageStatus.Clusters,
 			placementv1beta1.ClusterUpdatingStatus{ClusterName: fmt.Sprintf("unscheduled-cluster-%d", i)})
 	}
-	for i := range status.StagesStatus {
-		var beforeTasks []placementv1beta1.StageTaskStatus
-		for _, task := range updateStrategy.Spec.Stages[i].BeforeStageTasks {
-			taskStatus := placementv1beta1.StageTaskStatus{Type: task.Type}
-			if task.Type == placementv1beta1.StageTaskTypeApproval {
-				taskStatus.ApprovalRequestName = fmt.Sprintf(placementv1beta1.BeforeStageApprovalTaskNameFmt, updateRun.Name, status.StagesStatus[i].StageName)
-			}
-			beforeTasks = append(beforeTasks, taskStatus)
-		}
-		status.StagesStatus[i].BeforeStageTaskStatus = beforeTasks
+	populateStageTaskStatuses(status, updateRun.Name, updateStrategy.Spec.Stages)
+	return status
+}
 
-		var afterTasks []placementv1beta1.StageTaskStatus
-		for _, task := range updateStrategy.Spec.Stages[i].AfterStageTasks {
-			taskStatus := placementv1beta1.StageTaskStatus{Type: task.Type}
-			if task.Type == placementv1beta1.StageTaskTypeApproval {
-				taskStatus.ApprovalRequestName = fmt.Sprintf(placementv1beta1.AfterStageApprovalTaskNameFmt, updateRun.Name, status.StagesStatus[i].StageName)
-			}
-			afterTasks = append(afterTasks, taskStatus)
-		}
-		status.StagesStatus[i].AfterStageTaskStatus = afterTasks
+// generateInitializedStatusWithCustomStages creates an initialization status with custom stage configurations.
+// stagesStatus should contain the StageName and Clusters for each stage.
+// The BeforeStageTaskStatus and AfterStageTaskStatus are populated based on the updateStrategy stages.
+func generateInitializedStatusWithCustomStages(
+	crp *placementv1beta1.ClusterResourcePlacement,
+	updateRun *placementv1beta1.ClusterStagedUpdateRun,
+	resourceSnapshotIndex string,
+	policySnapshot *placementv1beta1.ClusterSchedulingPolicySnapshot,
+	updateStrategy *placementv1beta1.ClusterStagedUpdateStrategy,
+	stagesStatus []placementv1beta1.StageUpdatingStatus,
+	deletionStageStatus *placementv1beta1.StageUpdatingStatus,
+) *placementv1beta1.UpdateRunStatus {
+	status := &placementv1beta1.UpdateRunStatus{
+		PolicySnapshotIndexUsed:    policySnapshot.Labels[placementv1beta1.PolicyIndexLabel],
+		PolicyObservedClusterCount: 10,
+		ResourceSnapshotIndexUsed:  resourceSnapshotIndex,
+		ApplyStrategy:              crp.Spec.Strategy.ApplyStrategy.DeepCopy(),
+		UpdateStrategySnapshot:     &updateStrategy.Spec,
+		StagesStatus:               stagesStatus,
+		DeletionStageStatus:        deletionStageStatus,
+		Conditions: []metav1.Condition{
+			generateTrueCondition(updateRun, placementv1beta1.StagedUpdateRunConditionInitialized),
+		},
 	}
+	populateStageTaskStatuses(status, updateRun.Name, updateStrategy.Spec.Stages)
 	return status
 }
 

--- a/pkg/controllers/updaterun/initialization_integration_test.go
+++ b/pkg/controllers/updaterun/initialization_integration_test.go
@@ -653,8 +653,8 @@ var _ = Describe("Updaterun initialization tests", func() {
 
 			It("Should select all scheduled clusters if labelSelector is empty and select no clusters if labelSelector is nil", func() {
 				By("Creating a clusterStagedUpdateStrategy with two stages, using empty labelSelector and nil labelSelector respectively")
-				updateStrategy.Spec.Stages[0].LabelSelector = nil                     // no clusters selected
-				updateStrategy.Spec.Stages[1].LabelSelector = &metav1.LabelSelector{} // all clusters selected
+				updateStrategy.Spec.Stages[0].LabelSelector = &metav1.LabelSelector{} // all clusters selected
+				updateStrategy.Spec.Stages[1].LabelSelector = nil                     // no clusters selected
 				Expect(k8sClient.Create(ctx, updateStrategy)).To(Succeed())
 
 				By("Creating a new clusterStagedUpdateRun")
@@ -667,22 +667,7 @@ var _ = Describe("Updaterun initialization tests", func() {
 					}
 
 					// no resource snapshot created in this test
-					want := generateSucceededInitializationStatus(crp, updateRun, "", policySnapshot, updateStrategy, clusterResourceOverride)
-					// No clusters should be selected in the first stage.
-					want.StagesStatus[0].Clusters = []placementv1beta1.ClusterUpdatingStatus{}
-					// All clusters should be selected in the second stage and sorted by name.
-					want.StagesStatus[1].Clusters = []placementv1beta1.ClusterUpdatingStatus{
-						{ClusterName: "cluster-0"},
-						{ClusterName: "cluster-1"},
-						{ClusterName: "cluster-2"},
-						{ClusterName: "cluster-3"},
-						{ClusterName: "cluster-4"},
-						{ClusterName: "cluster-5"},
-						{ClusterName: "cluster-6"},
-						{ClusterName: "cluster-7"},
-						{ClusterName: "cluster-8"},
-						{ClusterName: "cluster-9"},
-					}
+					want := generateInitializedStatus(crp, updateRun, "", policySnapshot, updateStrategy, 10, generateTenClusterSingleStageStatus(nil), generateTenClusterDeletionStageStatus())
 					// initialization should fail due to resourceSnapshot not found.
 					want.Conditions = []metav1.Condition{
 						generateFalseCondition(updateRun, placementv1beta1.StagedUpdateRunConditionInitialized),
@@ -710,11 +695,8 @@ var _ = Describe("Updaterun initialization tests", func() {
 				}
 
 				// no resource snapshot created in this test
-				want := generateSucceededInitializationStatus(crp, updateRun, "", policySnapshot, updateStrategy, clusterResourceOverride)
-				for i := range want.StagesStatus[0].Clusters {
-					// Remove the CROs, as they are not added in this test.
-					want.StagesStatus[0].Clusters[i].ClusterResourceOverrideSnapshots = nil
-				}
+				stagesStatus := generateTenClusterStagesStatus(nil)
+				want := generateInitializedStatus(crp, updateRun, "", policySnapshot, updateStrategy, 10, stagesStatus, generateTenClusterDeletionStageStatus())
 				// initialization should fail due to resourceSnapshot not found.
 				want.Conditions = []metav1.Condition{
 					generateFalseCondition(updateRun, placementv1beta1.StagedUpdateRunConditionInitialized),
@@ -936,7 +918,7 @@ var _ = Describe("Updaterun initialization tests", func() {
 			Expect(k8sClient.Create(ctx, updateRun)).To(Succeed())
 
 			By("Validating the clusterStagedUpdateRun stats")
-			initialized := generateSucceededInitializationStatus(crp, updateRun, testResourceSnapshotIndex, policySnapshot, updateStrategy, clusterResourceOverride)
+			initialized := generateInitializedStatus(crp, updateRun, testResourceSnapshotIndex, policySnapshot, updateStrategy, 10, generateTenClusterStagesStatus(clusterResourceOverride), generateTenClusterDeletionStageStatus())
 			validateClusterStagedUpdateRunStatus(ctx, updateRun, initialized, "")
 
 			By("Validating the clusterStagedUpdateRun initialized consistently")
@@ -1141,115 +1123,22 @@ func buildTaskStatuses(
 	return taskStatuses
 }
 
-func generateSucceededInitializationStatus(
-	crp *placementv1beta1.ClusterResourcePlacement,
-	updateRun *placementv1beta1.ClusterStagedUpdateRun,
-	resourceSnapshotIndex string,
-	policySnapshot *placementv1beta1.ClusterSchedulingPolicySnapshot,
-	updateStrategy *placementv1beta1.ClusterStagedUpdateStrategy,
-	clusterResourceOverride *placementv1beta1.ClusterResourceOverrideSnapshot,
-) *placementv1beta1.UpdateRunStatus {
-	status := &placementv1beta1.UpdateRunStatus{
-		PolicySnapshotIndexUsed:    policySnapshot.Labels[placementv1beta1.PolicyIndexLabel],
-		PolicyObservedClusterCount: 10,
-		ResourceSnapshotIndexUsed:  resourceSnapshotIndex,
-		ApplyStrategy:              crp.Spec.Strategy.ApplyStrategy.DeepCopy(),
-		UpdateStrategySnapshot:     &updateStrategy.Spec,
-		StagesStatus: []placementv1beta1.StageUpdatingStatus{
-			{
-				StageName: "stage1",
-				Clusters: []placementv1beta1.ClusterUpdatingStatus{
-					{ClusterName: "cluster-9", ClusterResourceOverrideSnapshots: []string{clusterResourceOverride.Name}},
-					{ClusterName: "cluster-7", ClusterResourceOverrideSnapshots: []string{clusterResourceOverride.Name}},
-					{ClusterName: "cluster-5", ClusterResourceOverrideSnapshots: []string{clusterResourceOverride.Name}},
-					{ClusterName: "cluster-3", ClusterResourceOverrideSnapshots: []string{clusterResourceOverride.Name}},
-					{ClusterName: "cluster-1", ClusterResourceOverrideSnapshots: []string{clusterResourceOverride.Name}},
-				},
-			},
-			{
-				StageName: "stage2",
-				Clusters: []placementv1beta1.ClusterUpdatingStatus{
-					{ClusterName: "cluster-0"},
-					{ClusterName: "cluster-2"},
-					{ClusterName: "cluster-4"},
-					{ClusterName: "cluster-6"},
-					{ClusterName: "cluster-8"},
-				},
-			},
-		},
-		DeletionStageStatus: &placementv1beta1.StageUpdatingStatus{
-			StageName: "kubernetes-fleet.io/deleteStage",
-			Clusters: []placementv1beta1.ClusterUpdatingStatus{
-				{ClusterName: "unscheduled-cluster-0"},
-				{ClusterName: "unscheduled-cluster-1"},
-				{ClusterName: "unscheduled-cluster-2"},
-			},
-		},
-		Conditions: []metav1.Condition{
-			// initialization should succeed!
-			generateTrueCondition(updateRun, placementv1beta1.StagedUpdateRunConditionInitialized),
-		},
-	}
-	populateStageTaskStatuses(status, updateRun.Name, updateStrategy.Spec.Stages)
-	return status
-}
-
-func generateSucceededInitializationStatusForSmallClusters(
-	crp *placementv1beta1.ClusterResourcePlacement,
-	updateRun *placementv1beta1.ClusterStagedUpdateRun,
-	resourceSnapshotIndex string,
-	policySnapshot *placementv1beta1.ClusterSchedulingPolicySnapshot,
-	updateStrategy *placementv1beta1.ClusterStagedUpdateStrategy,
-	numUnscheduledClusters int,
-) *placementv1beta1.UpdateRunStatus {
-	status := &placementv1beta1.UpdateRunStatus{
-		PolicySnapshotIndexUsed:    policySnapshot.Labels[placementv1beta1.PolicyIndexLabel],
-		PolicyObservedClusterCount: 3,
-		ResourceSnapshotIndexUsed:  resourceSnapshotIndex,
-		ApplyStrategy:              crp.Spec.Strategy.ApplyStrategy.DeepCopy(),
-		UpdateStrategySnapshot:     &updateStrategy.Spec,
-		StagesStatus: []placementv1beta1.StageUpdatingStatus{
-			{
-				StageName: "stage1",
-				Clusters: []placementv1beta1.ClusterUpdatingStatus{
-					{ClusterName: "cluster-0"},
-					{ClusterName: "cluster-1"},
-					{ClusterName: "cluster-2"},
-				},
-			},
-		},
-		DeletionStageStatus: &placementv1beta1.StageUpdatingStatus{
-			StageName: "kubernetes-fleet.io/deleteStage",
-			Clusters:  []placementv1beta1.ClusterUpdatingStatus{},
-		},
-		Conditions: []metav1.Condition{
-			// initialization should succeed!
-			generateTrueCondition(updateRun, placementv1beta1.StagedUpdateRunConditionInitialized),
-		},
-	}
-	for i := range numUnscheduledClusters {
-		status.DeletionStageStatus.Clusters = append(status.DeletionStageStatus.Clusters,
-			placementv1beta1.ClusterUpdatingStatus{ClusterName: fmt.Sprintf("unscheduled-cluster-%d", i)})
-	}
-	populateStageTaskStatuses(status, updateRun.Name, updateStrategy.Spec.Stages)
-	return status
-}
-
-// generateInitializedStatusWithCustomStages creates an initialization status with custom stage configurations.
+// generateInitializedStatus creates an initialization status with custom stage configurations.
 // stagesStatus should contain the StageName and Clusters for each stage.
 // The BeforeStageTaskStatus and AfterStageTaskStatus are populated based on the updateStrategy stages.
-func generateInitializedStatusWithCustomStages(
+func generateInitializedStatus(
 	crp *placementv1beta1.ClusterResourcePlacement,
 	updateRun *placementv1beta1.ClusterStagedUpdateRun,
 	resourceSnapshotIndex string,
 	policySnapshot *placementv1beta1.ClusterSchedulingPolicySnapshot,
 	updateStrategy *placementv1beta1.ClusterStagedUpdateStrategy,
+	policyObservedClusterCount int,
 	stagesStatus []placementv1beta1.StageUpdatingStatus,
 	deletionStageStatus *placementv1beta1.StageUpdatingStatus,
 ) *placementv1beta1.UpdateRunStatus {
 	status := &placementv1beta1.UpdateRunStatus{
 		PolicySnapshotIndexUsed:    policySnapshot.Labels[placementv1beta1.PolicyIndexLabel],
-		PolicyObservedClusterCount: 10,
+		PolicyObservedClusterCount: policyObservedClusterCount,
 		ResourceSnapshotIndexUsed:  resourceSnapshotIndex,
 		ApplyStrategy:              crp.Spec.Strategy.ApplyStrategy.DeepCopy(),
 		UpdateStrategySnapshot:     &updateStrategy.Spec,
@@ -1260,6 +1149,104 @@ func generateInitializedStatusWithCustomStages(
 		},
 	}
 	populateStageTaskStatuses(status, updateRun.Name, updateStrategy.Spec.Stages)
+	return status
+}
+
+// generateTenClusterStagesStatus returns the stages status for 10 clusters split across 2 stages.
+// Stage 1 contains odd-numbered clusters (9,7,5,3,1) in descending order.
+// Stage 2 contains even-numbered clusters (0,2,4,6,8) in ascending order.
+// If clusterResourceOverride is provided, it is applied to all odd-numbered clusters (stage 1).
+func generateTenClusterStagesStatus(clusterResourceOverride *placementv1beta1.ClusterResourceOverrideSnapshot) []placementv1beta1.StageUpdatingStatus {
+	const numTargetClusters = 10
+
+	// Stage 1: odd-numbered clusters in descending order (9,7,5,3,1)
+	var stage1Clusters []placementv1beta1.ClusterUpdatingStatus
+	for i := numTargetClusters - 1; i >= 1; i -= 2 {
+		cluster := placementv1beta1.ClusterUpdatingStatus{ClusterName: fmt.Sprintf("cluster-%d", i)}
+		if clusterResourceOverride != nil {
+			cluster.ClusterResourceOverrideSnapshots = []string{clusterResourceOverride.Name}
+		}
+		stage1Clusters = append(stage1Clusters, cluster)
+	}
+
+	// Stage 2: even-numbered clusters in ascending order (0,2,4,6,8)
+	var stage2Clusters []placementv1beta1.ClusterUpdatingStatus
+	for i := 0; i < numTargetClusters; i += 2 {
+		stage2Clusters = append(stage2Clusters, placementv1beta1.ClusterUpdatingStatus{ClusterName: fmt.Sprintf("cluster-%d", i)})
+	}
+
+	return []placementv1beta1.StageUpdatingStatus{
+		{
+			StageName: "stage1",
+			Clusters:  stage1Clusters,
+		},
+		{
+			StageName: "stage2",
+			Clusters:  stage2Clusters,
+		},
+	}
+}
+
+// generateTenClusterDeletionStageStatus returns the deletion stage status for 3 unscheduled clusters.
+func generateTenClusterDeletionStageStatus() *placementv1beta1.StageUpdatingStatus {
+	return &placementv1beta1.StageUpdatingStatus{
+		StageName: "kubernetes-fleet.io/deleteStage",
+		Clusters: []placementv1beta1.ClusterUpdatingStatus{
+			{ClusterName: "unscheduled-cluster-0"},
+			{ClusterName: "unscheduled-cluster-1"},
+			{ClusterName: "unscheduled-cluster-2"},
+		},
+	}
+}
+
+// generateTenClusterSingleStageStatus returns a stages status with stage1 containing all 10 clusters and empty.
+// Clusters are sorted by name in descending order (9,8,7,...,0).
+// This is used for testing label selector scenarios where all clusters end up in one stage.
+func generateTenClusterSingleStageStatus(clusterResourceOverride *placementv1beta1.ClusterResourceOverrideSnapshot) []placementv1beta1.StageUpdatingStatus {
+	var clusters []placementv1beta1.ClusterUpdatingStatus
+	for i := 9; i >= 0; i-- {
+		clusterUpdatingStatus := placementv1beta1.ClusterUpdatingStatus{ClusterName: fmt.Sprintf("cluster-%d", i)}
+		if i%2 != 0 && clusterResourceOverride != nil {
+			clusterUpdatingStatus.ClusterResourceOverrideSnapshots = []string{clusterResourceOverride.Name}
+		}
+		clusters = append(clusters, clusterUpdatingStatus)
+	}
+	return []placementv1beta1.StageUpdatingStatus{
+		{
+			StageName: "stage1",
+			Clusters:  clusters,
+		},
+		{
+			StageName: "stage2",
+			Clusters:  []placementv1beta1.ClusterUpdatingStatus{},
+		},
+	}
+}
+
+// generateThreeClusterStagesStatus returns the stages status for 3 clusters in a single stage.
+func generateThreeClusterStagesStatus() []placementv1beta1.StageUpdatingStatus {
+	return []placementv1beta1.StageUpdatingStatus{
+		{
+			StageName: "stage1",
+			Clusters: []placementv1beta1.ClusterUpdatingStatus{
+				{ClusterName: "cluster-0"},
+				{ClusterName: "cluster-1"},
+				{ClusterName: "cluster-2"},
+			},
+		},
+	}
+}
+
+// generateDeletionStageStatus returns a deletion stage status with the specified number of unscheduled clusters.
+func generateDeletionStageStatus(numUnscheduledClusters int) *placementv1beta1.StageUpdatingStatus {
+	status := &placementv1beta1.StageUpdatingStatus{
+		StageName: "kubernetes-fleet.io/deleteStage",
+		Clusters:  []placementv1beta1.ClusterUpdatingStatus{},
+	}
+	for i := range numUnscheduledClusters {
+		status.Clusters = append(status.Clusters,
+			placementv1beta1.ClusterUpdatingStatus{ClusterName: fmt.Sprintf("unscheduled-cluster-%d", i)})
+	}
 	return status
 }
 

--- a/pkg/controllers/updaterun/stop_integration_test.go
+++ b/pkg/controllers/updaterun/stop_integration_test.go
@@ -173,7 +173,7 @@ var _ = Describe("UpdateRun stop tests", func() {
 			Expect(k8sClient.Create(ctx, updateRun)).To(Succeed())
 
 			By("Validating the initialization succeeded and the execution has not started")
-			initialized := generateSucceededInitializationStatusForSmallClusters(crp, updateRun, testResourceSnapshotIndex, policySnapshot, updateStrategy, 3)
+			initialized := generateInitializedStatus(crp, updateRun, testResourceSnapshotIndex, policySnapshot, updateStrategy, 3, generateThreeClusterStagesStatus(), generateDeletionStageStatus(3))
 			wantStatus = generateExecutionNotStartedStatus(updateRun, initialized)
 			validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus, "")
 
@@ -251,7 +251,7 @@ var _ = Describe("UpdateRun stop tests", func() {
 		It("Should mark the 1st cluster in the 1st stage as succeeded after marking the binding available", func() {
 			By("Validating the 1st clusterResourceBinding is updated to Bound")
 			binding := resourceBindings[0] // cluster-0
-			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, 0)
+			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, &updateRun.Status.StagesStatus[0].Clusters[0])
 
 			By("Updating the 1st clusterResourceBinding to Available")
 			meta.SetStatusCondition(&binding.Status.Conditions, generateTrueCondition(binding, placementv1beta1.ResourceBindingAvailable))
@@ -301,7 +301,7 @@ var _ = Describe("UpdateRun stop tests", func() {
 		It("Should have completely stopped after the in-progress cluster has finished updating", func() {
 			By("Validating the 2nd clusterResourceBinding is updated to Bound")
 			binding := resourceBindings[1] // cluster-1
-			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, 0)
+			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, &updateRun.Status.StagesStatus[0].Clusters[1])
 
 			By("Updating the 2nd clusterResourceBinding to Available")
 			meta.SetStatusCondition(&binding.Status.Conditions, generateTrueCondition(binding, placementv1beta1.ResourceBindingAvailable))
@@ -311,9 +311,9 @@ var _ = Describe("UpdateRun stop tests", func() {
 			// Mark 2nd cluster succeeded.
 			meta.SetStatusCondition(&wantStatus.StagesStatus[0].Clusters[1].Conditions, generateTrueCondition(updateRun, placementv1beta1.ClusterUpdatingConditionSucceeded))
 			// Mark stage progressing condition as false with stopped reason.
-			meta.SetStatusCondition(&wantStatus.StagesStatus[0].Conditions, generateFalseProgressingCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingStoppedReason))
+			meta.SetStatusCondition(&wantStatus.StagesStatus[0].Conditions, generateFalseConditionWithReason(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingStoppedReason))
 			// Mark updateRun progressing condition as false with stopped reason.
-			meta.SetStatusCondition(&wantStatus.Conditions, generateFalseProgressingCondition(updateRun, placementv1beta1.StagedUpdateRunConditionProgressing, condition.UpdateRunStoppedReason))
+			meta.SetStatusCondition(&wantStatus.Conditions, generateFalseConditionWithReason(updateRun, placementv1beta1.StagedUpdateRunConditionProgressing, condition.UpdateRunStoppedReason))
 			validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus, "")
 
 			By("Checking update run metrics are emitted")
@@ -351,7 +351,7 @@ var _ = Describe("UpdateRun stop tests", func() {
 		It("Should mark the 3rd cluster in the 1st stage as succeeded after marking the binding available", func() {
 			By("Validating the 3rd clusterResourceBinding is updated to Bound")
 			binding := resourceBindings[2] // cluster-2
-			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, 0)
+			validateBindingState(ctx, binding, resourceSnapshot.Name, updateRun, &updateRun.Status.StagesStatus[0].Clusters[2])
 
 			By("Updating the 3rd clusterResourceBinding to Available")
 			meta.SetStatusCondition(&binding.Status.Conditions, generateTrueCondition(binding, placementv1beta1.ResourceBindingAvailable))
@@ -462,7 +462,7 @@ var _ = Describe("UpdateRun stop tests", func() {
 			wantStatus.StagesStatus[0].AfterStageTaskStatus[1].Conditions = append(wantStatus.StagesStatus[0].AfterStageTaskStatus[1].Conditions,
 				generateTrueCondition(updateRun, placementv1beta1.StageTaskConditionWaitTimeElapsed))
 			// 1st stage completed, mark progressing condition reason as succeeded and add succeeded condition.
-			wantStatus.StagesStatus[0].Conditions[0] = generateFalseProgressingCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSucceededReason)
+			wantStatus.StagesStatus[0].Conditions[0] = generateFalseConditionWithReason(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSucceededReason)
 			wantStatus.StagesStatus[0].Conditions = append(wantStatus.StagesStatus[0].Conditions, generateTrueCondition(updateRun, placementv1beta1.StageUpdatingConditionSucceeded))
 			// Deletion stage started. Mark deletion stage progressing condition as true with progressing reason.
 			meta.SetStatusCondition(&wantStatus.DeletionStageStatus.Conditions, generateTrueCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing))
@@ -612,10 +612,10 @@ var _ = Describe("UpdateRun stop tests", func() {
 				meta.SetStatusCondition(&wantStatus.DeletionStageStatus.Clusters[i].Conditions, generateTrueCondition(updateRun, placementv1beta1.ClusterUpdatingConditionSucceeded))
 			}
 			// Mark the stage progressing condition as false with succeeded reason and add succeeded condition.
-			wantStatus.DeletionStageStatus.Conditions[0] = generateFalseProgressingCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSucceededReason)
+			wantStatus.DeletionStageStatus.Conditions[0] = generateFalseConditionWithReason(updateRun, placementv1beta1.StageUpdatingConditionProgressing, condition.StageUpdatingSucceededReason)
 			wantStatus.DeletionStageStatus.Conditions = append(wantStatus.DeletionStageStatus.Conditions, generateTrueCondition(updateRun, placementv1beta1.StageUpdatingConditionSucceeded))
 			// Mark updateRun progressing condition as false with succeeded reason and add succeeded condition.
-			meta.SetStatusCondition(&wantStatus.Conditions, generateFalseProgressingCondition(updateRun, placementv1beta1.StagedUpdateRunConditionProgressing, condition.UpdateRunSucceededReason))
+			meta.SetStatusCondition(&wantStatus.Conditions, generateFalseConditionWithReason(updateRun, placementv1beta1.StagedUpdateRunConditionProgressing, condition.UpdateRunSucceededReason))
 			wantStatus.Conditions = append(wantStatus.Conditions, generateTrueCondition(updateRun, placementv1beta1.StagedUpdateRunConditionSucceeded))
 			validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus, "")
 

--- a/pkg/controllers/updaterun/validation_integration_test.go
+++ b/pkg/controllers/updaterun/validation_integration_test.go
@@ -111,7 +111,7 @@ var _ = Describe("UpdateRun validation tests", func() {
 			Expect(k8sClient.Create(ctx, updateRun)).To(Succeed())
 
 			By("Validating the initialization succeeded")
-			initialized := generateSucceededInitializationStatus(crp, updateRun, testResourceSnapshotIndex, policySnapshot, updateStrategy, clusterResourceOverride)
+			initialized := generateInitializedStatus(crp, updateRun, testResourceSnapshotIndex, policySnapshot, updateStrategy, 10, generateTenClusterStagesStatus(clusterResourceOverride), generateTenClusterDeletionStageStatus())
 			wantStatus = generateExecutionNotStartedStatus(updateRun, initialized)
 			validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus, "")
 		})
@@ -446,7 +446,7 @@ var _ = Describe("UpdateRun validation tests", func() {
 			Expect(k8sClient.Create(ctx, updateRun)).To(Succeed())
 
 			By("Validating the initialization succeeded")
-			initialized := generateSucceededInitializationStatus(crp, updateRun, testResourceSnapshotIndex, policySnapshot, updateStrategy, clusterResourceOverride)
+			initialized := generateInitializedStatus(crp, updateRun, testResourceSnapshotIndex, policySnapshot, updateStrategy, 10, generateTenClusterStagesStatus(clusterResourceOverride), generateTenClusterDeletionStageStatus())
 			wantStatus = generateExecutionNotStartedStatus(updateRun, initialized)
 			validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus, "")
 		})
@@ -568,7 +568,7 @@ func generateFailedValidationStatus(
 	updateRun *placementv1beta1.ClusterStagedUpdateRun,
 	started *placementv1beta1.UpdateRunStatus,
 ) *placementv1beta1.UpdateRunStatus {
-	started.Conditions[1] = generateFalseProgressingCondition(updateRun, placementv1beta1.StagedUpdateRunConditionProgressing, condition.UpdateRunFailedReason)
+	started.Conditions[1] = generateFalseConditionWithReason(updateRun, placementv1beta1.StagedUpdateRunConditionProgressing, condition.UpdateRunFailedReason)
 	started.Conditions = append(started.Conditions, generateFalseCondition(updateRun, placementv1beta1.StagedUpdateRunConditionSucceeded))
 	return started
 }

--- a/pkg/utils/condition/reason.go
+++ b/pkg/utils/condition/reason.go
@@ -197,6 +197,9 @@ const (
 	// StageUpdatingSucceededReason is the reason string of condition if the stage updating succeeded.
 	StageUpdatingSucceededReason = "StageUpdatingSucceeded"
 
+	// StageUpdatingSkippedNoClustersReason is the reason string of condition if the stage was skipped because it has no clusters.
+	StageUpdatingSkippedNoClustersReason = "StageUpdatingSkippedNoClusters"
+
 	// ClusterUpdatingStartedReason is the reason string of condition if the cluster updating has started.
 	ClusterUpdatingStartedReason = "ClusterUpdatingStarted"
 

--- a/test/e2e/cluster_staged_updaterun_test.go
+++ b/test/e2e/cluster_staged_updaterun_test.go
@@ -670,8 +670,6 @@ var _ = Describe("test CRP rollout with staged update run", func() {
 			By("Validating crp status keeping as rollout pending with member-cluster-3 only")
 			crpStatusUpdatedActual := crpStatusWithExternalStrategyActual(workResourceIdentifiers(), resourceSnapshotIndex1st, false, []string{allMemberClusterNames[2]}, []string{resourceSnapshotIndex1st}, []bool{false}, nil, nil)
 			Consistently(crpStatusUpdatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to update CRP %s status as expected", crpName)
-
-			validateAndApproveClusterApprovalRequests(updateRunNames[2], envCanary, placementv1beta1.AfterStageApprovalTaskNameFmt, placementv1beta1.AfterStageTaskLabelValue)
 		})
 
 		It("Should remove resources on member-cluster-1 and member-cluster-2 after approval and complete the cluster staged update run successfully", func() {
@@ -769,8 +767,6 @@ var _ = Describe("test CRP rollout with staged update run", func() {
 			By("Validating crp status as pending rollout still")
 			crpStatusUpdatedActual := crpStatusWithExternalStrategyActual(nil, "", false, allMemberClusterNames[2:], []string{""}, []bool{false}, nil, nil)
 			Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update CRP %s status as expected", crpName)
-
-			validateAndApproveClusterApprovalRequests(updateRunNames[0], envCanary, placementv1beta1.AfterStageApprovalTaskNameFmt, placementv1beta1.AfterStageTaskLabelValue)
 		})
 
 		It("Should not rollout resources to prod stage until approved", func() {

--- a/test/e2e/cluster_staged_updaterun_test.go
+++ b/test/e2e/cluster_staged_updaterun_test.go
@@ -664,18 +664,21 @@ var _ = Describe("test CRP rollout with staged update run", func() {
 			createClusterStagedUpdateRunSucceed(updateRunNames[2], crpName, resourceSnapshotIndex1st, strategyName, placementv1beta1.StateRun)
 		})
 
-		It("Should still have resources on all member clusters and complete stage canary", func() {
+		It("Should still have resources on all member clusters and skip stage canary", func() {
 			checkIfPlacedWorkResourcesOnMemberClustersConsistently(allMemberClusters)
 
 			By("Validating crp status keeping as rollout pending with member-cluster-3 only")
 			crpStatusUpdatedActual := crpStatusWithExternalStrategyActual(workResourceIdentifiers(), resourceSnapshotIndex1st, false, []string{allMemberClusterNames[2]}, []string{resourceSnapshotIndex1st}, []bool{false}, nil, nil)
 			Consistently(crpStatusUpdatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to update CRP %s status as expected", crpName)
+
+			// Completes stage by skipping since there are 0 clusters.
 		})
 
-		It("Should remove resources on member-cluster-1 and member-cluster-2 after approval and complete the cluster staged update run successfully", func() {
+		It("Should remove resources on member-cluster-1 and member-cluster-2 after before-stage task approval and complete the cluster staged update run successfully", func() {
 			validateAndApproveClusterApprovalRequests(updateRunNames[2], envProd, placementv1beta1.BeforeStageApprovalTaskNameFmt, placementv1beta1.BeforeStageTaskLabelValue)
 
-			// need to go through two stages
+			// Need to go through two stages. The second stage takes care of member-cluster-3 and ensure the resource is rolled out to there.
+			// The deletion stage will remove the resources from member-cluster-1 and member-cluster-2.
 			csurSucceededActual := testutilsupdaterun.ClusterStagedUpdateRunStatusSucceededActual(ctx, hubClient, updateRunNames[2], resourceSnapshotIndex1st, policySnapshotIndex3rd, 1, defaultApplyStrategy, &strategy.Spec, [][]string{{}, {allMemberClusterNames[2]}}, []string{allMemberClusterNames[0], allMemberClusterNames[1]}, nil, nil, true)
 			Eventually(csurSucceededActual, 2*updateRunEventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to validate updateRun %s succeeded", updateRunNames[2])
 			checkIfRemovedWorkResourcesFromMemberClusters([]*framework.Cluster{allMemberClusters[0], allMemberClusters[1]})
@@ -761,19 +764,21 @@ var _ = Describe("test CRP rollout with staged update run", func() {
 			validateLatestClusterResourceSnapshot(crpName, resourceSnapshotIndex1st)
 		})
 
-		It("Should not rollout any resources to member clusters and complete stage canary", func() {
+		It("Should not rollout any resources to member clusters and skip stage canary", func() {
 			checkIfRemovedWorkResourcesFromMemberClustersConsistently(allMemberClusters)
 
 			By("Validating crp status as pending rollout still")
 			crpStatusUpdatedActual := crpStatusWithExternalStrategyActual(nil, "", false, allMemberClusterNames[2:], []string{""}, []bool{false}, nil, nil)
 			Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update CRP %s status as expected", crpName)
+
+			// Completes stage by skipping since there are 0 clusters.
 		})
 
 		It("Should not rollout resources to prod stage until approved", func() {
 			checkIfRemovedWorkResourcesFromMemberClustersConsistently([]*framework.Cluster{allMemberClusters[0], allMemberClusters[1]})
 		})
 
-		It("Should rollout resources to member-cluster-3 after approval and complete the cluster staged update run successfully", func() {
+		It("Should rollout resources to member-cluster-3 after before-stage task approval and complete the cluster staged update run successfully", func() {
 			validateAndApproveClusterApprovalRequests(updateRunNames[0], envProd, placementv1beta1.BeforeStageApprovalTaskNameFmt, placementv1beta1.BeforeStageTaskLabelValue)
 
 			csurSucceededActual := testutilsupdaterun.ClusterStagedUpdateRunStatusSucceededActual(ctx, hubClient, updateRunNames[0], resourceSnapshotIndex1st, policySnapshotIndex1st, 1, defaultApplyStrategy, &strategy.Spec, [][]string{{}, {allMemberClusterNames[2]}}, nil, nil, nil, true)

--- a/test/e2e/staged_updaterun_test.go
+++ b/test/e2e/staged_updaterun_test.go
@@ -667,7 +667,7 @@ var _ = Describe("test RP rollout with staged update run", Label("resourceplacem
 			rpStatusUpdatedActual := rpStatusWithExternalStrategyActual(appConfigMapIdentifiers(), resourceSnapshotIndex1st, false, []string{allMemberClusterNames[2]}, []string{resourceSnapshotIndex1st}, []bool{false}, nil, nil)
 			Consistently(rpStatusUpdatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to update RP %s/%s status as expected", testNamespace, rpName)
 
-			validateAndApproveNamespacedApprovalRequests(updateRunNames[2], testNamespace, envCanary, placementv1beta1.AfterStageApprovalTaskNameFmt, placementv1beta1.AfterStageTaskLabelValue)
+			// Completes stage by skipping since there are 0 clusters.
 		})
 
 		It("Should remove resources on member-cluster-1 and member-cluster-2 after approval and complete the staged update run successfully", func() {
@@ -770,7 +770,7 @@ var _ = Describe("test RP rollout with staged update run", Label("resourceplacem
 			rpStatusUpdatedActual := rpStatusWithExternalStrategyActual(nil, "", false, allMemberClusterNames[2:], []string{""}, []bool{false}, nil, nil)
 			Eventually(rpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update RP %s/%s status as expected", testNamespace, rpName)
 
-			validateAndApproveNamespacedApprovalRequests(updateRunNames[0], testNamespace, envCanary, placementv1beta1.AfterStageApprovalTaskNameFmt, placementv1beta1.AfterStageTaskLabelValue)
+			// Completes stage by skipping since there are 0 clusters.
 		})
 
 		It("Should not rollout resources to prod stage until approved", func() {

--- a/test/e2e/staged_updaterun_test.go
+++ b/test/e2e/staged_updaterun_test.go
@@ -660,7 +660,7 @@ var _ = Describe("test RP rollout with staged update run", Label("resourceplacem
 			createStagedUpdateRunSucceed(updateRunNames[2], testNamespace, rpName, resourceSnapshotIndex1st, strategyName, placementv1beta1.StateRun)
 		})
 
-		It("Should still have resources on all member clusters and complete stage canary", func() {
+		It("Should still have resources on all member clusters and skip stage canary", func() {
 			checkIfPlacedWorkResourcesOnMemberClustersConsistently(allMemberClusters)
 
 			By("Validating rp status keeping as rollout pending with member-cluster-3 only")
@@ -670,10 +670,11 @@ var _ = Describe("test RP rollout with staged update run", Label("resourceplacem
 			// Completes stage by skipping since there are 0 clusters.
 		})
 
-		It("Should remove resources on member-cluster-1 and member-cluster-2 after approval and complete the staged update run successfully", func() {
+		It("Should remove resources on member-cluster-1 and member-cluster-2 after before-stage task approval and complete the staged update run successfully", func() {
 			validateAndApproveNamespacedApprovalRequests(updateRunNames[2], testNamespace, envProd, placementv1beta1.BeforeStageApprovalTaskNameFmt, placementv1beta1.BeforeStageTaskLabelValue)
 
-			// need to go through two stages
+			// Need to go through two stages. The second stage takes care of member-cluster-3 and ensure the resource is rolled out to there.
+			// The deletion stage will remove the resources from member-cluster-1 and member-cluster-2.
 			surSucceededActual := testutilsupdaterun.StagedUpdateRunStatusSucceededActual(ctx, hubClient, updateRunNames[2], testNamespace, resourceSnapshotIndex1st, policySnapshotIndex3rd, 1, defaultApplyStrategy, &strategy.Spec, [][]string{{}, {allMemberClusterNames[2]}}, []string{allMemberClusterNames[0], allMemberClusterNames[1]}, nil, nil, true)
 			Eventually(surSucceededActual, 2*updateRunEventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to validate updateRun %s/%s succeeded", testNamespace, updateRunNames[2])
 			checkIfRemovedConfigMapFromMemberClusters([]*framework.Cluster{allMemberClusters[0], allMemberClusters[1]})
@@ -763,7 +764,7 @@ var _ = Describe("test RP rollout with staged update run", Label("resourceplacem
 			validateLatestResourceSnapshot(rpName, testNamespace, resourceSnapshotIndex1st)
 		})
 
-		It("Should not rollout any resources to member clusters and complete stage canary", func() {
+		It("Should not rollout any resources to member clusters and skip stage canary", func() {
 			checkIfRemovedConfigMapFromMemberClustersConsistently(allMemberClusters)
 
 			By("Validating rp status as pending rollout still")
@@ -777,7 +778,7 @@ var _ = Describe("test RP rollout with staged update run", Label("resourceplacem
 			checkIfRemovedConfigMapFromMemberClustersConsistently([]*framework.Cluster{allMemberClusters[0], allMemberClusters[1]})
 		})
 
-		It("Should rollout resources to member-cluster-3 after approval and complete the cluster staged update run successfully", func() {
+		It("Should rollout resources to member-cluster-3 after before-stage task approval and complete the cluster staged update run successfully", func() {
 			validateAndApproveNamespacedApprovalRequests(updateRunNames[0], testNamespace, envProd, placementv1beta1.BeforeStageApprovalTaskNameFmt, placementv1beta1.BeforeStageTaskLabelValue)
 
 			surSucceededActual := testutilsupdaterun.StagedUpdateRunStatusSucceededActual(ctx, hubClient, updateRunNames[0], testNamespace, resourceSnapshotIndex1st, policySnapshotIndex1st, 1, defaultApplyStrategy, &strategy.Spec, [][]string{{}, {allMemberClusterNames[2]}}, nil, nil, nil, true)

--- a/test/utils/updaterun/updaterun_status.go
+++ b/test/utils/updaterun/updaterun_status.go
@@ -191,7 +191,10 @@ func buildStageUpdatingStatuses(
 			if task.Type == placementv1beta1.StageTaskTypeApproval {
 				stagesStatus[i].BeforeStageTaskStatus[j].ApprovalRequestName = fmt.Sprintf(placementv1beta1.BeforeStageApprovalTaskNameFmt, updateRun.GetName(), stage.Name)
 			}
-			stagesStatus[i].BeforeStageTaskStatus[j].Conditions = updateRunStageTaskSucceedConditions(updateRun.GetGeneration(), task.Type)
+			// Skip populating task conditions if the stage has 0 clusters (stage is skipped).
+			if len(wantSelectedClusters[i]) > 0 {
+				stagesStatus[i].BeforeStageTaskStatus[j].Conditions = updateRunStageTaskSucceedConditions(updateRun.GetGeneration(), task.Type)
+			}
 		}
 		stagesStatus[i].AfterStageTaskStatus = make([]placementv1beta1.StageTaskStatus, len(stage.AfterStageTasks))
 		for j, task := range stage.AfterStageTasks {
@@ -199,9 +202,17 @@ func buildStageUpdatingStatuses(
 			if task.Type == placementv1beta1.StageTaskTypeApproval {
 				stagesStatus[i].AfterStageTaskStatus[j].ApprovalRequestName = fmt.Sprintf(placementv1beta1.AfterStageApprovalTaskNameFmt, updateRun.GetName(), stage.Name)
 			}
-			stagesStatus[i].AfterStageTaskStatus[j].Conditions = updateRunStageTaskSucceedConditions(updateRun.GetGeneration(), task.Type)
+			// Skip populating task conditions if the stage has 0 clusters (stage is skipped).
+			if len(wantSelectedClusters[i]) > 0 {
+				stagesStatus[i].AfterStageTaskStatus[j].Conditions = updateRunStageTaskSucceedConditions(updateRun.GetGeneration(), task.Type)
+			}
 		}
-		stagesStatus[i].Conditions = updateRunStageRolloutSucceedConditions(updateRun.GetGeneration())
+		// Use skipped conditions if the stage has 0 clusters.
+		if len(wantSelectedClusters[i]) == 0 {
+			stagesStatus[i].Conditions = updateRunStageSkippedNoClustersConditions(updateRun.GetGeneration())
+		} else {
+			stagesStatus[i].Conditions = updateRunStageRolloutSucceedConditions(updateRun.GetGeneration())
+		}
 	}
 	return stagesStatus
 }
@@ -259,6 +270,23 @@ func updateRunStageRolloutSucceedConditions(generation int64) []metav1.Condition
 			Type:               string(placementv1beta1.StageUpdatingConditionSucceeded),
 			Status:             metav1.ConditionTrue,
 			Reason:             condition.StageUpdatingSucceededReason,
+			ObservedGeneration: generation,
+		},
+	}
+}
+
+func updateRunStageSkippedNoClustersConditions(generation int64) []metav1.Condition {
+	return []metav1.Condition{
+		{
+			Type:               string(placementv1beta1.StageUpdatingConditionProgressing),
+			Status:             metav1.ConditionFalse,
+			Reason:             condition.StageUpdatingSkippedNoClustersReason,
+			ObservedGeneration: generation,
+		},
+		{
+			Type:               string(placementv1beta1.StageUpdatingConditionSucceeded),
+			Status:             metav1.ConditionTrue,
+			Reason:             condition.StageUpdatingSkippedNoClustersReason,
 			ObservedGeneration: generation,
 		},
 	}


### PR DESCRIPTION
### Description of your changes


Fixes #610 

I have:
- Updated staged update run execution to skip the entire stage (including stage tasks) if there are no clusters defined in the stage.
- Added integration test.

- [ ] Associated this change with a known KubeFleet Issue (Bug, Feature, etc).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- Unit Test
- Integration Test
- E2E Test

### Special notes for your reviewer

Before this change, we would execute the stage tasks for a stage even if there were no clusters to be updated in said stage. Example below of update run status with empty stage before:

```
  apiVersion: placement.kubernetes-fleet.io/v1beta1
  kind: ClusterStagedUpdateRun
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"placement.kubernetes-fleet.io/v1beta1","kind":"ClusterStagedUpdateRun","metadata":{"annotations":{},"name":"example-run"},"spec":{"placementName":"update-run-crp","resourceSnapshotIndex":"0","stagedRolloutStrategyName":"example-strategy"}}
    creationTimestamp: "2025-03-27T12:07:13Z"
    finalizers:
    - kubernetes-fleet.io/stagedupdaterun-finalizer
    generation: 1
    name: example-run
    resourceVersion: "238775497"
    uid: 9ba07f7b-f07e-4232-a86f-3a249ffcb462
  spec:
    placementName: update-run-crp
    resourceSnapshotIndex: "0"
    stagedRolloutStrategyName: example-strategy
  status:
    conditions:
    - lastTransitionTime: "2025-03-27T12:07:13Z"
      message: ClusterStagedUpdateRun initialized successfully
      observedGeneration: 1
      reason: UpdateRunInitializedSuccessfully
      status: "True"
      type: Initialized
    - lastTransitionTime: "2025-03-27T12:07:13Z"
      message: ""
      observedGeneration: 1
      reason: UpdateRunStarted
      status: "True"
      type: Progressing
    deletionStageStatus:
      clusters: []
      stageName: kubernetes-fleet.io/deleteStage
    policyObservedClusterCount: 4
    policySnapshotIndexUsed: "0"
    stagedUpdateStrategySnapshot:
      stages:
      - afterStageTasks:
        - type: TimedWait
          waitTime: 1m0s
        labelSelector:
          matchLabels:
            env: test
        name: test
      - labelSelector:
          matchLabels:
            env: prod
        name: prod
    stagesStatus:
    - afterStageTaskStatus:
      - type: TimedWait
      clusters: []
      conditions:
      - lastTransitionTime: "2025-03-27T12:07:13Z"
        message: ""
        observedGeneration: 1
        reason: StageUpdatingWaiting
        status: "False"
        type: Progressing
      stageName: test
    - clusters:
      - clusterName: aks-member-1
      - clusterName: aks-member-2
      - clusterName: aks-member-3
      - clusterName: aks-member-4
      stageName: prod
```

After change:
```
  apiVersion: placement.kubernetes-fleet.io/v1beta1
  kind: ClusterStagedUpdateRun
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"placement.kubernetes-fleet.io/v1beta1","kind":"ClusterStagedUpdateRun","metadata":{"annotations":{},"name":"example-run"},"spec":{"placementName":"update-run-crp","resourceSnapshotIndex":"0","stagedRolloutStrategyName":"example-strategy"}}
    creationTimestamp: "2025-03-27T12:07:13Z"
    finalizers:
    - kubernetes-fleet.io/stagedupdaterun-finalizer
    generation: 1
    name: example-run
    resourceVersion: "238775497"
    uid: 9ba07f7b-f07e-4232-a86f-3a249ffcb462
  spec:
    placementName: update-run-crp
    resourceSnapshotIndex: "0"
    stagedRolloutStrategyName: example-strategy
  status:
    conditions:
    - lastTransitionTime: "2025-03-27T12:07:13Z"
      message: ClusterStagedUpdateRun initialized successfully
      observedGeneration: 1
      reason: UpdateRunInitializedSuccessfully
      status: "True"
      type: Initialized
    - lastTransitionTime: "2025-03-27T12:07:13Z"
      message: ""
      observedGeneration: 1
      reason: UpdateRunStarted
      status: "True"
      type: Progressing
    deletionStageStatus:
      clusters: []
      stageName: kubernetes-fleet.io/deleteStage
    policyObservedClusterCount: 4
    policySnapshotIndexUsed: "0"
    stagedUpdateStrategySnapshot:
      stages:
      - afterStageTasks:
        - type: TimedWait
          waitTime: 1m0s
        labelSelector:
          matchLabels:
            env: test
        name: test
      - labelSelector:
          matchLabels:
            env: prod
        name: prod
    stagesStatus:
    - afterStageTaskStatus:
      - type: TimedWait
      clusters: []
      conditions:
      - lastTransitionTime: "2025-03-27T12:07:13Z"
        message: "Stage skipped because it has no clusters"
        observedGeneration: 1
        reason: StageUpdatingSkippedNoClusters
        status: "False"
        type: Progressing
      - lastTransitionTime: "2025-03-27T12:07:13Z"
        message: "Stage skipped because it has no clusters"
        observedGeneration: 1
        reason: StageUpdatingSkippedNoClusters
        status: "True"
        type: Succeed
      endTime: "2025-03-27T12:07:13Z""
      stageName: test
      startTime: "2025-03-27T12:07:13Z""
    - clusters:
        ....
      stageName: prod
       ...
 ```