### PR TITLE
fix: Member uses TLS to communicate with hub by default

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -43,7 +43,10 @@ helm install hub-agent oci://ghcr.io/kubefleet-dev/kubefleet/charts/hub-agent \
 helm install member-agent oci://ghcr.io/kubefleet-dev/kubefleet/charts/member-agent \
   --version VERSION \
   --namespace fleet-system \
-  --create-namespace
+  --create-namespace \
+  --set config.hubURL=https://<hub-api-server> \
+  --set config.hubCA=<base64-encoded-hub-ca> \
+  --set config.memberClusterName=<member-cluster-name>
 ```
 
 ### Option 2: Traditional Helm Repository
@@ -65,7 +68,10 @@ helm install hub-agent kubefleet/hub-agent \
 # Install member-agent
 helm install member-agent kubefleet/member-agent \
   --namespace fleet-system \
-  --create-namespace
+  --create-namespace \
+  --set config.hubURL=https://<hub-api-server> \
+  --set config.hubCA=<base64-encoded-hub-ca> \
+  --set config.memberClusterName=<member-cluster-name>
 ```
 
 ### Installing Specific Versions
@@ -137,7 +143,12 @@ For development and testing, you can install charts directly from the local repo
 ```bash
 # Install from local path
 helm install hub-agent ./charts/hub-agent --namespace fleet-system --create-namespace
-helm install member-agent ./charts/member-agent --namespace fleet-system --create-namespace
+helm install member-agent ./charts/member-agent \
+  --namespace fleet-system \
+  --create-namespace \
+  --set config.hubURL=https://<hub-api-server> \
+  --set config.hubCA=<base64-encoded-hub-ca> \
+  --set config.memberClusterName=<member-cluster-name>
 ```
 
 ### Linting

--- a/charts/member-agent/README.md
+++ b/charts/member-agent/README.md
@@ -6,6 +6,30 @@ Chart versions match the KubeFleet release versions. For example, to install Kub
 
 ## Install Chart
 
+### Prerequisites
+
+Before installing, collect the following values from the **hub** cluster:
+
+**`config.hubURL`** — the hub cluster's API server endpoint:
+
+```console
+kubectl config view --raw -o jsonpath='{.clusters[0].cluster.server}'
+```
+
+**`config.hubCA`** — the hub cluster's certificate authority data (base64-encoded):
+
+```console
+kubectl config view --raw -o jsonpath='{.clusters[0].cluster.certificate-authority-data}'
+```
+
+If your hub kubeconfig uses a CA file path instead of inline data, encode the file:
+
+```console
+cat /path/to/hub-ca.crt | base64 -w0
+```
+
+**`config.memberClusterName`** — the name you want this member cluster to be registered as in the hub. This must match the `MemberCluster` resource name on the hub.
+
 ### Using Published Chart (Recommended)
 
 The member-agent chart is published to both GitHub Container Registry (OCI) and GitHub Pages.
@@ -17,7 +41,10 @@ The member-agent chart is published to both GitHub Container Registry (OCI) and 
 helm install member-agent oci://ghcr.io/kubefleet-dev/kubefleet/charts/member-agent \
   --version VERSION \
   --namespace fleet-system \
-  --create-namespace
+  --create-namespace \
+  --set config.hubURL=https://<hub-api-server> \
+  --set config.hubCA=<base64-encoded-hub-ca> \
+  --set config.memberClusterName=<member-cluster-name>
 ```
 
 #### Option 2: Traditional Helm Repository
@@ -28,13 +55,23 @@ helm repo add kubefleet https://kubefleet-dev.github.io/kubefleet/charts
 helm repo update
 
 # Install member-agent (specify --version to pin to a specific release)
-helm install member-agent kubefleet/member-agent --namespace fleet-system --create-namespace
+helm install member-agent kubefleet/member-agent \
+  --namespace fleet-system \
+  --create-namespace \
+  --set config.hubURL=https://<hub-api-server> \
+  --set config.hubCA=<base64-encoded-hub-ca> \
+  --set config.memberClusterName=<member-cluster-name>
 ```
 
 ### From Local Source
 
 ```console
-helm install member-agent ./charts/member-agent/ --namespace fleet-system --create-namespace
+helm install member-agent ./charts/member-agent/ \
+  --namespace fleet-system \
+  --create-namespace \
+  --set config.hubURL=https://<hub-api-server> \
+  --set config.hubCA=<base64-encoded-hub-ca> \
+  --set config.memberClusterName=<member-cluster-name>
 ```
 
 _See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
