### PR TITLE
fix: disable rolling out fleet namespace staged rollout custom resources

### DIFF
--- a/pkg/controllers/updaterun/controller.go
+++ b/pkg/controllers/updaterun/controller.go
@@ -150,6 +150,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req runtime.Request) (runtim
 		}
 		// Validate the updateRun status to ensure the update can be continued and get the updating stage index and cluster indices.
 		if updatingStageIndex, toBeUpdatedBindings, toBeDeletedBindings, reconcileErr = r.validate(ctx, updateRun); reconcileErr != nil {
+			klog.ErrorS(reconcileErr, "Failed to validate the updateRun", "updateRun", runObjRef)
 			// errStagedUpdatedAborted cannot be retried.
 			if errors.Is(reconcileErr, errStagedUpdatedAborted) {
 				return runtime.Result{}, r.recordUpdateRunFailed(ctx, updateRun, reconcileErr.Error())

--- a/pkg/utils/apiresources.go
+++ b/pkg/utils/apiresources.go
@@ -121,6 +121,21 @@ var (
 		Kind:  placementv1beta1.ClusterApprovalRequestKind,
 	}
 
+	StagedUpdateRunGK = schema.GroupKind{
+		Group: placementv1beta1.GroupVersion.Group,
+		Kind:  placementv1beta1.StagedUpdateRunKind,
+	}
+
+	StagedUpdateStrategyGK = schema.GroupKind{
+		Group: placementv1beta1.GroupVersion.Group,
+		Kind:  placementv1beta1.StagedUpdateStrategyKind,
+	}
+
+	ApprovalRequestGK = schema.GroupKind{
+		Group: placementv1beta1.GroupVersion.Group,
+		Kind:  placementv1beta1.ApprovalRequestKind,
+	}
+
 	ClusterResourcePlacementEvictionGK = schema.GroupKind{
 		Group: placementv1beta1.GroupVersion.Group,
 		Kind:  placementv1beta1.ClusterResourcePlacementEvictionKind,
@@ -210,6 +225,9 @@ func NewResourceConfig(isAllowList bool) *ResourceConfig {
 	r.AddGroupKind(ClusterStagedUpdateRunGK)
 	r.AddGroupKind(ClusterStagedUpdateStrategyGK)
 	r.AddGroupKind(ClusterApprovalRequestGK)
+	r.AddGroupKind(StagedUpdateRunGK)
+	r.AddGroupKind(StagedUpdateStrategyGK)
+	r.AddGroupKind(ApprovalRequestGK)
 	r.AddGroupKind(ClusterResourcePlacementEvictionGK)
 	r.AddGroupKind(ClusterResourcePlacementDisruptionBudgetGK)
 	r.AddGroupKind(ClusterResourceOverrideGK)

--- a/pkg/utils/apiresources_test.go
+++ b/pkg/utils/apiresources_test.go
@@ -19,11 +19,12 @@ package utils
 import (
 	"testing"
 
-	"github.com/kubefleet-dev/kubefleet/test/utils/resource"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/restmapper"
+
+	"github.com/kubefleet-dev/kubefleet/test/utils/resource"
 )
 
 func TestResourceConfigGVKParse(t *testing.T) {
@@ -527,6 +528,47 @@ func TestDefaultResourceConfigGroupVersionKindParse(t *testing.T) {
 			Group:   "placement.kubernetes-fleet.io",
 			Version: "v1",
 			Kind:    "ResourceOverrideSnapshot",
+		},
+		// Namespaced staged update resources (should also be disabled)
+		{
+			Group:   "placement.kubernetes-fleet.io",
+			Version: "v1beta1",
+			Kind:    "StagedUpdateRun",
+		},
+		{
+			Group:   "placement.kubernetes-fleet.io",
+			Version: "v1",
+			Kind:    "StagedUpdateRun",
+		},
+		{
+			Group:   "placement.kubernetes-fleet.io",
+			Version: "v1beta1",
+			Kind:    "StagedUpdateStrategy",
+		},
+		{
+			Group:   "placement.kubernetes-fleet.io",
+			Version: "v1",
+			Kind:    "StagedUpdateStrategy",
+		},
+		{
+			Group:   "placement.kubernetes-fleet.io",
+			Version: "v1beta1",
+			Kind:    "ApprovalRequest",
+		},
+		{
+			Group:   "placement.kubernetes-fleet.io",
+			Version: "v1",
+			Kind:    "ApprovalRequest",
+		},
+		{
+			Group:   "placement.kubernetes-fleet.io",
+			Version: "v1beta1",
+			Kind:    "ClusterResourcePlacementStatus",
+		},
+		{
+			Group:   "placement.kubernetes-fleet.io",
+			Version: "v1",
+			Kind:    "ClusterResourcePlacementStatus",
 		},
 	}
 


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that have a clear purpose. If yours fix an issue,
please uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #632

I have:
- Add namespace-scope staged rollout resources to be disabled.

- [x] Associated this change with a known KubeFleet Issue (Bug, Feature, etc).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

When selecting a namespace to rollout with all their resources, we currently allow  the namespace-scope stage rollout resources to be rolled out as well.
```
status:
  conditions:
    - lastTransitionTime: '2026-03-27T03:10:57Z'
      message: >-
        Detected the new changes on the resources and started the rollout
        process, resourceSnapshotIndex: , updateRun:
        staged-rollout-1774570211066
      observedGeneration: 2
      reason: RolloutStarted
      status: 'True'
      type: RolloutStarted
    - lastTransitionTime: '2026-04-20T05:26:38Z'
      message: No override rules are configured for the selected resources
      observedGeneration: 2
      reason: NoOverrideSpecified
      status: 'True'
      type: Overridden
    - lastTransitionTime: '2026-04-20T05:26:38Z'
      message: All of the works are synchronized to the latest
      observedGeneration: 2
      reason: AllWorkSynced
      status: 'True'
      type: WorkSynchronized
    - lastTransitionTime: '2026-04-20T05:26:38Z'
      message: Work object example-placement-work has failed to apply
      observedGeneration: 2
      reason: NotAllWorkHaveBeenApplied
      status: 'False'
      type: Applied
  failedPlacements:
    - condition:
        lastTransitionTime: '2026-03-27T04:39:30Z'
        message: >-
          Failed to apply the manifest (error: failed to take over a
          pre-existing object: the object is already owned by some other
          sources(s) and co-ownership is disallowed (existingOwnerRefs:
          [{APIVersion:placement.kubernetes-fleet.io/v1beta1 Kind:AppliedWork
          Name:rollout-selected-namespaces-1774585351581-work
          UID:274b6d2c-564b-4e71-aafe-40baad3d76da Controller:<nil>
          BlockOwnerDeletion:0xc00120894b}]))
        reason: FailedToTakeOver
        status: 'False'
        type: Applied
      kind: Namespace
      name: test-namespace
      version: v1
    - condition:
        lastTransitionTime: '2026-04-01T05:33:37Z'
        message: >-
          Failed to apply the manifest (error: failed to decode manifest: failed
          to find GVR from member cluster client REST mapping: no matches for
          kind "StagedUpdateRun" in version "placement.kubernetes-fleet.io/v1")
        reason: DecodingErred
        status: 'False'
        type: Applied
      group: placement.kubernetes-fleet.io
      kind: StagedUpdateRun
      name: example-run
      namespace: test-namespace
      version: v1
```
