### PR TITLE
feat: determine failure type when possible for update run

### DIFF
--- a/pkg/controllers/updaterun/controller.go
+++ b/pkg/controllers/updaterun/controller.go
@@ -155,7 +155,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req runtime.Request) (runtim
 			// errStagedUpdatedAborted cannot be retried.
 			if errors.Is(validateErr, errStagedUpdatedAborted) {
 				reconcileErr = validateErr
-				return runtime.Result{}, r.recordUpdateRunFailed(ctx, updateRun, validateErr)
+				return runtime.Result{}, r.recordUpdateRunFailed(ctx, updateRun, validateErr.Error())
 			}
 			return runtime.Result{}, validateErr
 		}
@@ -178,7 +178,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req runtime.Request) (runtim
 		if errors.Is(execErr, errStagedUpdatedAborted) {
 			// errStagedUpdatedAborted cannot be retried.
 			reconcileErr = execErr
-			return runtime.Result{}, r.recordUpdateRunFailed(ctx, updateRun, execErr)
+			return runtime.Result{}, r.recordUpdateRunFailed(ctx, updateRun, execErr.Error())
 		}
 
 		if finished {
@@ -194,7 +194,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req runtime.Request) (runtim
 		if errors.Is(stopErr, errStagedUpdatedAborted) {
 			// errStagedUpdatedAborted cannot be retried.
 			reconcileErr = stopErr
-			return runtime.Result{}, r.recordUpdateRunFailed(ctx, updateRun, stopErr)
+			return runtime.Result{}, r.recordUpdateRunFailed(ctx, updateRun, stopErr.Error())
 		}
 
 		if finished {
@@ -210,7 +210,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req runtime.Request) (runtim
 		klog.ErrorS(unexpectedErr, "Invalid updateRun state", "state", state, "updateRun", runObjRef)
 		// This is an internal error - unsupported state should not happen
 		reconcileErr = unexpectedErr
-		return runtime.Result{}, r.recordUpdateRunFailed(ctx, updateRun, unexpectedErr)
+		return runtime.Result{}, r.recordUpdateRunFailed(ctx, updateRun, unexpectedErr.Error())
 	}
 	return runtime.Result{}, nil
 }
@@ -297,7 +297,7 @@ func (r *Reconciler) recordUpdateRunSucceeded(ctx context.Context, updateRun pla
 }
 
 // recordUpdateRunFailed records the failed condition in the updateRun status.
-func (r *Reconciler) recordUpdateRunFailed(ctx context.Context, updateRun placementv1beta1.UpdateRunObj, err error) error {
+func (r *Reconciler) recordUpdateRunFailed(ctx context.Context, updateRun placementv1beta1.UpdateRunObj, message string) error {
 	updateRunStatus := updateRun.GetUpdateRunStatus()
 	meta.SetStatusCondition(&updateRunStatus.Conditions, metav1.Condition{
 		Type:               string(placementv1beta1.StagedUpdateRunConditionProgressing),
@@ -311,7 +311,7 @@ func (r *Reconciler) recordUpdateRunFailed(ctx context.Context, updateRun placem
 		Status:             metav1.ConditionFalse,
 		ObservedGeneration: updateRun.GetGeneration(),
 		Reason:             condition.UpdateRunFailedReason,
-		Message:            err.Error(),
+		Message:            message,
 	})
 	if updateErr := r.Client.Status().Update(ctx, updateRun); updateErr != nil {
 		klog.ErrorS(updateErr, "Failed to update the updateRun status as failed", "updateRun", klog.KObj(updateRun))

--- a/pkg/controllers/updaterun/controller.go
+++ b/pkg/controllers/updaterun/controller.go
@@ -113,6 +113,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req runtime.Request) (runtim
 	// (user_error vs internal_error) in the emitted metrics.
 	var reconcileErr error
 	// Emit the update run status metric based on status conditions in the updateRun.
+	// Use a closure to capture reconcileErr by reference, so it reflects any updates made during reconciliation.
 	defer func() { emitUpdateRunStatusMetric(updateRun, reconcileErr) }()
 
 	state := updateRun.GetUpdateRunSpec().State
@@ -129,15 +130,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, req runtime.Request) (runtim
 		}
 
 		// Initialize the updateRun.
-		var initErr error
-		if toBeUpdatedBindings, toBeDeletedBindings, initErr = r.initialize(ctx, updateRun); initErr != nil {
-			klog.ErrorS(initErr, "Failed to initialize the updateRun", "updateRun", runObjRef)
+		if toBeUpdatedBindings, toBeDeletedBindings, reconcileErr = r.initialize(ctx, updateRun); reconcileErr != nil {
+			klog.ErrorS(reconcileErr, "Failed to initialize the updateRun", "updateRun", runObjRef)
 			// errStagedUpdatedAborted cannot be retried.
-			if errors.Is(initErr, errStagedUpdatedAborted) {
-				reconcileErr = initErr
-				return runtime.Result{}, r.recordInitializationFailed(ctx, updateRun, initErr.Error())
+			if errors.Is(reconcileErr, errStagedUpdatedAborted) {
+				return runtime.Result{}, r.recordInitializationFailed(ctx, updateRun, reconcileErr.Error())
 			}
-			return runtime.Result{}, initErr
+			return runtime.Result{}, reconcileErr
 		}
 		updatingStageIndex = 0 // start from the first stage (typically for Initialize or Run states).
 		klog.V(2).InfoS("Initialized the updateRun", "state", state, "updateRun", runObjRef)
@@ -149,15 +148,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, req runtime.Request) (runtim
 			klog.V(2).InfoS("The updateRun is finished", "finishedSuccessfully", finishedCond.Status, "updateRun", runObjRef)
 			return runtime.Result{}, nil
 		}
-		var validateErr error
 		// Validate the updateRun status to ensure the update can be continued and get the updating stage index and cluster indices.
-		if updatingStageIndex, toBeUpdatedBindings, toBeDeletedBindings, validateErr = r.validate(ctx, updateRun); validateErr != nil {
+		if updatingStageIndex, toBeUpdatedBindings, toBeDeletedBindings, reconcileErr = r.validate(ctx, updateRun); reconcileErr != nil {
 			// errStagedUpdatedAborted cannot be retried.
-			if errors.Is(validateErr, errStagedUpdatedAborted) {
-				reconcileErr = validateErr
-				return runtime.Result{}, r.recordUpdateRunFailed(ctx, updateRun, validateErr.Error())
+			if errors.Is(reconcileErr, errStagedUpdatedAborted) {
+				return runtime.Result{}, r.recordUpdateRunFailed(ctx, updateRun, reconcileErr.Error())
 			}
-			return runtime.Result{}, validateErr
+			return runtime.Result{}, reconcileErr
 		}
 		klog.V(2).InfoS("The updateRun is validated", "updateRun", runObjRef)
 	}
@@ -168,17 +165,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, req runtime.Request) (runtim
 		return runtime.Result{}, r.recordUpdateRunSucceeded(ctx, updateRun)
 	}
 
+	var finished bool
+	var waitTime time.Duration
 	switch state {
 	case placementv1beta1.StateInitialize:
 		klog.V(2).InfoS("The updateRun is initialized but not executed, waiting to execute", "state", state, "updateRun", runObjRef)
 	case placementv1beta1.StateRun:
 		// Execute the updateRun.
 		klog.V(2).InfoS("Continue to execute the updateRun", "updatingStageIndex", updatingStageIndex, "updateRun", runObjRef)
-		finished, waitTime, execErr := r.execute(ctx, updateRun, updatingStageIndex, toBeUpdatedBindings, toBeDeletedBindings)
-		if errors.Is(execErr, errStagedUpdatedAborted) {
+		finished, waitTime, reconcileErr = r.execute(ctx, updateRun, updatingStageIndex, toBeUpdatedBindings, toBeDeletedBindings)
+		if errors.Is(reconcileErr, errStagedUpdatedAborted) {
 			// errStagedUpdatedAborted cannot be retried.
-			reconcileErr = execErr
-			return runtime.Result{}, r.recordUpdateRunFailed(ctx, updateRun, execErr.Error())
+			return runtime.Result{}, r.recordUpdateRunFailed(ctx, updateRun, reconcileErr.Error())
 		}
 
 		if finished {
@@ -186,15 +184,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, req runtime.Request) (runtim
 			return runtime.Result{}, r.recordUpdateRunSucceeded(ctx, updateRun)
 		}
 
-		return r.handleIncompleteUpdateRun(ctx, updateRun, waitTime, execErr, state, runObjRef)
+		return r.handleIncompleteUpdateRun(ctx, updateRun, waitTime, reconcileErr, state, runObjRef)
 	case placementv1beta1.StateStop:
 		// Stop the updateRun.
 		klog.V(2).InfoS("Stopping the updateRun", "state", state, "updatingStageIndex", updatingStageIndex, "updateRun", runObjRef)
-		finished, waitTime, stopErr := r.stop(updateRun, updatingStageIndex, toBeUpdatedBindings, toBeDeletedBindings)
-		if errors.Is(stopErr, errStagedUpdatedAborted) {
+		finished, waitTime, reconcileErr = r.stop(updateRun, updatingStageIndex, toBeUpdatedBindings, toBeDeletedBindings)
+		if errors.Is(reconcileErr, errStagedUpdatedAborted) {
 			// errStagedUpdatedAborted cannot be retried.
-			reconcileErr = stopErr
-			return runtime.Result{}, r.recordUpdateRunFailed(ctx, updateRun, stopErr.Error())
+			return runtime.Result{}, r.recordUpdateRunFailed(ctx, updateRun, reconcileErr.Error())
 		}
 
 		if finished {
@@ -202,15 +199,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, req runtime.Request) (runtim
 			return runtime.Result{}, r.recordUpdateRunStopped(ctx, updateRun)
 		}
 
-		return r.handleIncompleteUpdateRun(ctx, updateRun, waitTime, stopErr, state, runObjRef)
+		return r.handleIncompleteUpdateRun(ctx, updateRun, waitTime, reconcileErr, state, runObjRef)
 
 	default:
 		// Initialize, Run, or Stop are the only supported states.
-		unexpectedErr := controller.NewUnexpectedBehaviorError(fmt.Errorf("found unsupported updateRun state: %s", state))
-		klog.ErrorS(unexpectedErr, "Invalid updateRun state", "state", state, "updateRun", runObjRef)
+		reconcileErr = controller.NewUnexpectedBehaviorError(fmt.Errorf("found unsupported updateRun state: %s", state))
+		klog.ErrorS(reconcileErr, "Invalid updateRun state", "state", state, "updateRun", runObjRef)
 		// This is an internal error - unsupported state should not happen
-		reconcileErr = unexpectedErr
-		return runtime.Result{}, r.recordUpdateRunFailed(ctx, updateRun, unexpectedErr.Error())
+		return runtime.Result{}, r.recordUpdateRunFailed(ctx, updateRun, reconcileErr.Error())
 	}
 	return runtime.Result{}, nil
 }

--- a/pkg/controllers/updaterun/controller.go
+++ b/pkg/controllers/updaterun/controller.go
@@ -109,8 +109,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req runtime.Request) (runtim
 		return runtime.Result{}, err
 	}
 
+	// Track errors for metrics emission. The error is used to determine the failure type
+	// (user_error vs internal_error) in the emitted metrics.
+	var reconcileErr error
 	// Emit the update run status metric based on status conditions in the updateRun.
-	defer emitUpdateRunStatusMetric(updateRun)
+	defer func() { emitUpdateRunStatusMetric(updateRun, reconcileErr) }()
 
 	state := updateRun.GetUpdateRunSpec().State
 
@@ -131,6 +134,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req runtime.Request) (runtim
 			klog.ErrorS(initErr, "Failed to initialize the updateRun", "updateRun", runObjRef)
 			// errStagedUpdatedAborted cannot be retried.
 			if errors.Is(initErr, errStagedUpdatedAborted) {
+				reconcileErr = initErr
 				return runtime.Result{}, r.recordInitializationFailed(ctx, updateRun, initErr.Error())
 			}
 			return runtime.Result{}, initErr
@@ -150,7 +154,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req runtime.Request) (runtim
 		if updatingStageIndex, toBeUpdatedBindings, toBeDeletedBindings, validateErr = r.validate(ctx, updateRun); validateErr != nil {
 			// errStagedUpdatedAborted cannot be retried.
 			if errors.Is(validateErr, errStagedUpdatedAborted) {
-				return runtime.Result{}, r.recordUpdateRunFailed(ctx, updateRun, validateErr.Error())
+				reconcileErr = validateErr
+				return runtime.Result{}, r.recordUpdateRunFailed(ctx, updateRun, validateErr)
 			}
 			return runtime.Result{}, validateErr
 		}
@@ -172,7 +177,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req runtime.Request) (runtim
 		finished, waitTime, execErr := r.execute(ctx, updateRun, updatingStageIndex, toBeUpdatedBindings, toBeDeletedBindings)
 		if errors.Is(execErr, errStagedUpdatedAborted) {
 			// errStagedUpdatedAborted cannot be retried.
-			return runtime.Result{}, r.recordUpdateRunFailed(ctx, updateRun, execErr.Error())
+			reconcileErr = execErr
+			return runtime.Result{}, r.recordUpdateRunFailed(ctx, updateRun, execErr)
 		}
 
 		if finished {
@@ -187,7 +193,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req runtime.Request) (runtim
 		finished, waitTime, stopErr := r.stop(updateRun, updatingStageIndex, toBeUpdatedBindings, toBeDeletedBindings)
 		if errors.Is(stopErr, errStagedUpdatedAborted) {
 			// errStagedUpdatedAborted cannot be retried.
-			return runtime.Result{}, r.recordUpdateRunFailed(ctx, updateRun, stopErr.Error())
+			reconcileErr = stopErr
+			return runtime.Result{}, r.recordUpdateRunFailed(ctx, updateRun, stopErr)
 		}
 
 		if finished {
@@ -201,7 +208,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req runtime.Request) (runtim
 		// Initialize, Run, or Stop are the only supported states.
 		unexpectedErr := controller.NewUnexpectedBehaviorError(fmt.Errorf("found unsupported updateRun state: %s", state))
 		klog.ErrorS(unexpectedErr, "Invalid updateRun state", "state", state, "updateRun", runObjRef)
-		return runtime.Result{}, r.recordUpdateRunFailed(ctx, updateRun, unexpectedErr.Error())
+		// This is an internal error - unsupported state should not happen
+		reconcileErr = unexpectedErr
+		return runtime.Result{}, r.recordUpdateRunFailed(ctx, updateRun, unexpectedErr)
 	}
 	return runtime.Result{}, nil
 }
@@ -288,7 +297,7 @@ func (r *Reconciler) recordUpdateRunSucceeded(ctx context.Context, updateRun pla
 }
 
 // recordUpdateRunFailed records the failed condition in the updateRun status.
-func (r *Reconciler) recordUpdateRunFailed(ctx context.Context, updateRun placementv1beta1.UpdateRunObj, message string) error {
+func (r *Reconciler) recordUpdateRunFailed(ctx context.Context, updateRun placementv1beta1.UpdateRunObj, err error) error {
 	updateRunStatus := updateRun.GetUpdateRunStatus()
 	meta.SetStatusCondition(&updateRunStatus.Conditions, metav1.Condition{
 		Type:               string(placementv1beta1.StagedUpdateRunConditionProgressing),
@@ -302,7 +311,7 @@ func (r *Reconciler) recordUpdateRunFailed(ctx context.Context, updateRun placem
 		Status:             metav1.ConditionFalse,
 		ObservedGeneration: updateRun.GetGeneration(),
 		Reason:             condition.UpdateRunFailedReason,
-		Message:            message,
+		Message:            err.Error(),
 	})
 	if updateErr := r.Client.Status().Update(ctx, updateRun); updateErr != nil {
 		klog.ErrorS(updateErr, "Failed to update the updateRun status as failed", "updateRun", klog.KObj(updateRun))

--- a/pkg/controllers/updaterun/controller_integration_test.go
+++ b/pkg/controllers/updaterun/controller_integration_test.go
@@ -433,7 +433,7 @@ func generateWaitingMetric(state placementv1beta1.State, updateRun *placementv1b
 func generateStuckMetric(state placementv1beta1.State, updateRun *placementv1beta1.ClusterStagedUpdateRun) *prometheusclientmodel.Metric {
 	return &prometheusclientmodel.Metric{
 		Label: generateMetricsLabels(updateRun, string(state), string(placementv1beta1.StagedUpdateRunConditionProgressing),
-			string(metav1.ConditionFalse), condition.UpdateRunStuckReason, string(hubmetrics.UpdateRunFailureTypeNone)),
+			string(metav1.ConditionFalse), condition.UpdateRunStuckReason, string(hubmetrics.UpdateRunFailureTypeInternalError)),
 		Gauge: &prometheusclientmodel.Gauge{
 			Value: ptr.To(float64(time.Now().UnixNano()) / 1e9),
 		},

--- a/pkg/controllers/updaterun/controller_integration_test.go
+++ b/pkg/controllers/updaterun/controller_integration_test.go
@@ -377,7 +377,7 @@ func generateApprovalStageTaskMetric(
 // the current updateRun state if the updateRun has transitioned since then.
 func generateMetricsLabels(
 	updateRun *placementv1beta1.ClusterStagedUpdateRun,
-	state, condition, status, reason string,
+	state, condition, status, reason, failureType string,
 ) []*prometheusclientmodel.LabelPair {
 	return []*prometheusclientmodel.LabelPair{
 		{Name: ptr.To("namespace"), Value: &updateRun.Namespace},
@@ -386,23 +386,24 @@ func generateMetricsLabels(
 		{Name: ptr.To("condition"), Value: ptr.To(condition)},
 		{Name: ptr.To("status"), Value: ptr.To(status)},
 		{Name: ptr.To("reason"), Value: ptr.To(reason)},
+		{Name: ptr.To("failureType"), Value: ptr.To(failureType)},
 	}
 }
 
 func generateInitializationSucceededMetric(state placementv1beta1.State, updateRun *placementv1beta1.ClusterStagedUpdateRun) *prometheusclientmodel.Metric {
 	return &prometheusclientmodel.Metric{
 		Label: generateMetricsLabels(updateRun, string(state), string(placementv1beta1.StagedUpdateRunConditionInitialized),
-			string(metav1.ConditionTrue), condition.UpdateRunInitializeSucceededReason),
+			string(metav1.ConditionTrue), condition.UpdateRunInitializeSucceededReason, string(hubmetrics.UpdateRunFailureTypeNone)),
 		Gauge: &prometheusclientmodel.Gauge{
 			Value: ptr.To(float64(time.Now().UnixNano()) / 1e9),
 		},
 	}
 }
 
-func generateInitializationFailedMetric(state placementv1beta1.State, updateRun *placementv1beta1.ClusterStagedUpdateRun) *prometheusclientmodel.Metric {
+func generateInitializationFailedMetric(state placementv1beta1.State, updateRun *placementv1beta1.ClusterStagedUpdateRun, failureType string) *prometheusclientmodel.Metric {
 	return &prometheusclientmodel.Metric{
 		Label: generateMetricsLabels(updateRun, string(state), string(placementv1beta1.StagedUpdateRunConditionInitialized),
-			string(metav1.ConditionFalse), condition.UpdateRunInitializeFailedReason),
+			string(metav1.ConditionFalse), condition.UpdateRunInitializeFailedReason, failureType),
 		Gauge: &prometheusclientmodel.Gauge{
 			Value: ptr.To(float64(time.Now().UnixNano()) / 1e9),
 		},
@@ -412,7 +413,7 @@ func generateInitializationFailedMetric(state placementv1beta1.State, updateRun 
 func generateProgressingMetric(state placementv1beta1.State, updateRun *placementv1beta1.ClusterStagedUpdateRun) *prometheusclientmodel.Metric {
 	return &prometheusclientmodel.Metric{
 		Label: generateMetricsLabels(updateRun, string(state), string(placementv1beta1.StagedUpdateRunConditionProgressing),
-			string(metav1.ConditionTrue), condition.UpdateRunProgressingReason),
+			string(metav1.ConditionTrue), condition.UpdateRunProgressingReason, string(hubmetrics.UpdateRunFailureTypeNone)),
 		Gauge: &prometheusclientmodel.Gauge{
 			Value: ptr.To(float64(time.Now().UnixNano()) / 1e9),
 		},
@@ -422,7 +423,7 @@ func generateProgressingMetric(state placementv1beta1.State, updateRun *placemen
 func generateWaitingMetric(state placementv1beta1.State, updateRun *placementv1beta1.ClusterStagedUpdateRun) *prometheusclientmodel.Metric {
 	return &prometheusclientmodel.Metric{
 		Label: generateMetricsLabels(updateRun, string(state), string(placementv1beta1.StagedUpdateRunConditionProgressing),
-			string(metav1.ConditionFalse), condition.UpdateRunWaitingReason),
+			string(metav1.ConditionFalse), condition.UpdateRunWaitingReason, string(hubmetrics.UpdateRunFailureTypeNone)),
 		Gauge: &prometheusclientmodel.Gauge{
 			Value: ptr.To(float64(time.Now().UnixNano()) / 1e9),
 		},
@@ -432,17 +433,17 @@ func generateWaitingMetric(state placementv1beta1.State, updateRun *placementv1b
 func generateStuckMetric(state placementv1beta1.State, updateRun *placementv1beta1.ClusterStagedUpdateRun) *prometheusclientmodel.Metric {
 	return &prometheusclientmodel.Metric{
 		Label: generateMetricsLabels(updateRun, string(state), string(placementv1beta1.StagedUpdateRunConditionProgressing),
-			string(metav1.ConditionFalse), condition.UpdateRunStuckReason),
+			string(metav1.ConditionFalse), condition.UpdateRunStuckReason, string(hubmetrics.UpdateRunFailureTypeNone)),
 		Gauge: &prometheusclientmodel.Gauge{
 			Value: ptr.To(float64(time.Now().UnixNano()) / 1e9),
 		},
 	}
 }
 
-func generateFailedMetric(state placementv1beta1.State, updateRun *placementv1beta1.ClusterStagedUpdateRun) *prometheusclientmodel.Metric {
+func generateFailedMetric(state placementv1beta1.State, updateRun *placementv1beta1.ClusterStagedUpdateRun, failureType string) *prometheusclientmodel.Metric {
 	return &prometheusclientmodel.Metric{
 		Label: generateMetricsLabels(updateRun, string(state), string(placementv1beta1.StagedUpdateRunConditionSucceeded),
-			string(metav1.ConditionFalse), condition.UpdateRunFailedReason),
+			string(metav1.ConditionFalse), condition.UpdateRunFailedReason, failureType),
 		Gauge: &prometheusclientmodel.Gauge{
 			Value: ptr.To(float64(time.Now().UnixNano()) / 1e9),
 		},
@@ -452,7 +453,7 @@ func generateFailedMetric(state placementv1beta1.State, updateRun *placementv1be
 func generateStoppingMetric(state placementv1beta1.State, updateRun *placementv1beta1.ClusterStagedUpdateRun) *prometheusclientmodel.Metric {
 	return &prometheusclientmodel.Metric{
 		Label: generateMetricsLabels(updateRun, string(state), string(placementv1beta1.StagedUpdateRunConditionProgressing),
-			string(metav1.ConditionUnknown), condition.UpdateRunStoppingReason),
+			string(metav1.ConditionUnknown), condition.UpdateRunStoppingReason, string(hubmetrics.UpdateRunFailureTypeNone)),
 		Gauge: &prometheusclientmodel.Gauge{
 			Value: ptr.To(float64(time.Now().UnixNano()) / 1e9),
 		},
@@ -462,7 +463,7 @@ func generateStoppingMetric(state placementv1beta1.State, updateRun *placementv1
 func generateStoppedMetric(state placementv1beta1.State, updateRun *placementv1beta1.ClusterStagedUpdateRun) *prometheusclientmodel.Metric {
 	return &prometheusclientmodel.Metric{
 		Label: generateMetricsLabels(updateRun, string(state), string(placementv1beta1.StagedUpdateRunConditionProgressing),
-			string(metav1.ConditionFalse), condition.UpdateRunStoppedReason),
+			string(metav1.ConditionFalse), condition.UpdateRunStoppedReason, string(hubmetrics.UpdateRunFailureTypeNone)),
 		Gauge: &prometheusclientmodel.Gauge{
 			Value: ptr.To(float64(time.Now().UnixNano()) / 1e9),
 		},
@@ -472,7 +473,7 @@ func generateStoppedMetric(state placementv1beta1.State, updateRun *placementv1b
 func generateSucceededMetric(state placementv1beta1.State, updateRun *placementv1beta1.ClusterStagedUpdateRun) *prometheusclientmodel.Metric {
 	return &prometheusclientmodel.Metric{
 		Label: generateMetricsLabels(updateRun, string(state), string(placementv1beta1.StagedUpdateRunConditionSucceeded),
-			string(metav1.ConditionTrue), condition.UpdateRunSucceededReason),
+			string(metav1.ConditionTrue), condition.UpdateRunSucceededReason, string(hubmetrics.UpdateRunFailureTypeNone)),
 		Gauge: &prometheusclientmodel.Gauge{
 			Value: ptr.To(float64(time.Now().UnixNano()) / 1e9),
 		},

--- a/pkg/controllers/updaterun/execution.go
+++ b/pkg/controllers/updaterun/execution.go
@@ -256,7 +256,7 @@ func (r *Reconciler) executeUpdatingStage(
 				"bindingSpecInSync", inSync, "bindingState", bindingSpec.State,
 				"bindingRolloutStarted", rolloutStarted, "binding", klog.KObj(binding), "updateRun", updateRunRef)
 			markClusterUpdatingFailed(clusterStatus, updateRun.GetGeneration(), preemptedErr.Error())
-			clusterUpdateErrors = append(clusterUpdateErrors, fmt.Errorf("%w: %s", errStagedUpdatedAborted, preemptedErr.Error()))
+			clusterUpdateErrors = append(clusterUpdateErrors, fmt.Errorf("%w: %w", errStagedUpdatedAborted, preemptedErr))
 			continue
 		}
 

--- a/pkg/controllers/updaterun/execution_integration_test.go
+++ b/pkg/controllers/updaterun/execution_integration_test.go
@@ -719,7 +719,7 @@ var _ = Describe("UpdateRun execution tests - double stages", func() {
 			validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus, "")
 
 			By("Checking update run status metrics are emitted")
-			validateUpdateRunMetricsEmitted(generateWaitingMetric(placementv1beta1.StateRun, updateRun), generateProgressingMetric(placementv1beta1.StateRun, updateRun), generateStuckMetric(placementv1beta1.StateRun, updateRun), generateFailedMetric(placementv1beta1.StateRun, updateRun, string(hubmetrics.UpdateRunFailureTypeInternalError)))
+			validateUpdateRunMetricsEmitted(generateWaitingMetric(placementv1beta1.StateRun, updateRun), generateProgressingMetric(placementv1beta1.StateRun, updateRun), generateStuckMetric(placementv1beta1.StateRun, updateRun), generateFailedMetric(placementv1beta1.StateRun, updateRun, string(hubmetrics.UpdateRunFailureTypeUserError)))
 		})
 	})
 

--- a/pkg/controllers/updaterun/execution_integration_test.go
+++ b/pkg/controllers/updaterun/execution_integration_test.go
@@ -31,6 +31,7 @@ import (
 
 	clusterv1beta1 "github.com/kubefleet-dev/kubefleet/apis/cluster/v1beta1"
 	placementv1beta1 "github.com/kubefleet-dev/kubefleet/apis/placement/v1beta1"
+	hubmetrics "github.com/kubefleet-dev/kubefleet/pkg/metrics/hub"
 	"github.com/kubefleet-dev/kubefleet/pkg/utils"
 	"github.com/kubefleet-dev/kubefleet/pkg/utils/condition"
 )
@@ -718,7 +719,7 @@ var _ = Describe("UpdateRun execution tests - double stages", func() {
 			validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus, "")
 
 			By("Checking update run status metrics are emitted")
-			validateUpdateRunMetricsEmitted(generateWaitingMetric(placementv1beta1.StateRun, updateRun), generateProgressingMetric(placementv1beta1.StateRun, updateRun), generateStuckMetric(placementv1beta1.StateRun, updateRun), generateFailedMetric(placementv1beta1.StateRun, updateRun))
+			validateUpdateRunMetricsEmitted(generateWaitingMetric(placementv1beta1.StateRun, updateRun), generateProgressingMetric(placementv1beta1.StateRun, updateRun), generateStuckMetric(placementv1beta1.StateRun, updateRun), generateFailedMetric(placementv1beta1.StateRun, updateRun, string(hubmetrics.UpdateRunFailureTypeInternalError)))
 		})
 	})
 

--- a/pkg/controllers/updaterun/initialization.go
+++ b/pkg/controllers/updaterun/initialization.go
@@ -91,7 +91,7 @@ func (r *Reconciler) validatePlacement(ctx context.Context, updateRun placementv
 		if apierrors.IsNotFound(err) {
 			placementNotFoundErr := controller.NewUserError(fmt.Errorf("parent placement not found"))
 			klog.ErrorS(err, "Failed to get placement", "placement", placementKey, "updateRun", updateRunRef)
-			return nil, types.NamespacedName{}, fmt.Errorf("%w: %s", errValidationFailed, placementNotFoundErr.Error())
+			return nil, types.NamespacedName{}, fmt.Errorf("%w: %w", errValidationFailed, placementNotFoundErr)
 		}
 		klog.ErrorS(err, "Failed to get placement", "placement", placementKey, "updateRun", updateRunRef)
 		return nil, types.NamespacedName{}, controller.NewAPIServerError(true, err)
@@ -106,7 +106,7 @@ func (r *Reconciler) validatePlacement(ctx context.Context, updateRun placementv
 	if placementSpec.Strategy.Type != placementv1beta1.ExternalRolloutStrategyType {
 		klog.V(2).InfoS("The placement does not have an external rollout strategy", "placement", placementKey, "updateRun", updateRunRef)
 		wrongRolloutTypeErr := controller.NewUserError(errors.New("parent placement does not have an external rollout strategy, current strategy: " + string(placementSpec.Strategy.Type)))
-		return nil, types.NamespacedName{}, fmt.Errorf("%w: %s", errValidationFailed, wrongRolloutTypeErr.Error())
+		return nil, types.NamespacedName{}, fmt.Errorf("%w: %w", errValidationFailed, wrongRolloutTypeErr)
 	}
 
 	updateRunStatus := updateRun.GetUpdateRunStatus()
@@ -281,7 +281,7 @@ func (r *Reconciler) generateStagesByStrategy(
 		if apierrors.IsNotFound(err) {
 			// we won't continue or retry the initialization if the UpdateStrategy is not found.
 			strategyNotFoundErr := controller.NewUserError(fmt.Errorf("referenced updateStrategy not found: `%s`", strategyKey))
-			return fmt.Errorf("%w: %s", errValidationFailed, strategyNotFoundErr.Error())
+			return fmt.Errorf("%w: %w", errValidationFailed, strategyNotFoundErr)
 		}
 		// other err can be retried.
 		return controller.NewAPIServerError(true, err)
@@ -348,13 +348,13 @@ func (r *Reconciler) computeRunStageStatus(
 			klog.ErrorS(err, "Failed to validate the before stage tasks", "updateStrategy", strategyKey, "stageName", stage.Name, "updateRun", updateRunRef)
 			// no more retries here.
 			invalidBeforeStageErr := controller.NewUserError(fmt.Errorf("the before stage tasks are invalid, updateStrategy: `%s`, stage: %s, err: %s", strategyKey, stage.Name, err.Error()))
-			return fmt.Errorf("%w: %s", errValidationFailed, invalidBeforeStageErr.Error())
+			return fmt.Errorf("%w: %w", errValidationFailed, invalidBeforeStageErr)
 		}
 		if err := validateAfterStageTask(stage.AfterStageTasks); err != nil {
 			klog.ErrorS(err, "Failed to validate the after stage tasks", "updateStrategy", strategyKey, "stageName", stage.Name, "updateRun", updateRunRef)
 			// no more retries here.
 			invalidAfterStageErr := controller.NewUserError(fmt.Errorf("the after stage tasks are invalid, updateStrategy: `%s`, stage: %s, err: %s", strategyKey, stage.Name, err.Error()))
-			return fmt.Errorf("%w: %s", errValidationFailed, invalidAfterStageErr.Error())
+			return fmt.Errorf("%w: %w", errValidationFailed, invalidAfterStageErr)
 		}
 
 		curStageUpdatingStatus := placementv1beta1.StageUpdatingStatus{StageName: stage.Name}
@@ -364,7 +364,7 @@ func (r *Reconciler) computeRunStageStatus(
 			klog.ErrorS(err, "Failed to convert label selector", "updateStrategy", strategyKey, "stageName", stage.Name, "labelSelector", stage.LabelSelector, "updateRun", updateRunRef)
 			// no more retries here.
 			invalidLabelErr := controller.NewUserError(fmt.Errorf("the stage label selector is invalid, updateStrategy: `%s`, stage: %s, err: %s", strategyKey, stage.Name, err.Error()))
-			return fmt.Errorf("%w: %s", errValidationFailed, invalidLabelErr.Error())
+			return fmt.Errorf("%w: %w", errValidationFailed, invalidLabelErr)
 		}
 		// List all the clusters that match the label selector.
 		var clusterList clusterv1beta1.MemberClusterList
@@ -382,7 +382,7 @@ func (r *Reconciler) computeRunStageStatus(
 					dupErr := controller.NewUserError(fmt.Errorf("cluster `%s` appears in more than one stages", cluster.Name))
 					klog.ErrorS(dupErr, "Failed to compute the stage", "updateStrategy", strategyKey, "stageName", stage.Name, "updateRun", updateRunRef)
 					// no more retries here.
-					return fmt.Errorf("%w: %s", errValidationFailed, dupErr.Error())
+					return fmt.Errorf("%w: %w", errValidationFailed, dupErr)
 				}
 				if stage.SortingLabelKey != nil {
 					// interpret the label values as integers.
@@ -390,7 +390,7 @@ func (r *Reconciler) computeRunStageStatus(
 						keyErr := controller.NewUserError(fmt.Errorf("the sorting label `%s:%s` on cluster `%s` is not valid: %s", *stage.SortingLabelKey, cluster.Labels[*stage.SortingLabelKey], cluster.Name, err.Error()))
 						klog.ErrorS(keyErr, "Failed to sort clusters in the stage", "updateStrategy", strategyKey, "stageName", stage.Name, "updateRun", updateRunRef)
 						// no more retries here.
-						return fmt.Errorf("%w: %s", errValidationFailed, keyErr.Error())
+						return fmt.Errorf("%w: %w", errValidationFailed, keyErr)
 					}
 				}
 				curStageClusters = append(curStageClusters, cluster)
@@ -457,7 +457,7 @@ func (r *Reconciler) computeRunStageStatus(
 		sort.Strings(missingClusters)
 		klog.ErrorS(missingErr, "Clusters are missing in any stage", "clusters", strings.Join(missingClusters, ", "), "updateStrategy", strategyKey, "updateRun", updateRunRef)
 		// no more retries here, only show the first 10 missing clusters in the placement status.
-		return fmt.Errorf("%w: %s, total %d, showing up to 10: %s", errValidationFailed, missingErr.Error(), len(missingClusters), strings.Join(missingClusters[:min(10, len(missingClusters))], ", "))
+		return fmt.Errorf("%w: %w, total %d, showing up to 10: %s", errValidationFailed, missingErr, len(missingClusters), strings.Join(missingClusters[:min(10, len(missingClusters))], ", "))
 	}
 	return nil
 }
@@ -571,10 +571,10 @@ func (r *Reconciler) getResourceSnapshotObjs(ctx context.Context, placement plac
 	if updateRunSpec.ResourceSnapshotIndex != "" {
 		snapshotIndex, err := strconv.Atoi(updateRunSpec.ResourceSnapshotIndex)
 		if err != nil || snapshotIndex < 0 {
-			err := controller.NewUserError(fmt.Errorf("invalid resource snapshot index `%s` provided, expected an integer >= 0", updateRunSpec.ResourceSnapshotIndex))
-			klog.ErrorS(err, "Failed to parse the resource snapshot index", "updateRun", updateRunRef)
+			userErr := controller.NewUserError(fmt.Errorf("invalid resource snapshot index `%s` provided, expected an integer >= 0", updateRunSpec.ResourceSnapshotIndex))
+			klog.ErrorS(userErr, "Failed to parse the resource snapshot index", "updateRun", updateRunRef)
 			// no more retries here.
-			return nil, fmt.Errorf("%w: %s", errValidationFailed, err.Error())
+			return nil, fmt.Errorf("%w: %w", errValidationFailed, userErr)
 		}
 
 		resourceSnapshotList, err := controller.ListAllResourceSnapshotWithAnIndex(ctx, r.Client, updateRunSpec.ResourceSnapshotIndex, placementKey.Name, placementKey.Namespace)
@@ -587,10 +587,10 @@ func (r *Reconciler) getResourceSnapshotObjs(ctx context.Context, placement plac
 
 		resourceSnapshotObjs = resourceSnapshotList.GetResourceSnapshotObjs()
 		if len(resourceSnapshotObjs) == 0 {
-			err := controller.NewUserError(fmt.Errorf("no resourceSnapshots with index `%d` found for placement `%s`", snapshotIndex, placementKey))
-			klog.ErrorS(err, "No specified resourceSnapshots found", "updateRun", updateRunRef)
+			userErr := controller.NewUserError(fmt.Errorf("no resourceSnapshots with index `%d` found for placement `%s`", snapshotIndex, placementKey))
+			klog.ErrorS(userErr, "No specified resourceSnapshots found", "updateRun", updateRunRef)
 			// no more retries here.
-			return resourceSnapshotObjs, fmt.Errorf("%w: %s", errValidationFailed, err.Error())
+			return resourceSnapshotObjs, fmt.Errorf("%w: %w", errValidationFailed, userErr)
 		}
 		return resourceSnapshotObjs, nil
 	}
@@ -602,7 +602,7 @@ func (r *Reconciler) getResourceSnapshotObjs(ctx context.Context, placement plac
 	if err != nil {
 		klog.ErrorS(err, "Failed to select resources for placement", "placement", placementKey, "updateRun", updateRunRef)
 		if errors.Is(err, controller.ErrUserError) {
-			return nil, fmt.Errorf("%w: %s", errValidationFailed, err.Error())
+			return nil, fmt.Errorf("%w: %w", errValidationFailed, err)
 		}
 		return nil, err
 	}

--- a/pkg/controllers/updaterun/initialization_integration_test.go
+++ b/pkg/controllers/updaterun/initialization_integration_test.go
@@ -34,6 +34,7 @@ import (
 
 	clusterv1beta1 "github.com/kubefleet-dev/kubefleet/apis/cluster/v1beta1"
 	placementv1beta1 "github.com/kubefleet-dev/kubefleet/apis/placement/v1beta1"
+	hubmetrics "github.com/kubefleet-dev/kubefleet/pkg/metrics/hub"
 	"github.com/kubefleet-dev/kubefleet/pkg/utils"
 	"github.com/kubefleet-dev/kubefleet/pkg/utils/condition"
 	"github.com/kubefleet-dev/kubefleet/pkg/utils/resource"
@@ -63,6 +64,7 @@ var _ = Describe("Updaterun initialization tests", func() {
 	var unscheduledClusters []*clusterv1beta1.MemberCluster
 	var resourceSnapshot, resourceSnapshot2, resourceSnapshot3 *placementv1beta1.ClusterResourceSnapshot
 	var clusterResourceOverride *placementv1beta1.ClusterResourceOverrideSnapshot
+	var failureType hubmetrics.UpdateRunFailureType
 
 	BeforeEach(func() {
 		testUpdateRunName = "updaterun-" + utils.RandStr()
@@ -87,6 +89,7 @@ var _ = Describe("Updaterun initialization tests", func() {
 		stageUpdatingWaitTime = time.Second * 3
 		clusterUpdatingWaitTime = time.Second * 2
 
+		failureType = hubmetrics.UpdateRunFailureTypeInternalError // All following tests will still fail due to not fully set up environment.
 	})
 
 	AfterEach(func() {
@@ -142,7 +145,7 @@ var _ = Describe("Updaterun initialization tests", func() {
 	Context("Test validateCRP", func() {
 		AfterEach(func() {
 			By("Checking update run status metrics are emitted")
-			validateUpdateRunMetricsEmitted(generateInitializationFailedMetric(placementv1beta1.StateInitialize, updateRun))
+			validateUpdateRunMetricsEmitted(generateInitializationFailedMetric(placementv1beta1.StateInitialize, updateRun, string(failureType)))
 		})
 
 		It("Should fail to initialize if CRP is not found", func() {
@@ -150,6 +153,7 @@ var _ = Describe("Updaterun initialization tests", func() {
 			Expect(k8sClient.Create(ctx, updateRun)).To(Succeed())
 
 			By("Validating the initialization failed")
+			failureType = hubmetrics.UpdateRunFailureTypeUserError
 			validateFailedInitCondition(ctx, updateRun, "parent placement not found")
 		})
 
@@ -162,6 +166,7 @@ var _ = Describe("Updaterun initialization tests", func() {
 			Expect(k8sClient.Create(ctx, updateRun)).To(Succeed())
 
 			By("Validating the initialization failed")
+			failureType = hubmetrics.UpdateRunFailureTypeUserError
 			validateFailedInitCondition(ctx, updateRun,
 				"parent placement does not have an external rollout strategy")
 		})
@@ -194,7 +199,7 @@ var _ = Describe("Updaterun initialization tests", func() {
 
 		AfterEach(func() {
 			By("Checking update run status metrics are emitted")
-			validateUpdateRunMetricsEmitted(generateInitializationFailedMetric(placementv1beta1.StateInitialize, updateRun))
+			validateUpdateRunMetricsEmitted(generateInitializationFailedMetric(placementv1beta1.StateInitialize, updateRun, string(failureType)))
 		})
 
 		It("Should fail to initialize if the latest policy snapshot is not found", func() {
@@ -304,7 +309,7 @@ var _ = Describe("Updaterun initialization tests", func() {
 
 		AfterEach(func() {
 			By("Checking update run status metrics are emitted")
-			validateUpdateRunMetricsEmitted(generateInitializationFailedMetric(placementv1beta1.StateInitialize, updateRun))
+			validateUpdateRunMetricsEmitted(generateInitializationFailedMetric(placementv1beta1.StateInitialize, updateRun, string(failureType)))
 		})
 		It("Should copy the latest policy snapshot details to the updateRun status -- pickFixed policy", func() {
 			By("Creating scheduling policy snapshot with pickFixed policy")
@@ -352,7 +357,7 @@ var _ = Describe("Updaterun initialization tests", func() {
 		})
 		AfterEach(func() {
 			By("Checking update run status metrics are emitted")
-			validateUpdateRunMetricsEmitted(generateInitializationFailedMetric(placementv1beta1.StateInitialize, updateRun))
+			validateUpdateRunMetricsEmitted(generateInitializationFailedMetric(placementv1beta1.StateInitialize, updateRun, string(failureType)))
 		})
 
 		It("Should copy the latest policy snapshot details to the updateRun status -- pickAll policy", func() {
@@ -410,7 +415,7 @@ var _ = Describe("Updaterun initialization tests", func() {
 
 		AfterEach(func() {
 			By("Checking update run status metrics are emitted")
-			validateUpdateRunMetricsEmitted(generateInitializationFailedMetric(placementv1beta1.StateInitialize, updateRun))
+			validateUpdateRunMetricsEmitted(generateInitializationFailedMetric(placementv1beta1.StateInitialize, updateRun, string(failureType)))
 		})
 		It("Should fail to initialize if there is no selected or to-be-deleted cluster", func() {
 			By("Creating a new clusterStagedUpdateRun")
@@ -504,7 +509,7 @@ var _ = Describe("Updaterun initialization tests", func() {
 
 		AfterEach(func() {
 			By("Checking update run status metrics are emitted")
-			validateUpdateRunMetricsEmitted(generateInitializationFailedMetric(placementv1beta1.StateInitialize, updateRun))
+			validateUpdateRunMetricsEmitted(generateInitializationFailedMetric(placementv1beta1.StateInitialize, updateRun, string(failureType)))
 		})
 
 		It("Should not report error if there are only to-be-deleted clusters", func() {
@@ -517,6 +522,7 @@ var _ = Describe("Updaterun initialization tests", func() {
 
 			By("Validating the initialization not failed due to no selected cluster")
 			// it should fail due to strategy not found
+			failureType = hubmetrics.UpdateRunFailureTypeUserError
 			validateFailedInitCondition(ctx, updateRun, "referenced updateStrategy not found")
 		})
 
@@ -529,6 +535,7 @@ var _ = Describe("Updaterun initialization tests", func() {
 
 			By("Validating the initialization not failed due to no selected cluster")
 			// it should fail due to strategy not found
+			failureType = hubmetrics.UpdateRunFailureTypeUserError
 			validateFailedInitCondition(ctx, updateRun, "referenced updateStrategy not found")
 
 			By("Validating the ObservedClusterCount is updated")
@@ -569,7 +576,7 @@ var _ = Describe("Updaterun initialization tests", func() {
 
 		AfterEach(func() {
 			By("Checking update run status metrics are emitted")
-			validateUpdateRunMetricsEmitted(generateInitializationFailedMetric(placementv1beta1.StateInitialize, updateRun))
+			validateUpdateRunMetricsEmitted(generateInitializationFailedMetric(placementv1beta1.StateInitialize, updateRun, string(failureType)))
 		})
 
 		It("fail the initialization if the clusterStagedUpdateStrategy is not found", func() {
@@ -577,6 +584,7 @@ var _ = Describe("Updaterun initialization tests", func() {
 			Expect(k8sClient.Create(ctx, updateRun)).To(Succeed())
 
 			By("Validating the initialization failed")
+			failureType = hubmetrics.UpdateRunFailureTypeUserError
 			validateFailedInitCondition(ctx, updateRun, "referenced updateStrategy not found")
 		})
 
@@ -594,6 +602,7 @@ var _ = Describe("Updaterun initialization tests", func() {
 					Expect(k8sClient.Create(ctx, updateRun)).To(Succeed())
 
 					By("Validating the initialization failed")
+					failureType = hubmetrics.UpdateRunFailureTypeUserError
 					validateFailedInitCondition(ctx, updateRun, "afterStageTasks cannot have two tasks of the same type")
 				})
 
@@ -608,6 +617,7 @@ var _ = Describe("Updaterun initialization tests", func() {
 					Expect(k8sClient.Create(ctx, updateRun)).To(Succeed())
 
 					By("Validating the initialization failed")
+					failureType = hubmetrics.UpdateRunFailureTypeUserError
 					validateFailedInitCondition(ctx, updateRun, "has wait duration <= 0")
 				})
 			})
@@ -622,6 +632,7 @@ var _ = Describe("Updaterun initialization tests", func() {
 				Expect(k8sClient.Create(ctx, updateRun)).To(Succeed())
 
 				By("Validating the initialization failed")
+				failureType = hubmetrics.UpdateRunFailureTypeUserError
 				validateFailedInitCondition(ctx, updateRun, "the sorting label `not-exist-label:`")
 			})
 
@@ -636,6 +647,7 @@ var _ = Describe("Updaterun initialization tests", func() {
 				Expect(k8sClient.Create(ctx, updateRun)).To(Succeed())
 
 				By("Validating the initialization failed")
+				failureType = hubmetrics.UpdateRunFailureTypeUserError
 				validateFailedInitCondition(ctx, updateRun, "appears in more than one stages")
 			})
 
@@ -648,6 +660,7 @@ var _ = Describe("Updaterun initialization tests", func() {
 				Expect(k8sClient.Create(ctx, updateRun)).To(Succeed())
 
 				By("Validating the initialization failed")
+				failureType = hubmetrics.UpdateRunFailureTypeUserError
 				validateFailedInitCondition(ctx, updateRun, "some clusters are not placed in any stage, total 5, showing up to 10: cluster-0, cluster-2, cluster-4, cluster-6, cluster-8")
 			})
 
@@ -668,7 +681,8 @@ var _ = Describe("Updaterun initialization tests", func() {
 
 					// no resource snapshot created in this test
 					want := generateInitializedStatus(crp, updateRun, "", policySnapshot, updateStrategy, 10, generateTenClusterSingleStageStatus(nil), generateTenClusterDeletionStageStatus())
-					// initialization should fail due to resourceSnapshot not found.
+					// Initialization should fail due to resourceSnapshot not found.
+					failureType = hubmetrics.UpdateRunFailureTypeUserError
 					want.Conditions = []metav1.Condition{
 						generateFalseCondition(updateRun, placementv1beta1.StagedUpdateRunConditionInitialized),
 					}
@@ -697,7 +711,8 @@ var _ = Describe("Updaterun initialization tests", func() {
 				// no resource snapshot created in this test
 				stagesStatus := generateTenClusterStagesStatus(nil)
 				want := generateInitializedStatus(crp, updateRun, "", policySnapshot, updateStrategy, 10, stagesStatus, generateTenClusterDeletionStageStatus())
-				// initialization should fail due to resourceSnapshot not found.
+				// Initialization should fail due to resourceSnapshot not found.
+				failureType = hubmetrics.UpdateRunFailureTypeUserError
 				want.Conditions = []metav1.Condition{
 					generateFalseCondition(updateRun, placementv1beta1.StagedUpdateRunConditionInitialized),
 				}
@@ -758,7 +773,8 @@ var _ = Describe("Updaterun initialization tests", func() {
 			validateFailedInitCondition(ctx, updateRun, "invalid resource snapshot index `invalid-index` provided")
 
 			By("Checking update run status metrics are emitted")
-			validateUpdateRunMetricsEmitted(generateInitializationFailedMetric(placementv1beta1.StateInitialize, updateRun))
+			failureType = hubmetrics.UpdateRunFailureTypeUserError
+			validateUpdateRunMetricsEmitted(generateInitializationFailedMetric(placementv1beta1.StateInitialize, updateRun, string(failureType)))
 		})
 
 		It("Should fail to initialize if the specified resource snapshot index is invalid - negative integer", func() {
@@ -770,7 +786,8 @@ var _ = Describe("Updaterun initialization tests", func() {
 			validateFailedInitCondition(ctx, updateRun, "invalid resource snapshot index `-1` provided")
 
 			By("Checking update run status metrics are emitted")
-			validateUpdateRunMetricsEmitted(generateInitializationFailedMetric(placementv1beta1.StateInitialize, updateRun))
+			failureType = hubmetrics.UpdateRunFailureTypeUserError
+			validateUpdateRunMetricsEmitted(generateInitializationFailedMetric(placementv1beta1.StateInitialize, updateRun, string(failureType)))
 		})
 
 		It("Should fail to initialize if the specified resource snapshot is not found - no resourceSnapshots at all", func() {
@@ -781,7 +798,8 @@ var _ = Describe("Updaterun initialization tests", func() {
 			validateFailedInitCondition(ctx, updateRun, "no resourceSnapshots with index `0` found")
 
 			By("Checking update run status metrics are emitted")
-			validateUpdateRunMetricsEmitted(generateInitializationFailedMetric(placementv1beta1.StateInitialize, updateRun))
+			failureType = hubmetrics.UpdateRunFailureTypeUserError
+			validateUpdateRunMetricsEmitted(generateInitializationFailedMetric(placementv1beta1.StateInitialize, updateRun, string(failureType)))
 		})
 
 		It("Should create a new resource snapshot and succeed initialization when no resource index specified - no resourceSnapshots at all", func() {
@@ -823,7 +841,8 @@ var _ = Describe("Updaterun initialization tests", func() {
 			validateFailedInitCondition(ctx, updateRun, "no resourceSnapshots with index `0` found")
 
 			By("Checking update run status metrics are emitted")
-			validateUpdateRunMetricsEmitted(generateInitializationFailedMetric(placementv1beta1.StateInitialize, updateRun))
+			failureType = hubmetrics.UpdateRunFailureTypeUserError
+			validateUpdateRunMetricsEmitted(generateInitializationFailedMetric(placementv1beta1.StateInitialize, updateRun, string(failureType)))
 		})
 
 		It("Should fail to initialize if the specified resource snapshot is not found - no resource index label found", func() {
@@ -838,7 +857,8 @@ var _ = Describe("Updaterun initialization tests", func() {
 			validateFailedInitCondition(ctx, updateRun, "no resourceSnapshots with index `0` found")
 
 			By("Checking update run status metrics are emitted")
-			validateUpdateRunMetricsEmitted(generateInitializationFailedMetric(placementv1beta1.StateInitialize, updateRun))
+			failureType = hubmetrics.UpdateRunFailureTypeUserError
+			validateUpdateRunMetricsEmitted(generateInitializationFailedMetric(placementv1beta1.StateInitialize, updateRun, string(failureType)))
 		})
 
 		It("Should fail to initialize if the specified resource snapshot is not master snapshot", func() {
@@ -853,7 +873,8 @@ var _ = Describe("Updaterun initialization tests", func() {
 			validateFailedInitCondition(ctx, updateRun, "no master resourceSnapshot found for placement")
 
 			By("Checking update run status metrics are emitted")
-			validateUpdateRunMetricsEmitted(generateInitializationFailedMetric(placementv1beta1.StateInitialize, updateRun))
+			failureType = hubmetrics.UpdateRunFailureTypeInternalError
+			validateUpdateRunMetricsEmitted(generateInitializationFailedMetric(placementv1beta1.StateInitialize, updateRun, string(failureType)))
 		})
 
 		It("Should create a new resource snapshot when no resource index defined, previous snapshots hash does not match", func() {

--- a/pkg/controllers/updaterun/initialization_integration_test.go
+++ b/pkg/controllers/updaterun/initialization_integration_test.go
@@ -89,7 +89,7 @@ var _ = Describe("Updaterun initialization tests", func() {
 		stageUpdatingWaitTime = time.Second * 3
 		clusterUpdatingWaitTime = time.Second * 2
 
-		// All following tests will report internal errors, if not user error, because only the updaterun controller
+		// Tests that fail below will report internal errors, if not user error, because only the updaterun controller
 		// is running in this test environment. Other controllers (e.g., rollout, work generator,
 		// binding controllers) are not set up, causing operations that depend on them to fail.
 		failureType = hubmetrics.UpdateRunFailureTypeInternalError

--- a/pkg/controllers/updaterun/initialization_integration_test.go
+++ b/pkg/controllers/updaterun/initialization_integration_test.go
@@ -89,7 +89,10 @@ var _ = Describe("Updaterun initialization tests", func() {
 		stageUpdatingWaitTime = time.Second * 3
 		clusterUpdatingWaitTime = time.Second * 2
 
-		failureType = hubmetrics.UpdateRunFailureTypeInternalError // All following tests will still fail due to not fully set up environment.
+		// All following tests will report internal errors, if not user error, because only the updaterun controller
+		// is running in this test environment. Other controllers (e.g., rollout, work generator,
+		// binding controllers) are not set up, causing operations that depend on them to fail.
+		failureType = hubmetrics.UpdateRunFailureTypeInternalError
 	})
 
 	AfterEach(func() {
@@ -520,8 +523,7 @@ var _ = Describe("Updaterun initialization tests", func() {
 			By("Creating a new clusterStagedUpdateRun")
 			Expect(k8sClient.Create(ctx, updateRun)).To(Succeed())
 
-			By("Validating the initialization not failed due to no selected cluster")
-			// it should fail due to strategy not found
+			By("Validating initialization proceeds past cluster selection (fails later due to missing strategy)")
 			failureType = hubmetrics.UpdateRunFailureTypeUserError
 			validateFailedInitCondition(ctx, updateRun, "referenced updateStrategy not found")
 		})
@@ -533,8 +535,7 @@ var _ = Describe("Updaterun initialization tests", func() {
 			By("Creating a new clusterStagedUpdateRun")
 			Expect(k8sClient.Create(ctx, updateRun)).To(Succeed())
 
-			By("Validating the initialization not failed due to no selected cluster")
-			// it should fail due to strategy not found
+			By("Validating initialization proceeds past cluster selection (fails later due to missing strategy)")
 			failureType = hubmetrics.UpdateRunFailureTypeUserError
 			validateFailedInitCondition(ctx, updateRun, "referenced updateStrategy not found")
 

--- a/pkg/controllers/updaterun/metrics.go
+++ b/pkg/controllers/updaterun/metrics.go
@@ -17,15 +17,18 @@ limitations under the License.
 package updaterun
 
 import (
+	"errors"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 
 	placementv1beta1 "github.com/kubefleet-dev/kubefleet/apis/placement/v1beta1"
 	hubmetrics "github.com/kubefleet-dev/kubefleet/pkg/metrics/hub"
 	"github.com/kubefleet-dev/kubefleet/pkg/utils/condition"
+	"github.com/kubefleet-dev/kubefleet/pkg/utils/controller"
 )
 
 // deleteUpdateRunMetrics deletes the metrics related to the update run when the update run is deleted.
@@ -35,30 +38,60 @@ func deleteUpdateRunMetrics(updateRun placementv1beta1.UpdateRunObj) {
 	hubmetrics.FleetUpdateRunApprovalRequestLatencySeconds.DeletePartialMatch(prometheus.Labels{"namespace": updateRun.GetNamespace(), "name": updateRun.GetName()})
 }
 
+// determineFailureType determines the type of failure based on the condition status and error.
+// It returns:
+// - "none" for successful, in-progress, waiting, or stopping conditions
+// - "user_error" for known customer configuration errors (when err wraps controller.ErrUserError)
+// - "internal_error" for errors that require investigation
+func determineFailureType(cond *metav1.Condition, generation int64, err error) hubmetrics.UpdateRunFailureType {
+	klog.InfoS("Condition:", "type", cond.Type, "status", cond.Status, "reason", cond.Reason, "message", cond.Message)
+	// If the condition status is True (success) or Unknown (in-progress), there's no failure.
+	if !condition.IsConditionStatusFalse(cond, generation) {
+		return hubmetrics.UpdateRunFailureTypeNone
+	}
+
+	// For False status, check if the error is a user error.
+	if err != nil && errors.Is(err, controller.ErrUserError) {
+		return hubmetrics.UpdateRunFailureTypeUserError
+	}
+
+	// Failed condition that is not a user error is an internal error.
+	if err != nil {
+		return hubmetrics.UpdateRunFailureTypeInternalError
+	}
+
+	// For False, there are possible reasons that are not failures (i.e. "Waiting", "Stopped")
+	return hubmetrics.UpdateRunFailureTypeNone
+}
+
 // emitUpdateRunStatusMetric emits the update run status metric based on status conditions in the updateRun.
-func emitUpdateRunStatusMetric(updateRun placementv1beta1.UpdateRunObj) {
+// The err parameter is used to determine the failure type for failed conditions.
+func emitUpdateRunStatusMetric(updateRun placementv1beta1.UpdateRunObj, err error) {
 	generation := updateRun.GetGeneration()
 	state := updateRun.GetUpdateRunSpec().State
 
 	updateRunStatus := updateRun.GetUpdateRunStatus()
 	succeedCond := meta.FindStatusCondition(updateRunStatus.Conditions, string(placementv1beta1.StagedUpdateRunConditionSucceeded))
 	if succeedCond != nil && succeedCond.ObservedGeneration == generation {
+		failureType := determineFailureType(succeedCond, generation, err)
 		hubmetrics.FleetUpdateRunStatusLastTimestampSeconds.WithLabelValues(updateRun.GetNamespace(), updateRun.GetName(), string(state),
-			string(placementv1beta1.StagedUpdateRunConditionSucceeded), string(succeedCond.Status), succeedCond.Reason).SetToCurrentTime()
+			string(placementv1beta1.StagedUpdateRunConditionSucceeded), string(succeedCond.Status), succeedCond.Reason, string(failureType)).SetToCurrentTime()
 		return
 	}
 
 	progressingCond := meta.FindStatusCondition(updateRunStatus.Conditions, string(placementv1beta1.StagedUpdateRunConditionProgressing))
 	if progressingCond != nil && progressingCond.ObservedGeneration == generation {
+		failureType := determineFailureType(progressingCond, generation, err)
 		hubmetrics.FleetUpdateRunStatusLastTimestampSeconds.WithLabelValues(updateRun.GetNamespace(), updateRun.GetName(), string(state),
-			string(placementv1beta1.StagedUpdateRunConditionProgressing), string(progressingCond.Status), progressingCond.Reason).SetToCurrentTime()
+			string(placementv1beta1.StagedUpdateRunConditionProgressing), string(progressingCond.Status), progressingCond.Reason, string(failureType)).SetToCurrentTime()
 		return
 	}
 
 	initializedCond := meta.FindStatusCondition(updateRunStatus.Conditions, string(placementv1beta1.StagedUpdateRunConditionInitialized))
 	if initializedCond != nil && initializedCond.ObservedGeneration == generation {
+		failureType := determineFailureType(initializedCond, generation, err)
 		hubmetrics.FleetUpdateRunStatusLastTimestampSeconds.WithLabelValues(updateRun.GetNamespace(), updateRun.GetName(), string(state),
-			string(placementv1beta1.StagedUpdateRunConditionInitialized), string(initializedCond.Status), initializedCond.Reason).SetToCurrentTime()
+			string(placementv1beta1.StagedUpdateRunConditionInitialized), string(initializedCond.Status), initializedCond.Reason, string(failureType)).SetToCurrentTime()
 		return
 	}
 

--- a/pkg/controllers/updaterun/metrics.go
+++ b/pkg/controllers/updaterun/metrics.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 
 	placementv1beta1 "github.com/kubefleet-dev/kubefleet/apis/placement/v1beta1"
@@ -43,24 +42,17 @@ func deleteUpdateRunMetrics(updateRun placementv1beta1.UpdateRunObj) {
 // - "none" for successful, in-progress, waiting, or stopping conditions
 // - "user_error" for known customer configuration errors (when err wraps controller.ErrUserError)
 // - "internal_error" for errors that require investigation
-func determineFailureType(cond *metav1.Condition, generation int64, err error) hubmetrics.UpdateRunFailureType {
-	klog.InfoS("Condition:", "type", cond.Type, "status", cond.Status, "reason", cond.Reason, "message", cond.Message)
-	// If the condition status is True (success) or Unknown (in-progress), there's no failure.
-	if !condition.IsConditionStatusFalse(cond, generation) {
-		return hubmetrics.UpdateRunFailureTypeNone
-	}
-
-	// For False status, check if the error is a user error.
-	if err != nil && errors.Is(err, controller.ErrUserError) {
-		return hubmetrics.UpdateRunFailureTypeUserError
-	}
-
-	// Failed condition that is not a user error is an internal error.
+func determineFailureType(err error) hubmetrics.UpdateRunFailureType {
 	if err != nil {
+		// Check if error for the failed condition is a user error.
+		if errors.Is(err, controller.ErrUserError) {
+			return hubmetrics.UpdateRunFailureTypeUserError
+		}
+		// Failed condition that is not a user error is an internal error.
 		return hubmetrics.UpdateRunFailureTypeInternalError
 	}
 
-	// For False, there are possible reasons that are not failures (i.e. "Waiting", "Stopped")
+	// If there's no error, there's no failure to categorize.
 	return hubmetrics.UpdateRunFailureTypeNone
 }
 
@@ -73,7 +65,7 @@ func emitUpdateRunStatusMetric(updateRun placementv1beta1.UpdateRunObj, err erro
 	updateRunStatus := updateRun.GetUpdateRunStatus()
 	succeedCond := meta.FindStatusCondition(updateRunStatus.Conditions, string(placementv1beta1.StagedUpdateRunConditionSucceeded))
 	if succeedCond != nil && succeedCond.ObservedGeneration == generation {
-		failureType := determineFailureType(succeedCond, generation, err)
+		failureType := determineFailureType(err)
 		hubmetrics.FleetUpdateRunStatusLastTimestampSeconds.WithLabelValues(updateRun.GetNamespace(), updateRun.GetName(), string(state),
 			string(placementv1beta1.StagedUpdateRunConditionSucceeded), string(succeedCond.Status), succeedCond.Reason, string(failureType)).SetToCurrentTime()
 		return
@@ -81,7 +73,7 @@ func emitUpdateRunStatusMetric(updateRun placementv1beta1.UpdateRunObj, err erro
 
 	progressingCond := meta.FindStatusCondition(updateRunStatus.Conditions, string(placementv1beta1.StagedUpdateRunConditionProgressing))
 	if progressingCond != nil && progressingCond.ObservedGeneration == generation {
-		failureType := determineFailureType(progressingCond, generation, err)
+		failureType := determineFailureType(err)
 		hubmetrics.FleetUpdateRunStatusLastTimestampSeconds.WithLabelValues(updateRun.GetNamespace(), updateRun.GetName(), string(state),
 			string(placementv1beta1.StagedUpdateRunConditionProgressing), string(progressingCond.Status), progressingCond.Reason, string(failureType)).SetToCurrentTime()
 		return
@@ -89,7 +81,7 @@ func emitUpdateRunStatusMetric(updateRun placementv1beta1.UpdateRunObj, err erro
 
 	initializedCond := meta.FindStatusCondition(updateRunStatus.Conditions, string(placementv1beta1.StagedUpdateRunConditionInitialized))
 	if initializedCond != nil && initializedCond.ObservedGeneration == generation {
-		failureType := determineFailureType(initializedCond, generation, err)
+		failureType := determineFailureType(err)
 		hubmetrics.FleetUpdateRunStatusLastTimestampSeconds.WithLabelValues(updateRun.GetNamespace(), updateRun.GetName(), string(state),
 			string(placementv1beta1.StagedUpdateRunConditionInitialized), string(initializedCond.Status), initializedCond.Reason, string(failureType)).SetToCurrentTime()
 		return

--- a/pkg/controllers/updaterun/metrics.go
+++ b/pkg/controllers/updaterun/metrics.go
@@ -63,9 +63,9 @@ func emitUpdateRunStatusMetric(updateRun placementv1beta1.UpdateRunObj, err erro
 	state := updateRun.GetUpdateRunSpec().State
 
 	updateRunStatus := updateRun.GetUpdateRunStatus()
+	failureType := determineFailureType(err)
 	succeedCond := meta.FindStatusCondition(updateRunStatus.Conditions, string(placementv1beta1.StagedUpdateRunConditionSucceeded))
 	if succeedCond != nil && succeedCond.ObservedGeneration == generation {
-		failureType := determineFailureType(err)
 		hubmetrics.FleetUpdateRunStatusLastTimestampSeconds.WithLabelValues(updateRun.GetNamespace(), updateRun.GetName(), string(state),
 			string(placementv1beta1.StagedUpdateRunConditionSucceeded), string(succeedCond.Status), succeedCond.Reason, string(failureType)).SetToCurrentTime()
 		return
@@ -73,7 +73,6 @@ func emitUpdateRunStatusMetric(updateRun placementv1beta1.UpdateRunObj, err erro
 
 	progressingCond := meta.FindStatusCondition(updateRunStatus.Conditions, string(placementv1beta1.StagedUpdateRunConditionProgressing))
 	if progressingCond != nil && progressingCond.ObservedGeneration == generation {
-		failureType := determineFailureType(err)
 		hubmetrics.FleetUpdateRunStatusLastTimestampSeconds.WithLabelValues(updateRun.GetNamespace(), updateRun.GetName(), string(state),
 			string(placementv1beta1.StagedUpdateRunConditionProgressing), string(progressingCond.Status), progressingCond.Reason, string(failureType)).SetToCurrentTime()
 		return
@@ -81,7 +80,6 @@ func emitUpdateRunStatusMetric(updateRun placementv1beta1.UpdateRunObj, err erro
 
 	initializedCond := meta.FindStatusCondition(updateRunStatus.Conditions, string(placementv1beta1.StagedUpdateRunConditionInitialized))
 	if initializedCond != nil && initializedCond.ObservedGeneration == generation {
-		failureType := determineFailureType(err)
 		hubmetrics.FleetUpdateRunStatusLastTimestampSeconds.WithLabelValues(updateRun.GetNamespace(), updateRun.GetName(), string(state),
 			string(placementv1beta1.StagedUpdateRunConditionInitialized), string(initializedCond.Status), initializedCond.Reason, string(failureType)).SetToCurrentTime()
 		return

--- a/pkg/controllers/updaterun/metrics_test.go
+++ b/pkg/controllers/updaterun/metrics_test.go
@@ -22,99 +22,42 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	placementv1beta1 "github.com/kubefleet-dev/kubefleet/apis/placement/v1beta1"
 	hubmetrics "github.com/kubefleet-dev/kubefleet/pkg/metrics/hub"
-	"github.com/kubefleet-dev/kubefleet/pkg/utils/condition"
 	"github.com/kubefleet-dev/kubefleet/pkg/utils/controller"
 )
 
 func TestDetermineFailureType(t *testing.T) {
 	tests := []struct {
-		name       string
-		cond       *metav1.Condition
-		generation int64
-		err        error
-		want       hubmetrics.UpdateRunFailureType
+		name string
+		err  error
+		want hubmetrics.UpdateRunFailureType
 	}{
 		{
-			name: "update run succeeded - no failure",
-			cond: &metav1.Condition{
-				Type:               string(placementv1beta1.StagedUpdateRunConditionSucceeded),
-				Status:             metav1.ConditionTrue,
-				ObservedGeneration: 1,
-				Reason:             condition.UpdateRunSucceededReason,
-			},
-			generation: 1,
-			err:        nil,
-			want:       hubmetrics.UpdateRunFailureTypeNone,
-		},
-		{
-			name: "update run is stopping - no failure",
-			cond: &metav1.Condition{
-				Type:               string(placementv1beta1.StagedUpdateRunConditionProgressing),
-				Status:             metav1.ConditionUnknown,
-				ObservedGeneration: 1,
-				Reason:             condition.UpdateRunStoppingReason,
-			},
-			generation: 1,
-			err:        nil,
-			want:       hubmetrics.UpdateRunFailureTypeNone,
+			name: "update run no failure",
+			err:  nil,
+			want: hubmetrics.UpdateRunFailureTypeNone,
 		},
 		{
 			name: "update run failed with user error",
-			cond: &metav1.Condition{
-				Type:               string(placementv1beta1.StagedUpdateRunConditionSucceeded),
-				Status:             metav1.ConditionFalse,
-				ObservedGeneration: 1,
-				Reason:             condition.UpdateRunFailedReason,
-			},
-			generation: 1,
-			err:        fmt.Errorf("cannot continue the updateRun: failed to validate the updateRun: %w", controller.ErrUserError),
-			want:       hubmetrics.UpdateRunFailureTypeUserError,
+			err:  fmt.Errorf("cannot continue the updateRun: failed to validate the updateRun: %w", controller.ErrUserError),
+			want: hubmetrics.UpdateRunFailureTypeUserError,
 		},
 		{
 			name: "update run failed with internal error",
-			cond: &metav1.Condition{
-				Type:               string(placementv1beta1.StagedUpdateRunConditionSucceeded),
-				Status:             metav1.ConditionFalse,
-				ObservedGeneration: 1,
-				Reason:             condition.UpdateRunFailedReason,
-			},
-			generation: 1,
-			err:        errors.New("cannot continue the updateRun"),
-			want:       hubmetrics.UpdateRunFailureTypeInternalError,
-		},
-		{
-			name: "update run is waiting for stage task - no error",
-			cond: &metav1.Condition{
-				Type:               string(placementv1beta1.StagedUpdateRunConditionProgressing),
-				Status:             metav1.ConditionFalse,
-				ObservedGeneration: 1,
-				Reason:             condition.UpdateRunWaitingReason,
-			},
-			generation: 1,
-			err:        nil,
-			want:       hubmetrics.UpdateRunFailureTypeNone,
+			err:  errors.New("cannot continue the updateRun"),
+			want: hubmetrics.UpdateRunFailureTypeInternalError,
 		},
 		{
 			name: "update run is stuck - internal error",
-			cond: &metav1.Condition{
-				Type:               string(placementv1beta1.StagedUpdateRunConditionProgressing),
-				Status:             metav1.ConditionFalse,
-				ObservedGeneration: 1,
-				Reason:             condition.UpdateRunStuckReason,
-			},
-			generation: 1,
-			err:        errors.New("updateRun is stuck waiting for 1 cluster(s) in stage stage1 to finish updating, please check placement status for potential errors"),
-			want:       hubmetrics.UpdateRunFailureTypeInternalError,
+			err:  errors.New("updateRun is stuck waiting for 1 cluster(s) in stage stage1 to finish updating, please check placement status for potential errors"),
+			want: hubmetrics.UpdateRunFailureTypeInternalError,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := determineFailureType(tc.cond, tc.generation, tc.err)
+			got := determineFailureType(tc.err)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("determineFailureType() = %v, want %v, diff (-want +got):\n%s", got, tc.want, diff)
 			}

--- a/pkg/controllers/updaterun/metrics_test.go
+++ b/pkg/controllers/updaterun/metrics_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2025 The KubeFleet Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package updaterun
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	placementv1beta1 "github.com/kubefleet-dev/kubefleet/apis/placement/v1beta1"
+	hubmetrics "github.com/kubefleet-dev/kubefleet/pkg/metrics/hub"
+	"github.com/kubefleet-dev/kubefleet/pkg/utils/condition"
+	"github.com/kubefleet-dev/kubefleet/pkg/utils/controller"
+)
+
+func TestDetermineFailureType(t *testing.T) {
+	tests := []struct {
+		name       string
+		cond       *metav1.Condition
+		generation int64
+		err        error
+		want       hubmetrics.UpdateRunFailureType
+	}{
+		{
+			name: "update run succeeded - no failure",
+			cond: &metav1.Condition{
+				Type:               string(placementv1beta1.StagedUpdateRunConditionSucceeded),
+				Status:             metav1.ConditionTrue,
+				ObservedGeneration: 1,
+				Reason:             condition.UpdateRunSucceededReason,
+			},
+			generation: 1,
+			err:        nil,
+			want:       hubmetrics.UpdateRunFailureTypeNone,
+		},
+		{
+			name: "update run is stopping - no failure",
+			cond: &metav1.Condition{
+				Type:               string(placementv1beta1.StagedUpdateRunConditionProgressing),
+				Status:             metav1.ConditionUnknown,
+				ObservedGeneration: 1,
+				Reason:             condition.UpdateRunStoppingReason,
+			},
+			generation: 1,
+			err:        nil,
+			want:       hubmetrics.UpdateRunFailureTypeNone,
+		},
+		{
+			name: "update run failed with user error",
+			cond: &metav1.Condition{
+				Type:               string(placementv1beta1.StagedUpdateRunConditionSucceeded),
+				Status:             metav1.ConditionFalse,
+				ObservedGeneration: 1,
+				Reason:             condition.UpdateRunFailedReason,
+			},
+			generation: 1,
+			err:        fmt.Errorf("cannot continue the updateRun: failed to validate the updateRun: %w", controller.ErrUserError),
+			want:       hubmetrics.UpdateRunFailureTypeUserError,
+		},
+		{
+			name: "update run failed with internal error",
+			cond: &metav1.Condition{
+				Type:               string(placementv1beta1.StagedUpdateRunConditionSucceeded),
+				Status:             metav1.ConditionFalse,
+				ObservedGeneration: 1,
+				Reason:             condition.UpdateRunFailedReason,
+			},
+			generation: 1,
+			err:        errors.New("cannot continue the updateRun"),
+			want:       hubmetrics.UpdateRunFailureTypeInternalError,
+		},
+		{
+			name: "update run is waiting for stage task - no error",
+			cond: &metav1.Condition{
+				Type:               string(placementv1beta1.StagedUpdateRunConditionProgressing),
+				Status:             metav1.ConditionFalse,
+				ObservedGeneration: 1,
+				Reason:             condition.UpdateRunWaitingReason,
+			},
+			generation: 1,
+			err:        nil,
+			want:       hubmetrics.UpdateRunFailureTypeNone,
+		},
+		{
+			name: "update run is stuck - internal error",
+			cond: &metav1.Condition{
+				Type:               string(placementv1beta1.StagedUpdateRunConditionProgressing),
+				Status:             metav1.ConditionFalse,
+				ObservedGeneration: 1,
+				Reason:             condition.UpdateRunStuckReason,
+			},
+			generation: 1,
+			err:        errors.New("updateRun is stuck waiting for 1 cluster(s) in stage stage1 to finish updating, please check placement status for potential errors"),
+			want:       hubmetrics.UpdateRunFailureTypeInternalError,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := determineFailureType(tc.cond, tc.generation, tc.err)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("determineFailureType() = %v, want %v, diff (-want +got):\n%s", got, tc.want, diff)
+			}
+		})
+	}
+}

--- a/pkg/controllers/updaterun/validation.go
+++ b/pkg/controllers/updaterun/validation.go
@@ -54,7 +54,7 @@ func (r *Reconciler) validate(
 	if !reflect.DeepEqual(updateRunStatus.ApplyStrategy, updateRunCopyStatus.ApplyStrategy) {
 		mismatchErr := controller.NewUserError(fmt.Errorf("the applyStrategy in the updateRun is outdated, latest: %v, recorded: %v", updateRunCopyStatus.ApplyStrategy, updateRunStatus.ApplyStrategy))
 		klog.ErrorS(mismatchErr, "the applyStrategy in the placement has changed", "placement", placementNamespacedName, "updateRun", updateRunRef)
-		return -1, nil, nil, fmt.Errorf("%w: %s", errStagedUpdatedAborted, mismatchErr.Error())
+		return -1, nil, nil, fmt.Errorf("%w: %w", errStagedUpdatedAborted, mismatchErr)
 	}
 
 	// Retrieve the latest policy snapshot.

--- a/pkg/controllers/updaterun/validation_integration_test.go
+++ b/pkg/controllers/updaterun/validation_integration_test.go
@@ -117,6 +117,9 @@ var _ = Describe("UpdateRun validation tests", func() {
 			wantStatus = generateExecutionNotStartedStatus(updateRun, initialized)
 			validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus, "")
 
+			// All following tests will report internal errors, if not user error, because only the updaterun controller
+			// is running in this test environment. Other controllers (e.g., rollout, work generator,
+			// binding controllers) are not set up, causing operations that depend on them to fail.
 			failureType = hubmetrics.UpdateRunFailureTypeInternalError
 		})
 

--- a/pkg/controllers/updaterun/validation_integration_test.go
+++ b/pkg/controllers/updaterun/validation_integration_test.go
@@ -33,6 +33,7 @@ import (
 
 	clusterv1beta1 "github.com/kubefleet-dev/kubefleet/apis/cluster/v1beta1"
 	placementv1beta1 "github.com/kubefleet-dev/kubefleet/apis/placement/v1beta1"
+	hubmetrics "github.com/kubefleet-dev/kubefleet/pkg/metrics/hub"
 	"github.com/kubefleet-dev/kubefleet/pkg/utils"
 	"github.com/kubefleet-dev/kubefleet/pkg/utils/condition"
 )
@@ -49,6 +50,7 @@ var _ = Describe("UpdateRun validation tests", func() {
 		var resourceSnapshot *placementv1beta1.ClusterResourceSnapshot
 		var clusterResourceOverride *placementv1beta1.ClusterResourceOverrideSnapshot
 		var wantStatus *placementv1beta1.UpdateRunStatus
+		var failureType hubmetrics.UpdateRunFailureType
 
 		BeforeEach(func() {
 			testUpdateRunName = "updaterun-" + utils.RandStr()
@@ -114,6 +116,8 @@ var _ = Describe("UpdateRun validation tests", func() {
 			initialized := generateInitializedStatus(crp, updateRun, testResourceSnapshotIndex, policySnapshot, updateStrategy, 10, generateTenClusterStagesStatus(clusterResourceOverride), generateTenClusterDeletionStageStatus())
 			wantStatus = generateExecutionNotStartedStatus(updateRun, initialized)
 			validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus, "")
+
+			failureType = hubmetrics.UpdateRunFailureTypeInternalError
 		})
 
 		AfterEach(func() {
@@ -165,7 +169,7 @@ var _ = Describe("UpdateRun validation tests", func() {
 		Context("Test validateCRP", func() {
 			AfterEach(func() {
 				By("Checking update run status metrics are emitted")
-				validateUpdateRunMetricsEmitted(generateWaitingMetric(placementv1beta1.StateRun, updateRun), generateFailedMetric(placementv1beta1.StateRun, updateRun))
+				validateUpdateRunMetricsEmitted(generateWaitingMetric(placementv1beta1.StateRun, updateRun), generateFailedMetric(placementv1beta1.StateRun, updateRun, string(failureType)))
 			})
 
 			It("Should fail to validate if the CRP is not found", func() {
@@ -173,6 +177,7 @@ var _ = Describe("UpdateRun validation tests", func() {
 				Expect(k8sClient.Delete(ctx, crp)).Should(Succeed())
 
 				By("Validating the validation failed")
+				failureType = hubmetrics.UpdateRunFailureTypeUserError
 				wantStatus = generateFailedValidationStatus(updateRun, wantStatus)
 				validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus, "parent placement not found")
 			})
@@ -186,6 +191,7 @@ var _ = Describe("UpdateRun validation tests", func() {
 				Expect(k8sClient.Create(ctx, crp)).To(Succeed())
 
 				By("Validating the validation failed")
+				failureType = hubmetrics.UpdateRunFailureTypeUserError
 				wantStatus = generateFailedValidationStatus(updateRun, wantStatus)
 				validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus,
 					"parent placement does not have an external rollout strategy")
@@ -197,6 +203,7 @@ var _ = Describe("UpdateRun validation tests", func() {
 				Expect(k8sClient.Update(ctx, crp)).To(Succeed())
 
 				By("Validating the validation failed")
+				failureType = hubmetrics.UpdateRunFailureTypeUserError
 				wantStatus = generateFailedValidationStatus(updateRun, wantStatus)
 				validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus, "the applyStrategy in the updateRun is outdated")
 			})
@@ -212,7 +219,7 @@ var _ = Describe("UpdateRun validation tests", func() {
 				validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus, "no latest policy snapshot associated")
 
 				By("Checking update run status metrics are emitted")
-				validateUpdateRunMetricsEmitted(generateWaitingMetric(placementv1beta1.StateRun, updateRun), generateFailedMetric(placementv1beta1.StateRun, updateRun))
+				validateUpdateRunMetricsEmitted(generateWaitingMetric(placementv1beta1.StateRun, updateRun), generateFailedMetric(placementv1beta1.StateRun, updateRun, string(failureType)))
 			})
 
 			It("Should fail to validate if the latest policySnapshot has changed", func() {
@@ -241,7 +248,7 @@ var _ = Describe("UpdateRun validation tests", func() {
 				Expect(k8sClient.Delete(ctx, newPolicySnapshot)).Should(Succeed())
 
 				By("Checking update run status metrics are emitted")
-				validateUpdateRunMetricsEmitted(generateWaitingMetric(placementv1beta1.StateRun, updateRun), generateFailedMetric(placementv1beta1.StateRun, updateRun))
+				validateUpdateRunMetricsEmitted(generateWaitingMetric(placementv1beta1.StateRun, updateRun), generateFailedMetric(placementv1beta1.StateRun, updateRun, string(failureType)))
 			})
 
 			It("Should fail to validate if the cluster count has changed", func() {
@@ -255,14 +262,14 @@ var _ = Describe("UpdateRun validation tests", func() {
 					"the cluster count initialized in the updateRun is outdated")
 
 				By("Checking update run status metrics are emitted")
-				validateUpdateRunMetricsEmitted(generateWaitingMetric(placementv1beta1.StateRun, updateRun), generateFailedMetric(placementv1beta1.StateRun, updateRun))
+				validateUpdateRunMetricsEmitted(generateWaitingMetric(placementv1beta1.StateRun, updateRun), generateFailedMetric(placementv1beta1.StateRun, updateRun, string(failureType)))
 			})
 		})
 
 		Context("Test validateStagesStatus", func() {
 			AfterEach(func() {
 				By("Checking update run status metrics are emitted")
-				validateUpdateRunMetricsEmitted(generateWaitingMetric(placementv1beta1.StateRun, updateRun), generateFailedMetric(placementv1beta1.StateRun, updateRun))
+				validateUpdateRunMetricsEmitted(generateWaitingMetric(placementv1beta1.StateRun, updateRun), generateFailedMetric(placementv1beta1.StateRun, updateRun, string(failureType)))
 			})
 
 			It("Should fail to validate if the UpdateStrategySnapshot is nil", func() {
@@ -379,6 +386,7 @@ var _ = Describe("UpdateRun validation tests", func() {
 		var resourceSnapshot *placementv1beta1.ClusterResourceSnapshot
 		var clusterResourceOverride *placementv1beta1.ClusterResourceOverrideSnapshot
 		var wantStatus *placementv1beta1.UpdateRunStatus
+
 		BeforeEach(func() {
 			testUpdateRunName = "updaterun-" + utils.RandStr()
 			testCRPName = "crp-" + utils.RandStr()

--- a/pkg/controllers/updaterun/validation_integration_test.go
+++ b/pkg/controllers/updaterun/validation_integration_test.go
@@ -117,7 +117,7 @@ var _ = Describe("UpdateRun validation tests", func() {
 			wantStatus = generateExecutionNotStartedStatus(updateRun, initialized)
 			validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus, "")
 
-			// All following tests will report internal errors, if not user error, because only the updaterun controller
+			// Tests that fail below will report internal errors, if not user error, because only the updaterun controller
 			// is running in this test environment. Other controllers (e.g., rollout, work generator,
 			// binding controllers) are not set up, causing operations that depend on them to fail.
 			failureType = hubmetrics.UpdateRunFailureTypeInternalError

--- a/pkg/metrics/hub/metrics.go
+++ b/pkg/metrics/hub/metrics.go
@@ -22,6 +22,23 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
+// UpdateRunFailureType represents the type of failure for an update run.
+type UpdateRunFailureType string
+
+const (
+	// UpdateRunFailureTypeNone indicates no failure (success or in-progress states).
+	UpdateRunFailureTypeNone UpdateRunFailureType = "none"
+
+	// UpdateRunFailureTypeUserError indicates a failure caused by user configuration errors
+	// such as validation failures, missing resources, or invalid settings.
+	// These are known customer errors that do not require investigation.
+	UpdateRunFailureTypeUserError UpdateRunFailureType = "user_error"
+
+	// UpdateRunFailureTypeInternalError indicates a failure caused by internal system errors
+	// that may require investigation, such as unexpected behaviors or API server errors.
+	UpdateRunFailureTypeInternalError UpdateRunFailureType = "internal_error"
+)
+
 var (
 	// FleetPlacementStatusLastTimeStampSeconds is a prometheus metric which keeps track of the last placement status.
 	FleetPlacementStatusLastTimeStampSeconds = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -38,10 +55,12 @@ var (
 
 	// FleetUpdateRunStatusLastTimestampSeconds is a prometheus metric which holds the
 	// last update timestamp of update run status in seconds.
+	// The failure_type label indicates whether a failure is a user_error (customer configuration issue),
+	// internal_error (requires investigation), or none (no failure).
 	FleetUpdateRunStatusLastTimestampSeconds = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "fleet_workload_update_run_status_last_timestamp_seconds",
 		Help: "Last update timestamp of update run status in seconds",
-	}, []string{"namespace", "name", "state", "condition", "status", "reason"})
+	}, []string{"namespace", "name", "state", "condition", "status", "reason", "failureType"})
 
 	// FleetUpdateRunApprovalRequestLatencySeconds tracks how long users take to approve approval requests.
 	FleetUpdateRunApprovalRequestLatencySeconds = prometheus.NewHistogramVec(prometheus.HistogramOpts{


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that have a clear purpose. If yours fix an issue,
please uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:
- Included failure type label for "fleet_workload_update_run_status_last_timestamp_seconds" to help determine what failed update runs were due to user error. 
- Determination is based on if the error has the user error wrapper. 

- [ ] Associated this change with a known KubeFleet Issue (Bug, Feature, etc).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- UT
- Integration


### Special notes for your reviewer

This is to help with alerts that are based on the number of failed update run. We want excluded those with known user error, so we don't have to investigate.