@@ -64,6 +101,8 @@ helm upgrade member-agent kubefleet/member-agent --namespace fleet-system
 | resources               | The resource request/limits for the container image                                                                                                                                                                                            | limits: "2" CPU, 4Gi, requests: 100m CPU, 128Mi      |
 | namespace               | Namespace that this Helm chart is installed on.                                                                                                                                                                                                | `fleet-system`                                       |
 | logVerbosity            | Log level. Uses V logs (klog)                                                                                                                                                                                                                  | `3`                                                  |
+| tlsClientInsecure       | Skip TLS server certificate verification when the member agent connects to the hub cluster. Leave this `false` unless you explicitly trust the endpoint and understand the risk.                                                            | `false`                                              |
+| useCAAuth               | Use certificate-based authentication for the hub connection instead of the token-based path.                                                                                                                                                  | `false`                                              |
 | propertyProvider        | The property provider to use with the member agent; if none is specified, the Fleet member agent will start with no property provider (i.e., the agent will expose no cluster properties, and collect only limited resource usage information) | ``                                                   |
 | region                  | The region where the member cluster resides                                                                                                                                                                                                    | ``                                                   |
 | enableNamespaceCollectionInPropertyProvider | Enable namespace collection in the property provider; when enabled, the member agent will collect and report the list of namespaces present in the member cluster to the hub cluster for use in scheduling decisions | `false` |
@@ -77,6 +116,12 @@ helm upgrade member-agent kubefleet/member-agent --namespace fleet-system
 | workApplierRequeueRateLimiterSkipToFastBackoffForAvailableOrDiffReportedWorkObjs | This parameter is a set of values to control how frequent KubeFleet should reconcile (process) manifests; it specifies whether to skip the slow backoff stage and start fast backoff immediately for available or diff-reported work objects | `true` |
 | config.azureCloudConfig | The cloud provider configuration                                                                                                                                                                                                               | **required if property provider is set to azure**    |
 
+
+## Hub TLS configuration
+
+By default, the chart keeps TLS server certificate verification enabled for the member agent's connection to the hub API server (`tlsClientInsecure=false`). This requires a valid `config.hubCA` value — the placeholder in `values.yaml` will cause the agent to fail at startup. See [Prerequisites](#prerequisites) for how to obtain the hub CA data.
+
+Set `tlsClientInsecure=true` only for explicitly trusted test environments where certificate verification cannot be configured.
 
 ## Override Azure cloud config
 

--- a/charts/member-agent/values.yaml
+++ b/charts/member-agent/values.yaml
@@ -56,7 +56,7 @@ secret:
 azure:
   clientid: <member_cluster_clientID>
 
-tlsClientInsecure: true #TODO should be false in the production
+tlsClientInsecure: false
 useCAAuth: false
 
 enablePprof: true

--- a/hack/Azure/property-based-scheduling.md
+++ b/hack/Azure/property-based-scheduling.md
@@ -172,6 +172,7 @@ do
 done
 
 # Install the member agent.
+export HUB_CA=$(kubectl config view --raw -o jsonpath="{.clusters[?(@.name==\"$HUB_CLUSTER\")].cluster.certificate-authority-data}")
 for (( i=0; i<3; i++ ));
 do
     kubectl config use-context "${MEMBER_CLUSTERS[$i]}-admin"
@@ -179,6 +180,7 @@ do
       --namespace fleet-system \
       --create-namespace \
         --set config.hubURL=$HUB_SERVER_ADDR \
+        --set config.hubCA=$HUB_CA \
         --set image.repository=$REGISTRY/member-agent \
         --set image.tag=$TAG \
         --set refreshtoken.repository=$REGISTRY/refresh-token \

--- a/hack/Azure/setup/joinMC.sh
+++ b/hack/Azure/setup/joinMC.sh
@@ -4,6 +4,7 @@
 export HUB_CLUSTER="$1"
 export HUB_CLUSTER_CONTEXT=$(kubectl config view -o jsonpath="{.contexts[?(@.context.cluster==\"$HUB_CLUSTER\")].name}")
 export HUB_CLUSTER_ADDRESS=$(kubectl config view -o jsonpath="{.clusters[?(@.name==\"$HUB_CLUSTER\")].cluster.server}")
