### PR TITLE
fix: deterministic envelope Work names to prevent duplicates

### DIFF
--- a/pkg/controllers/workgenerator/envelope.go
+++ b/pkg/controllers/workgenerator/envelope.go
@@ -215,9 +215,9 @@ func refreshWorkForEnvelopeCR(
 // derived from the envelope's identity. Using a deterministic suffix (instead of a random
 // UUID) means two concurrent Create attempts for the same envelope collide on name at the
 // API server, which enforces the "one Work per (binding, envelope)" invariant server-side.
-// The hash is truncated to 16 hex characters (8 bytes of SHA-256), keeping the overall
-// Work name well under the DNS-1123 subdomain limit; collision probability at the scale
-// of a single binding's envelope set is ~2^-64.
+// The hash is truncated to 8 bytes of SHA-256 (rendered as 16 hex characters), keeping
+// the overall Work name well under the DNS-1123 subdomain limit; collision probability
+// at the scale of a single binding's envelope set is ~2^-64.
 func envelopeWorkNameSuffix(envelopeReader fleetv1beta1.EnvelopeReader) string {
 	// NOTE: ClusterResourceEnvelope has an empty namespace; ResourceEnvelope has a namespace.
 	// Including the type disambiguates an unlikely name collision across kinds.

--- a/pkg/controllers/workgenerator/envelope.go
+++ b/pkg/controllers/workgenerator/envelope.go
@@ -18,13 +18,15 @@ package workgenerator
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"sort"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -87,18 +89,27 @@ func (r *Reconciler) createOrUpdateEnvelopeCRWorkObj(
 	var work *fleetv1beta1.Work
 	switch {
 	case len(workList.Items) > 1:
-		// Multiple matching work objects found; this should never occur under normal conditions.
-		wrappedErr := fmt.Errorf("%d work objects found for the same envelope %v, only one expected", len(workList.Items), envelopeReader.GetEnvelopeObjRef())
-		klog.ErrorS(wrappedErr, "Failed to create or update work object for envelope",
-			"resourceBinding", klog.KObj(binding),
-			"resourceSnapshot", klog.KObj(resourceSnapshot),
-			"envelope", envelopeReader.GetEnvelopeObjRef())
-		// Log the work object names to help debug.
+		// Multiple matching work objects found. This can only happen in environments that
+		// were stuck on this state *before* deterministic Work naming was introduced in
+		// buildNewWorkForEnvelopeCR; newly-raced reconciles are now prevented by the
+		// API server's name-uniqueness check. We deliberately do NOT auto-delete the
+		// extras: both Works may have been applied by the member agent, and deleting one
+		// would trigger member-side resource cleanup and user-visible fluctuation on
+		// resources the survivor still owns. Surface the state for operator cleanup
+		// (manually delete all but the oldest Work in the affected namespace).
 		workNames := make([]string, len(workList.Items))
 		for i := range workList.Items {
 			workNames[i] = workList.Items[i].Name
 		}
-		klog.ErrorS(wrappedErr, "Duplicate work objects found", "works", workNames)
+		wrappedErr := fmt.Errorf("%d work objects found for the same envelope %v, only one expected", len(workList.Items), envelopeReader.GetEnvelopeObjRef())
+		klog.ErrorS(wrappedErr, "Duplicate envelope Work objects found; manual cleanup required — delete all but the oldest Work in the namespace",
+			"works", workNames,
+			"resourceBinding", klog.KObj(binding),
+			"resourceSnapshot", klog.KObj(resourceSnapshot),
+			"envelope", envelopeReader.GetEnvelopeObjRef())
+		r.recorder.Eventf(binding, corev1.EventTypeWarning, "DuplicateEnvelopeWorks",
+			"Multiple Work objects (%v) found for envelope %v in namespace %s; delete all but the oldest to recover",
+			workNames, envelopeReader.GetEnvelopeObjRef(), fmt.Sprintf(utils.NamespaceNameFormat, binding.GetBindingSpec().TargetCluster))
 		return nil, controller.NewUnexpectedBehaviorError(wrappedErr)
 	case len(workList.Items) == 1:
 		klog.V(2).InfoS("Found existing work object for the envelope; updating it",
@@ -200,6 +211,24 @@ func refreshWorkForEnvelopeCR(
 	work.Spec.ApplyStrategy = resourceBinding.GetBindingSpec().ApplyStrategy
 }
 
+// envelopeWorkNameSuffix returns a deterministic suffix for the envelope Work's name,
+// derived from the envelope's identity. Using a deterministic suffix (instead of a random
+// UUID) means two concurrent Create attempts for the same envelope collide on name at the
+// API server, which enforces the "one Work per (binding, envelope)" invariant server-side.
+// The hash is truncated to 16 hex characters (8 bytes of SHA-256), keeping the overall
+// Work name well under the DNS-1123 subdomain limit; collision probability at the scale
+// of a single binding's envelope set is ~2^-64.
+func envelopeWorkNameSuffix(envelopeReader fleetv1beta1.EnvelopeReader) string {
+	// NOTE: ClusterResourceEnvelope has an empty namespace; ResourceEnvelope has a namespace.
+	// Including the type disambiguates an unlikely name collision across kinds.
+	identity := fmt.Sprintf("%s/%s/%s",
+		envelopeReader.GetEnvelopeType(),
+		envelopeReader.GetNamespace(),
+		envelopeReader.GetName())
+	sum := sha256.Sum256([]byte(identity))
+	return hex.EncodeToString(sum[:8])
+}
+
 func buildNewWorkForEnvelopeCR(
 	workNamePrefix string,
 	resourceBinding fleetv1beta1.BindingObj,
@@ -208,7 +237,7 @@ func buildNewWorkForEnvelopeCR(
 	manifests []fleetv1beta1.Manifest,
 	resourceOverrideSnapshotHash, clusterResourceOverrideSnapshotHash string,
 ) *fleetv1beta1.Work {
-	workName := fmt.Sprintf(fleetv1beta1.WorkNameWithEnvelopeCRFmt, workNamePrefix, uuid.NewUUID())
+	workName := fmt.Sprintf(fleetv1beta1.WorkNameWithEnvelopeCRFmt, workNamePrefix, envelopeWorkNameSuffix(envelopeReader))
 	workNamespace := fmt.Sprintf(utils.NamespaceNameFormat, resourceBinding.GetBindingSpec().TargetCluster)
 
 	// Create the labels map

--- a/pkg/controllers/workgenerator/envelope_test.go
+++ b/pkg/controllers/workgenerator/envelope_test.go
@@ -17,8 +17,11 @@ limitations under the License.
 package workgenerator
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -26,14 +29,18 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	fleetv1beta1 "github.com/kubefleet-dev/kubefleet/apis/placement/v1beta1"
 	"github.com/kubefleet-dev/kubefleet/pkg/utils"
+	"github.com/kubefleet-dev/kubefleet/pkg/utils/controller"
 	"github.com/kubefleet-dev/kubefleet/test/utils/informer"
 )
+
+const testWorkNamePrefix = "test-work"
 
 func TestExtractManifestsFromEnvelopeCR(t *testing.T) {
 	tests := []struct {
@@ -255,8 +262,6 @@ func TestCreateOrUpdateEnvelopeCRWorkObj(t *testing.T) {
 	ignoreWorkMeta := cmpopts.IgnoreFields(metav1.ObjectMeta{}, "Name", "OwnerReferences")
 	scheme := serviceScheme(t)
 
-	workNamePrefix := "test-work"
-
 	resourceSnapshot := &fleetv1beta1.ClusterResourceSnapshot{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-snapshot",
@@ -306,7 +311,7 @@ func TestCreateOrUpdateEnvelopeCRWorkObj(t *testing.T) {
 	// Create an existing work for update test
 	existingWork := &fleetv1beta1.Work{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      workNamePrefix,
+			Name:      testWorkNamePrefix,
 			Namespace: "fleet-member-test-cluster-1",
 			Labels: map[string]string{
 				fleetv1beta1.ParentBindingLabel:     resourceBinding.Name,
@@ -483,7 +488,13 @@ func TestCreateOrUpdateEnvelopeCRWorkObj(t *testing.T) {
 			wantErr:                             true,
 		},
 		{
-			name:                                "two existing works should result in error",
+			// Duplicate envelope Works indicate an environment that was stuck before
+			// deterministic naming was introduced. The controller surfaces the state
+			// (error + Event) but does NOT auto-delete, because deleting a Work the
+			// member agent has already applied would trigger resource fluctuation on
+			// the member side. Full post-conditions are verified in
+			// TestCreateOrUpdateEnvelopeCRWorkObj_DuplicateWorksSurfaceWithoutMutation.
+			name:                                "two existing works surface an UnexpectedBehaviorError without mutation",
 			envelopeReader:                      resourceEnvelope,
 			resourceOverrideSnapshotHash:        "new-resource-hash",
 			clusterResourceOverrideSnapshotHash: "new-cluster-resource-hash",
@@ -512,7 +523,7 @@ func TestCreateOrUpdateEnvelopeCRWorkObj(t *testing.T) {
 			}
 
 			// Call the function under test
-			got, err := r.createOrUpdateEnvelopeCRWorkObj(ctx, tt.envelopeReader, workNamePrefix,
+			got, err := r.createOrUpdateEnvelopeCRWorkObj(ctx, tt.envelopeReader, testWorkNamePrefix,
 				resourceBinding, resourceSnapshot, tt.resourceOverrideSnapshotHash, tt.clusterResourceOverrideSnapshotHash)
 
 			if (err != nil) != tt.wantErr {
@@ -532,7 +543,6 @@ func TestCreateOrUpdateEnvelopeCRWorkObj(t *testing.T) {
 func TestProcessOneSelectedResource(t *testing.T) {
 	scheme := serviceScheme(t)
 
-	workNamePrefix := "test-work"
 	resourceBinding := &fleetv1beta1.ClusterResourceBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-binding",
@@ -685,7 +695,7 @@ func TestProcessOneSelectedResource(t *testing.T) {
 				tt.selectedResource,
 				resourceBinding,
 				snapshot,
-				workNamePrefix,
+				testWorkNamePrefix,
 				tt.resourceOverrideSnapshotHash,
 				tt.clusterResourceOverrideSnapshotHash,
 				activeWork,
@@ -724,4 +734,169 @@ func createResourceContent(t *testing.T, obj runtime.Object) *fleetv1beta1.Resou
 			Raw: jsonData,
 		},
 	}
+}
+
+// TestEnvelopeWorkNameSuffix verifies that the suffix is a stable, length-bounded function
+// of the envelope's identity. Determinism is what lets the API server enforce the
+// "one Work per (binding, envelope)" invariant via name uniqueness.
+func TestEnvelopeWorkNameSuffix(t *testing.T) {
+	resourceEnvelope := &fleetv1beta1.ResourceEnvelope{
+		ObjectMeta: metav1.ObjectMeta{Name: "env-a", Namespace: "ns-1"},
+	}
+	sameResourceEnvelope := &fleetv1beta1.ResourceEnvelope{
+		ObjectMeta: metav1.ObjectMeta{Name: "env-a", Namespace: "ns-1"},
+	}
+	differentName := &fleetv1beta1.ResourceEnvelope{
+		ObjectMeta: metav1.ObjectMeta{Name: "env-b", Namespace: "ns-1"},
+	}
+	differentNamespace := &fleetv1beta1.ResourceEnvelope{
+		ObjectMeta: metav1.ObjectMeta{Name: "env-a", Namespace: "ns-2"},
+	}
+	clusterEnvelope := &fleetv1beta1.ClusterResourceEnvelope{
+		ObjectMeta: metav1.ObjectMeta{Name: "env-a"}, // same name as resourceEnvelope, but cluster-scoped
+	}
+
+	// Same identity → identical suffix.
+	if got, want := envelopeWorkNameSuffix(resourceEnvelope), envelopeWorkNameSuffix(sameResourceEnvelope); got != want {
+		t.Errorf("envelopeWorkNameSuffix(%v) = %q, want %q (same identity should hash the same)", resourceEnvelope, got, want)
+	}
+
+	// Different identities → different suffixes.
+	for _, other := range []struct {
+		name string
+		r    fleetv1beta1.EnvelopeReader
+	}{
+		{"different name", differentName},
+		{"different namespace", differentNamespace},
+		{"different type (cluster-scoped vs namespaced, same name)", clusterEnvelope},
+	} {
+		if got, collision := envelopeWorkNameSuffix(resourceEnvelope), envelopeWorkNameSuffix(other.r); got == collision {
+			t.Errorf("envelopeWorkNameSuffix collision for %s: both %q", other.name, got)
+		}
+	}
+
+	// Suffix is bounded and DNS-1123-safe (lowercase hex).
+	suffix := envelopeWorkNameSuffix(resourceEnvelope)
+	if len(suffix) != 16 {
+		t.Errorf("envelopeWorkNameSuffix length = %d, want 16", len(suffix))
+	}
+	if strings.ToLower(suffix) != suffix {
+		t.Errorf("envelopeWorkNameSuffix(%v) = %q, want lowercase", resourceEnvelope, suffix)
+	}
+}
+
+// TestCreateOrUpdateEnvelopeCRWorkObj_DuplicateWorksSurfaceWithoutMutation verifies that
+// when the label query returns multiple Works for the same (binding, envelope), the
+// controller surfaces the condition (UnexpectedBehaviorError + Event) but does NOT
+// mutate cluster state. Auto-deleting duplicates is unsafe because the member agent
+// may have applied them; deleting one triggers resource cleanup that conflicts with
+// the survivor. Deterministic naming (see buildNewWorkForEnvelopeCR) prevents new
+// duplicates; pre-existing ones require operator cleanup.
+func TestCreateOrUpdateEnvelopeCRWorkObj_DuplicateWorksSurfaceWithoutMutation(t *testing.T) {
+	scheme := serviceScheme(t)
+	ctx := context.Background()
+
+	resourceSnapshot := &fleetv1beta1.ClusterResourceSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "test-snapshot",
+			Labels: map[string]string{fleetv1beta1.PlacementTrackingLabel: "test-crp"},
+		},
+	}
+	resourceBinding := &fleetv1beta1.ClusterResourceBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "test-binding",
+			Labels: map[string]string{fleetv1beta1.PlacementTrackingLabel: "test-crp"},
+		},
+		Spec: fleetv1beta1.ResourceBindingSpec{
+			TargetCluster:        "test-cluster-1",
+			ResourceSnapshotName: resourceSnapshot.Name,
+		},
+	}
+	resourceEnvelope := &fleetv1beta1.ResourceEnvelope{
+		ObjectMeta: metav1.ObjectMeta{Name: "dup-envelope", Namespace: "default"},
+		Data: map[string]runtime.RawExtension{
+			"configmap": {Raw: []byte(`{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"cm","namespace":"default"}}`)},
+		},
+	}
+
+	workNamespace := fmt.Sprintf(utils.NamespaceNameFormat, resourceBinding.Spec.TargetCluster)
+	labelsForWork := map[string]string{
+		fleetv1beta1.ParentBindingLabel:     resourceBinding.Name,
+		fleetv1beta1.PlacementTrackingLabel: resourceBinding.Labels[fleetv1beta1.PlacementTrackingLabel],
+		fleetv1beta1.EnvelopeTypeLabel:      string(fleetv1beta1.ResourceEnvelopeType),
+		fleetv1beta1.EnvelopeNameLabel:      resourceEnvelope.Name,
+		fleetv1beta1.EnvelopeNamespaceLabel: resourceEnvelope.Namespace,
+	}
+	dupNames := []string{"dup-envelope-a", "dup-envelope-b", "dup-envelope-c"}
+	mkWork := func(name string) *fleetv1beta1.Work {
+		return &fleetv1beta1.Work{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: workNamespace,
+				Labels:    labelsForWork,
+			},
+		}
+	}
+	objs := make([]client.Object, 0, len(dupNames))
+	for _, n := range dupNames {
+		objs = append(objs, mkWork(n))
+	}
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objs...).
+		Build()
+
+	recorder := record.NewFakeRecorder(10)
+	r := &Reconciler{
+		Client:          fakeClient,
+		recorder:        recorder,
+		InformerManager: &informer.FakeManager{},
+	}
+
+	got, err := r.createOrUpdateEnvelopeCRWorkObj(ctx, resourceEnvelope, testWorkNamePrefix,
+		resourceBinding, resourceSnapshot, "", "")
+
+	if got != nil {
+		t.Errorf("createOrUpdateEnvelopeCRWorkObj() = %v, want nil on duplicate-detected path", got)
+	}
+	if err == nil {
+		t.Fatalf("createOrUpdateEnvelopeCRWorkObj() error = nil, want UnexpectedBehaviorError")
+	}
+	if !errors.Is(err, controller.ErrUnexpectedBehavior) {
+		t.Errorf("createOrUpdateEnvelopeCRWorkObj() error = %v, want wrapping controller.ErrUnexpectedBehavior", err)
+	}
+
+	// Post-condition: all duplicates remain untouched — no auto-deletion.
+	remaining := &fleetv1beta1.WorkList{}
+	if err := fakeClient.List(ctx, remaining, client.InNamespace(workNamespace)); err != nil {
+		t.Fatalf("List Works in %q: %v", workNamespace, err)
+	}
+	if len(remaining.Items) != len(dupNames) {
+		t.Errorf("remaining Works = %d (%v), want %d (no mutation expected)",
+			len(remaining.Items), workNames(remaining.Items), len(dupNames))
+	}
+	for _, n := range dupNames {
+		var w fleetv1beta1.Work
+		if err := fakeClient.Get(ctx, types.NamespacedName{Namespace: workNamespace, Name: n}, &w); err != nil {
+			t.Errorf("Work %q missing after call, expected still present: %v", n, err)
+		}
+	}
+
+	// Post-condition: a Warning Event was emitted so operators can see the stuck state.
+	select {
+	case ev := <-recorder.Events:
+		if !strings.Contains(ev, "DuplicateEnvelopeWorks") {
+			t.Errorf("event = %q, want reason DuplicateEnvelopeWorks", ev)
+		}
+	default:
+		t.Error("no Event emitted for duplicate envelope Works; operators would have no surface signal")
+	}
+}
+
+func workNames(items []fleetv1beta1.Work) []string {
+	out := make([]string, len(items))
+	for i := range items {
+		out[i] = items[i].Name
+	}
+	return out
 }

--- a/pkg/controllers/workgenerator/envelope_test.go
+++ b/pkg/controllers/workgenerator/envelope_test.go
@@ -29,7 +29,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -740,48 +739,58 @@ func createResourceContent(t *testing.T, obj runtime.Object) *fleetv1beta1.Resou
 // of the envelope's identity. Determinism is what lets the API server enforce the
 // "one Work per (binding, envelope)" invariant via name uniqueness.
 func TestEnvelopeWorkNameSuffix(t *testing.T) {
-	resourceEnvelope := &fleetv1beta1.ResourceEnvelope{
+	base := &fleetv1beta1.ResourceEnvelope{
 		ObjectMeta: metav1.ObjectMeta{Name: "env-a", Namespace: "ns-1"},
 	}
-	sameResourceEnvelope := &fleetv1beta1.ResourceEnvelope{
-		ObjectMeta: metav1.ObjectMeta{Name: "env-a", Namespace: "ns-1"},
-	}
-	differentName := &fleetv1beta1.ResourceEnvelope{
-		ObjectMeta: metav1.ObjectMeta{Name: "env-b", Namespace: "ns-1"},
-	}
-	differentNamespace := &fleetv1beta1.ResourceEnvelope{
-		ObjectMeta: metav1.ObjectMeta{Name: "env-a", Namespace: "ns-2"},
-	}
-	clusterEnvelope := &fleetv1beta1.ClusterResourceEnvelope{
-		ObjectMeta: metav1.ObjectMeta{Name: "env-a"}, // same name as resourceEnvelope, but cluster-scoped
-	}
 
-	// Same identity → identical suffix.
-	if got, want := envelopeWorkNameSuffix(resourceEnvelope), envelopeWorkNameSuffix(sameResourceEnvelope); got != want {
-		t.Errorf("envelopeWorkNameSuffix(%v) = %q, want %q (same identity should hash the same)", resourceEnvelope, got, want)
-	}
-
-	// Different identities → different suffixes.
-	for _, other := range []struct {
-		name string
-		r    fleetv1beta1.EnvelopeReader
+	tests := []struct {
+		name      string
+		other     fleetv1beta1.EnvelopeReader
+		wantEqual bool // true → suffix must match base; false → suffix must differ
 	}{
-		{"different name", differentName},
-		{"different namespace", differentNamespace},
-		{"different type (cluster-scoped vs namespaced, same name)", clusterEnvelope},
-	} {
-		if got, collision := envelopeWorkNameSuffix(resourceEnvelope), envelopeWorkNameSuffix(other.r); got == collision {
-			t.Errorf("envelopeWorkNameSuffix collision for %s: both %q", other.name, got)
-		}
+		{
+			name:      "same identity",
+			other:     &fleetv1beta1.ResourceEnvelope{ObjectMeta: metav1.ObjectMeta{Name: "env-a", Namespace: "ns-1"}},
+			wantEqual: true,
+		},
+		{
+			name:      "different name",
+			other:     &fleetv1beta1.ResourceEnvelope{ObjectMeta: metav1.ObjectMeta{Name: "env-b", Namespace: "ns-1"}},
+			wantEqual: false,
+		},
+		{
+			name:      "different namespace",
+			other:     &fleetv1beta1.ResourceEnvelope{ObjectMeta: metav1.ObjectMeta{Name: "env-a", Namespace: "ns-2"}},
+			wantEqual: false,
+		},
+		{
+			// Same name as base, but cluster-scoped — the type field in the hash input disambiguates.
+			name:      "different type, same name",
+			other:     &fleetv1beta1.ClusterResourceEnvelope{ObjectMeta: metav1.ObjectMeta{Name: "env-a"}},
+			wantEqual: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotBase := envelopeWorkNameSuffix(base)
+			gotOther := envelopeWorkNameSuffix(tt.other)
+			if tt.wantEqual && gotBase != gotOther {
+				t.Errorf("envelopeWorkNameSuffix(%v) = %q, envelopeWorkNameSuffix(%v) = %q, want equal", base, gotBase, tt.other, gotOther)
+			}
+			if !tt.wantEqual && gotBase == gotOther {
+				t.Errorf("envelopeWorkNameSuffix(%v) = envelopeWorkNameSuffix(%v) = %q, want different", base, tt.other, gotBase)
+			}
+		})
 	}
 
 	// Suffix is bounded and DNS-1123-safe (lowercase hex).
-	suffix := envelopeWorkNameSuffix(resourceEnvelope)
+	suffix := envelopeWorkNameSuffix(base)
 	if len(suffix) != 16 {
 		t.Errorf("envelopeWorkNameSuffix length = %d, want 16", len(suffix))
 	}
 	if strings.ToLower(suffix) != suffix {
-		t.Errorf("envelopeWorkNameSuffix(%v) = %q, want lowercase", resourceEnvelope, suffix)
+		t.Errorf("envelopeWorkNameSuffix(%v) = %q, want lowercase", base, suffix)
 	}
 }
 
@@ -871,15 +880,9 @@ func TestCreateOrUpdateEnvelopeCRWorkObj_DuplicateWorksSurfaceWithoutMutation(t 
 	if err := fakeClient.List(ctx, remaining, client.InNamespace(workNamespace)); err != nil {
 		t.Fatalf("List Works in %q: %v", workNamespace, err)
 	}
-	if len(remaining.Items) != len(dupNames) {
-		t.Errorf("remaining Works = %d (%v), want %d (no mutation expected)",
-			len(remaining.Items), workNames(remaining.Items), len(dupNames))
-	}
-	for _, n := range dupNames {
-		var w fleetv1beta1.Work
-		if err := fakeClient.Get(ctx, types.NamespacedName{Namespace: workNamespace, Name: n}, &w); err != nil {
-			t.Errorf("Work %q missing after call, expected still present: %v", n, err)
-		}
+	sortStrings := cmpopts.SortSlices(func(a, b string) bool { return a < b })
+	if diff := cmp.Diff(dupNames, workNames(remaining.Items), sortStrings); diff != "" {
+		t.Errorf("Works after call mismatch (-want +got):\n%s", diff)
 	}
 
 	// Post-condition: a Warning Event was emitted so operators can see the stuck state.


### PR DESCRIPTION
### Description of your changes

Envelope Work names were generated with a fresh `uuid.NewUUID()` on every Create, so two back-to-back reconciles of the same binding with a stale informer-cache List could each build a Work with different names and both succeed. The `len > 1` branch then returned `UnexpectedBehaviorError` without any recovery, leaving the binding permanently stuck in `WorkSynchronized=False/SyncWorkFailed` and the placement never converging on that cluster.

`buildNewWorkForEnvelopeCR` now derives the name suffix from a truncated SHA-256 hash of `(envelope type, namespace, name)`. Two concurrent Creates for the same `(binding, envelope)` produce the same name and collide at the API server; the existing `AlreadyExists` handling in `upsertWork` requeues into the `len == 1` update branch.

When the `len > 1` state is still observed (possible only in environments that were stuck before this change), the controller now emits a Warning Event on the binding (reason=`DuplicateEnvelopeWorks`) and a clear log message instructing the operator to delete all but the oldest Work in the affected namespace. See **Special notes** for why auto-deletion was deliberately avoided.

Fixes #630

I have:

- [x] Associated this change with a known KubeFleet Issue (Bug, Feature, etc).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

**Unit tests** (`pkg/controllers/workgenerator/envelope_test.go`):
- `TestEnvelopeWorkNameSuffix` — determinism, cross-identity uniqueness (different name, different namespace, different type all hash differently), fixed length (16 hex chars), lowercase DNS-1123-safe format.
- `TestCreateOrUpdateEnvelopeCRWorkObj_DuplicateWorksSurfaceWithoutMutation` — when multiple Works match the label query, the function returns `ErrUnexpectedBehavior`, **no Work is deleted**, and a `DuplicateEnvelopeWorks` Event is emitted.
- Existing `TestCreateOrUpdateEnvelopeCRWorkObj` table case updated: "two existing works surface an UnexpectedBehaviorError without mutation".
- All existing tests in the workgenerator package still pass; lint (`make lint`) clean.

**Live-cluster reproduction** (Kind hub + 3 members, fresh build of hub-agent with this change):
1. Created a CRP selecting a namespace containing a `ResourceEnvelope`.
2. Verified all 3 member-cluster namespaces got the same deterministic Work name suffix (`ad22e36a8e622bff`), derived from the envelope identity — confirming Fix 1.
3. Injected a duplicate Work by cloning the real one with a new name but identical labels (simulates the state an environment stuck on the race would be in). Confirmed:
   - Binding transitions to `WorkSynchronized: False, Reason: SyncWorkFailed` with the byte-identical message `"Failed to synchronize the work to the latest: 2 work objects found for the same envelope <ns>/<envelope>, only one expected"`.
   - **Both Works remain** — no auto-delete.
   - `DuplicateEnvelopeWorks` Warning Event is present on the binding with cleanup instructions.
   - Hub-agent log contains `"Duplicate envelope Work objects found; manual cleanup required"`.
4. Manually deleted the extra Work (simulating operator intervention). Binding recovered to `AllWorkSynced` within ~8 seconds.

**Edge case — same envelope name, different namespaces:** two CRPs, each selecting a namespace containing a `ResourceEnvelope` named `shared-name`. The generated Work names differ (`8671af501951ff8c` vs. `f430c5e4da73cda1`), because the namespace is part of the hash input.

**Soak — 40-minute envelope-focused `ginkgo --until-it-fails -p` loop** against the fixed build:
- 37 clean iterations, 740 specs total, 0 failures.
- Duplicate-Work watcher (`kubectl get works -l envelope-work` polled every 3s) fired zero times.
- No `SyncWorkFailed`, no `Duplicate work objects`, no `manual cleanup required` log entries.
- For reference: on unpatched `main`, this CI path flakes at ~7.5% per run. Probability of 37 clean iterations if the bug still existed: `(1 − 0.075)^37 ≈ 5.3%`.

### Special notes for your reviewer

**Why not auto-delete duplicates?** An earlier draft of this change deduplicated on detection (kept the oldest by `CreationTimestamp`, deleted the rest). That was withdrawn after feedback from @michaelawyu: once created, Works can be reconciled by the member agent and lead to resource creation; deleting a Work that the member agent has already applied triggers resource removal on the member side and causes user-visible fluctuation. The current change detects and surfaces but does not mutate. Pre-existing stuck deployments require one-time manual cleanup (delete all but the oldest Work matching the `parent-resource-binding` + `envelope-name` labels in the affected `fleet-member-<cluster>` namespace).

**Relationship to broader work:** @michaelawyu mentioned an adjacent task to "remove the scheduler raw list" covering a similar read/write consistency pattern, and flagged resource-version-based consistent views as the longer-term direction. This change takes a compatible but different angle — pushing the `one Work per (binding, envelope)` invariant into the API server's name-uniqueness check via deterministic naming. It can coexist with a future resource-version-based lookup and does not preclude it.

**Upgrade behavior:** existing envelope Works with UUID-based names are unaffected. On the first reconcile after upgrade, the `len == 1` branch at `envelope.go:103-110` updates the existing Work in place via `refreshWorkForEnvelopeCR` — no rename, no churn. New Works (for new envelopes, new CRPs, or after an envelope is deleted and recreated) get the deterministic name. Clusters end up with a mix, both work correctly; over time, UUID-named Works age out naturally. No migration step required.

**Hash format:** truncated to 8 bytes (16 hex characters) of SHA-256 over `"<type>/<namespace>/<name>"`. Collision probability per binding's envelope set is ~2^-64. No code in the codebase parses the suffix portion of the Work name — identity is carried by labels — so the naming change is safe.