+export HUB_CA=$(kubectl config view --raw -o jsonpath="{.clusters[?(@.name==\"$HUB_CLUSTER\")].cluster.certificate-authority-data}")
 
 for MC in "${@:2}"; do
 
@@ -82,6 +83,7 @@ helm install member-agent charts/member-agent/ \
         --namespace fleet-system \
         --create-namespace \
         --set config.hubURL=$HUB_CLUSTER_ADDRESS  \
+        --set config.hubCA=$HUB_CA \
         --set image.repository=$REGISTRY/$MEMBER_AGENT_IMAGE \
         --set image.tag=$FLEET_VERSION \
         --set refreshtoken.repository=$REGISTRY/$REFRESH_TOKEN_IMAGE \

--- a/hack/membership/join.sh
+++ b/hack/membership/join.sh
@@ -49,6 +49,10 @@ fi
 
 [ -z "$HUB_CLUSTER_ADDRESS" ] && echo "Environment variable HUB_CLUSTER_ADDRESS is not set." #&& exit 1
 
+# Extract the hub cluster CA for secure TLS verification
+HUB_CLUSTER_NAME=$(kubectl config view -o jsonpath="{.contexts[?(@.name==\"$HUB_CLUSTER_CONTEXT\")].context.cluster}")
+HUB_CA=$(kubectl config view --raw -o jsonpath="{.clusters[?(@.name==\"$HUB_CLUSTER_NAME\")].cluster.certificate-authority-data}")
+
 [ -z "$MEMBER_CLUSTER" ] && echo "Environment variable MEMBER_CLUSTER is not set." #&& exit 1
 
 [ -z "$MEMBER_CLUSTER_CONTEXT" ] && echo "Environment variable MEMBER_CLUSTER_CONTEXT is not set; will use the value of MEMBER_CLUSTER instead." #&& exit 1
@@ -120,6 +124,7 @@ helm install member-agent charts/member-agent/ \
     --namespace fleet-system \
     --create-namespace \
     --set config.hubURL=$HUB_CLUSTER_ADDRESS \
+    --set config.hubCA=$HUB_CA \
     --set image.repository=$REGISTRY/$MEMBER_AGENT_IMAGE \
     --set image.tag=$FLEET_VERSION \
     --set image.pullPolicy=Never \

--- a/hack/quickstart/join-member-clusters.ps1
+++ b/hack/quickstart/join-member-clusters.ps1
@@ -121,7 +121,8 @@ if ($parsedHubURL.Scheme -ne "https") {
 }
 
 # Extract the hub cluster CA for secure TLS verification
-$HubCA = kubectl config view --raw -o jsonpath="{.clusters[?(@.name=='$HubClusterName')].cluster.certificate-authority-data}"
+$jsonpath = "{.clusters[?(@.name==""$HubClusterName"")].cluster.certificate-authority-data}"
+$HubCA = kubectl config view --raw -o "jsonpath=$jsonpath"
 if ([string]::IsNullOrWhiteSpace($HubCA)) {
     Write-Error "Failed to extract certificate authority data from hub cluster '$HubClusterName'"
     exit 1

--- a/hack/quickstart/join-member-clusters.ps1
+++ b/hack/quickstart/join-member-clusters.ps1
@@ -120,6 +120,13 @@ if ($parsedHubURL.Scheme -ne "https") {
     Fail-WithHelp "hub control plane URL must use https"
 }
 
+# Extract the hub cluster CA for secure TLS verification
+$HubCA = kubectl config view --raw -o jsonpath="{.clusters[?(@.name=='$HubClusterName')].cluster.certificate-authority-data}"
+if ([string]::IsNullOrWhiteSpace($HubCA)) {
+    Write-Error "Failed to extract certificate authority data from hub cluster '$HubClusterName'"
+    exit 1
+}
+
 foreach ($memberClusterName in $MemberClusterNames) {
     if ([string]::IsNullOrWhiteSpace($memberClusterName)) {
         Fail-WithHelp "member cluster name cannot be empty"
@@ -196,6 +203,7 @@ spec:
     helm install member-agent oci://ghcr.io/kubefleet-dev/kubefleet/charts/member-agent `
         --version $KubefleetVersion `
         --set "config.hubURL=$HubControlPlaneURL" `
+        --set "config.hubCA=$HubCA" `
         --set "config.memberClusterName=$memberClusterName" `
         --set logFileMaxSize=100000 `
         --namespace fleet-system `

--- a/hack/quickstart/join-member-clusters.sh
+++ b/hack/quickstart/join-member-clusters.sh
@@ -95,6 +95,10 @@ export SERVICE_ACCOUNT="$MEMBER_CLUSTER_NAME-hub-cluster-access"
 
 echo "Switching into hub cluster context..."
 kubectl config use $HUB_CLUSTER_NAME
+
+# Extract the hub cluster CA for secure TLS verification
+export HUB_CA=$(kubectl config view --raw -o jsonpath="{.clusters[?(@.name==\"$HUB_CLUSTER_NAME\")].cluster.certificate-authority-data}")
+
 # The service account can, in theory, be created in any namespace; for simplicity reasons,
 # here you will use the namespace reserved by Fleet installation, `fleet-system`.
 #
@@ -149,6 +153,7 @@ echo "Installing member-agent..."
 helm install member-agent oci://ghcr.io/kubefleet-dev/kubefleet/charts/member-agent \
   --version $KUBEFLEET_VERSION \
   --set config.hubURL=$HUB_CONTROL_PLANE_URL \
+  --set config.hubCA=$HUB_CA \
   --set config.memberClusterName=$MEMBER_CLUSTER_NAME \
   --set logFileMaxSize=100000 \
   --namespace fleet-system \

--- a/test/e2e/setup.sh
+++ b/test/e2e/setup.sh
@@ -197,6 +197,9 @@ done
 kind export kubeconfig --name $HUB_CLUSTER
 HUB_SERVER_URL="https://$(docker inspect $HUB_CLUSTER-control-plane --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}'):6443"
 
+# Extract the hub cluster CA for secure TLS verification
+HUB_CA=$(kubectl config view --raw -o jsonpath='{.clusters[?(@.name=="kind-'$HUB_CLUSTER'")].cluster.certificate-authority-data}')
+
 # Install the member agents and related components
 # Note that the work applier in the member agent are set to requeue at max. every 5 seconds instead of using the default 
 # exponential backoff behavior; this is to accommodate some of the timeout settings in the E2E test specs.
@@ -208,6 +211,7 @@ do
             --namespace fleet-system \
             --create-namespace \
             --set config.hubURL=$HUB_SERVER_URL \
+            --set config.hubCA=$HUB_CA \
             --set image.repository=$REGISTRY/$MEMBER_AGENT_IMAGE \
             --set image.tag=$TAG \
             --set refreshtoken.repository=$REGISTRY/$REFRESH_TOKEN_IMAGE \
@@ -229,6 +233,7 @@ do
             --namespace fleet-system \
             --create-namespace \
             --set config.hubURL=$HUB_SERVER_URL \
+            --set config.hubCA=$HUB_CA \
             --set image.repository=$REGISTRY/$MEMBER_AGENT_IMAGE \
             --set image.tag=$TAG \
             --set refreshtoken.repository=$REGISTRY/$REFRESH_TOKEN_IMAGE \

--- a/test/upgrade/setup.sh
+++ b/test/upgrade/setup.sh
@@ -111,6 +111,9 @@ done
 kind export kubeconfig --name $HUB_CLUSTER
 HUB_SERVER_URL="https://$(docker inspect $HUB_CLUSTER-control-plane --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}'):6443"
 
+# Extract the hub cluster CA for secure TLS verification
+HUB_CA=$(kubectl config view --raw -o jsonpath='{.clusters[?(@.name=="kind-'$HUB_CLUSTER'")].cluster.certificate-authority-data}')
+
 # Install the member agents and related components.
 for (( i=0; i<${MEMBER_CLUSTER_COUNT}; i++ ));
 do
@@ -119,6 +122,7 @@ do
         --namespace fleet-system \
         --create-namespace \
         --set config.hubURL=$HUB_SERVER_URL \
+        --set config.hubCA=$HUB_CA \
         --set image.repository=$REGISTRY/$MEMBER_AGENT_IMAGE \
         --set image.tag=$IMAGE_TAG \
         --set refreshtoken.repository=$REGISTRY/$REFRESH_TOKEN_IMAGE \


### PR DESCRIPTION
### Description of your changes

Member uses TLS to communicate with hub by default. Also update scripts/docs everywhere.

With TLS being the default, we need to set hubCA everywhere

related to #216

I have:

- [x] Associated this change with a known KubeFleet Issue (Bug, Feature, etc).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
