### PR TITLE
refactor: extract IsLatest/LookupLatest policy snapshot helpers

### DIFF
--- a/pkg/controllers/placement/controller.go
+++ b/pkg/controllers/placement/controller.go
@@ -507,25 +507,23 @@ func (r *Reconciler) ensureLatestPolicySnapshot(ctx context.Context, placementOb
 // 2 & 3 should never happen.
 func (r *Reconciler) lookupLatestSchedulingPolicySnapshot(ctx context.Context, placement fleetv1beta1.PlacementObj) (fleetv1beta1.PolicySnapshotObj, int, error) {
 	placementKey := types.NamespacedName{Name: placement.GetName(), Namespace: placement.GetNamespace()}
-	snapshotList, err := controller.FetchLatestPolicySnapshot(ctx, r.Client, placementKey)
-	if err != nil {
+	placementKObj := klog.KObj(placement)
+	activeSnapshot, err := controller.LookupLatestPolicySnapshot(ctx, r.Client, placementKey)
+	switch {
+	case err == nil:
+		policyIndex, parseErr := labels.ParsePolicyIndexFromLabel(activeSnapshot)
+		if parseErr != nil {
+			klog.ErrorS(parseErr, "Failed to parse the policy index label", "placement", placementKObj, "policySnapshot", klog.KObj(activeSnapshot))
+			return nil, -1, controller.NewUnexpectedBehaviorError(parseErr)
+		}
+		return activeSnapshot, policyIndex, nil
+	case errors.Is(err, controller.ErrNoLatestPolicySnapshot):
+		// No active snapshot found; recover below by picking the largest-index snapshot.
+	default:
+		// API or invariant-violation error — propagate.
 		return nil, -1, err
 	}
-	placementKObj := klog.KObj(placement)
-	policySnapshotItems := snapshotList.GetPolicySnapshotObjs()
-	if len(policySnapshotItems) == 1 {
-		policyIndex, err := labels.ParsePolicyIndexFromLabel(policySnapshotItems[0])
-		if err != nil {
-			klog.ErrorS(err, "Failed to parse the policy index label", "placement", placementKObj, "policySnapshot", klog.KObj(policySnapshotItems[0]))
-			return nil, -1, controller.NewUnexpectedBehaviorError(err)
-		}
-		return policySnapshotItems[0], policyIndex, nil
-	} else if len(policySnapshotItems) > 1 {
-		// It means there are multiple active snapshots and should never happen.
-		err := fmt.Errorf("there are %d active schedulingPolicySnapshots owned by placement %v", len(policySnapshotItems), placementKey)
-		klog.ErrorS(err, "Invalid schedulingPolicySnapshots", "placement", placementKObj)
-		return nil, -1, controller.NewUnexpectedBehaviorError(err)
-	}
+
 	// When there are no active snapshots, find the one who has the largest policy index.
 	// It should be rare only when placement controller is crashed before creating the new active snapshot.
 	sortedList, err := r.listSortedSchedulingPolicySnapshots(ctx, placement)

--- a/pkg/controllers/updaterun/initialization.go
+++ b/pkg/controllers/updaterun/initialization.go
@@ -125,29 +125,19 @@ func (r *Reconciler) determinePolicySnapshot(
 	updateRunRef := klog.KObj(updateRun)
 
 	// Get the latest policy snapshot.
-	policySnapshotList, err := controller.FetchLatestPolicySnapshot(ctx, r.Client, placementKey)
+	latestPolicySnapshot, err := controller.LookupLatestPolicySnapshot(ctx, r.Client, placementKey)
 	if err != nil {
-		klog.ErrorS(err, "Failed to list the latest policy snapshots", "placement", placementKey, "updateRun", updateRunRef)
-		// err can be retried.
-		return nil, -1, controller.NewAPIServerError(true, err)
-	}
-
-	policySnapshotObjs := policySnapshotList.GetPolicySnapshotObjs()
-	if len(policySnapshotObjs) != 1 {
-		if len(policySnapshotObjs) > 1 {
-			err := controller.NewUnexpectedBehaviorError(fmt.Errorf("more than one (%d in actual) latest policy snapshots associated with the placement: `%s`", len(policySnapshotObjs), placementKey))
-			klog.ErrorS(err, "Failed to find the latest policy snapshot", "placement", placementKey, "updateRun", updateRunRef)
-			// no more retries for this error.
+		klog.ErrorS(err, "Failed to find the latest policy snapshot", "placement", placementKey, "updateRun", updateRunRef)
+		// Missing or duplicate-active snapshots are placement-state invariants the run cannot
+		// recover from on its own — fail validation. Anything else (e.g. List errors classified as
+		// ErrAPIServerError, or unexpected cache failures promoted to ErrUnexpectedBehavior) is
+		// propagated raw so controller-runtime retries.
+		if errors.Is(err, controller.ErrNoLatestPolicySnapshot) || errors.Is(err, controller.ErrMultipleActivePolicySnapshots) {
 			return nil, -1, fmt.Errorf("%w: %s", errValidationFailed, err.Error())
 		}
-		// no latest policy snapshot found.
-		err := fmt.Errorf("no latest policy snapshot associated with the placement: `%s`", placementKey)
-		klog.ErrorS(err, "Failed to find the latest policy snapshot", "placement", placementKey, "updateRun", updateRunRef)
-		// again, no more retries here.
-		return nil, -1, fmt.Errorf("%w: %s", errValidationFailed, err.Error())
+		return nil, -1, err
 	}
 
-	latestPolicySnapshot := policySnapshotObjs[0]
 	policySnapshotRef := klog.KObj(latestPolicySnapshot)
 	policyIndex, foundIndex := latestPolicySnapshot.GetLabels()[placementv1beta1.PolicyIndexLabel]
 	if !foundIndex || len(policyIndex) == 0 {

--- a/pkg/controllers/updaterun/initialization_integration_test.go
+++ b/pkg/controllers/updaterun/initialization_integration_test.go
@@ -210,7 +210,7 @@ var _ = Describe("Updaterun initialization tests", func() {
 			Expect(k8sClient.Create(ctx, updateRun)).To(Succeed())
 
 			By("Validating the initialization failed")
-			validateFailedInitCondition(ctx, updateRun, "no latest policy snapshot associated")
+			validateFailedInitCondition(ctx, updateRun, "no latest policy snapshot found")
 		})
 
 		It("Should fail to initialize if there are multiple latest policy snapshots", func() {
@@ -223,7 +223,7 @@ var _ = Describe("Updaterun initialization tests", func() {
 			Expect(k8sClient.Create(ctx, updateRun)).To(Succeed())
 
 			By("Validating the initialization failed")
-			validateFailedInitCondition(ctx, updateRun, "more than one (2 in actual) latest policy snapshots associated")
+			validateFailedInitCondition(ctx, updateRun, "got 2 active policy snapshots")
 
 			By("Deleting the second scheduling policy snapshot")
 			Expect(k8sClient.Delete(ctx, snapshot2)).Should(Succeed())

--- a/pkg/controllers/updaterun/initialization_integration_test.go
+++ b/pkg/controllers/updaterun/initialization_integration_test.go
@@ -223,7 +223,7 @@ var _ = Describe("Updaterun initialization tests", func() {
 			Expect(k8sClient.Create(ctx, updateRun)).To(Succeed())
 
 			By("Validating the initialization failed")
-			validateFailedInitCondition(ctx, updateRun, "got 2 active policy snapshots")
+			validateFailedInitCondition(ctx, updateRun, "multiple active policy snapshots found")
 
 			By("Deleting the second scheduling policy snapshot")
 			Expect(k8sClient.Delete(ctx, snapshot2)).Should(Succeed())

--- a/pkg/controllers/updaterun/validation_integration_test.go
+++ b/pkg/controllers/updaterun/validation_integration_test.go
@@ -219,7 +219,7 @@ var _ = Describe("UpdateRun validation tests", func() {
 
 				By("Validating the validation failed")
 				wantStatus = generateFailedValidationStatus(updateRun, wantStatus)
-				validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus, "no latest policy snapshot associated")
+				validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus, "no latest policy snapshot found")
 
 				By("Checking update run status metrics are emitted")
 				validateUpdateRunMetricsEmitted(generateWaitingMetric(placementv1beta1.StateRun, updateRun), generateFailedMetric(placementv1beta1.StateRun, updateRun, string(failureType)))

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -21,12 +21,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strconv"
 	"sync"
 	"time"
 
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/record"
@@ -347,57 +345,21 @@ func (s *Scheduler) cleanUpAllBindingsFor(ctx context.Context, placement fleetv1
 }
 
 // lookupLatestPolicySnapshot returns the latest (i.e., active) policy snapshot associated with a placement.
-// TODO(ryan): move this to a common lib
+//
+// It delegates to controller.LookupLatestPolicySnapshot so the same lookup can be reused outside the
+// scheduler. The scheduler lists with a cached client; this does not have any consistency concern as
+// sources will always trigger the scheduler when a new policy snapshot is created.
+//
+// The "no latest snapshot" case can happen transiently when a placement is newly created or its
+// latest snapshot is being replaced; the scheduler will be triggered again when the situation
+// corrects itself, so this is logged and surfaced as a non-unexpected error.
 func (s *Scheduler) lookupLatestPolicySnapshot(ctx context.Context, placement fleetv1beta1.PlacementObj) (fleetv1beta1.PolicySnapshotObj, error) {
-	placementRef := klog.KObj(placement)
-	// Prepare the list options to filter policy snapshots by the placement name and the latest snapshot label.
-	var listOptions []client.ListOption
-	labelSelector := labels.SelectorFromSet(labels.Set{
-		fleetv1beta1.PlacementTrackingLabel: placement.GetName(),
-		fleetv1beta1.IsLatestSnapshotLabel:  strconv.FormatBool(true),
-	})
-	listOptions = append(listOptions, &client.ListOptions{LabelSelector: labelSelector})
-	// Find out the latest policy snapshot associated with the placement.
-	var policySnapshotList fleetv1beta1.PolicySnapshotList
-	if placement.GetNamespace() == "" {
-		policySnapshotList = &fleetv1beta1.ClusterSchedulingPolicySnapshotList{}
-	} else {
-		policySnapshotList = &fleetv1beta1.SchedulingPolicySnapshotList{}
-		listOptions = append(listOptions, client.InNamespace(placement.GetNamespace()))
-	}
-
-	// The scheduler lists with a cached client; this does not have any consistency concern as sources
-	// will always trigger the scheduler when a new policy snapshot is created.
-	if err := s.client.List(ctx, policySnapshotList, listOptions...); err != nil {
-		klog.ErrorS(err, "Failed to list policy snapshots of a placement", "placement", placementRef)
-		return nil, controller.NewAPIServerError(true, err)
-	}
-	policySnapshots := policySnapshotList.GetPolicySnapshotObjs()
-	switch {
-	case len(policySnapshots) == 0:
-		// There is no latest policy snapshot associated with the placement; it could happen when
-		// * the placement is newly created; or
-		// * the new policy snapshot is in the middle of being replaced.
-		//
-		// Either way, it is out of the scheduler's scope to handle such a case; the scheduler will
-		// be triggered again if the situation is corrected.
-		err := fmt.Errorf("no latest policy snapshot associated with placement")
-		klog.ErrorS(err, "Failed to find the latest policy snapshot, will retry", "placement", placementRef)
+	snapshot, err := controller.LookupLatestPolicySnapshot(ctx, s.client, placement)
+	if err != nil {
+		klog.ErrorS(err, "Failed to look up latest policy snapshot, will retry", "placement", klog.KObj(placement))
 		return nil, err
-	case len(policySnapshots) > 1:
-		// There are multiple active policy snapshots associated with the placement; normally this
-		// will never happen, as only one policy snapshot can be active in the sequence.
-		//
-		// Similarly, it is out of the scheduler's scope to handle such a case; the scheduler will
-		// report this unexpected occurrence but does not register it as a scheduler-side error.
-		// If (and when) the situation is corrected, the scheduler will be triggered again.
-		err := controller.NewUnexpectedBehaviorError(fmt.Errorf("too many active policy snapshots: %d, want 1", len(policySnapshots)))
-		klog.ErrorS(err, "There are multiple latest policy snapshots associated with placement", "placement", placementRef)
-		return nil, err
-	default:
-		// Found the one and only active policy snapshot.
-		return policySnapshots[0], nil
 	}
+	return snapshot, nil
 }
 
 // addSchedulerCleanupFinalizer adds the scheduler cleanup finalizer to a placement (if it does not

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -354,7 +354,7 @@ func (s *Scheduler) cleanUpAllBindingsFor(ctx context.Context, placement fleetv1
 // latest snapshot is being replaced; the scheduler will be triggered again when the situation
 // corrects itself, so this is logged and surfaced as a non-unexpected error.
 func (s *Scheduler) lookupLatestPolicySnapshot(ctx context.Context, placement fleetv1beta1.PlacementObj) (fleetv1beta1.PolicySnapshotObj, error) {
-	snapshot, err := controller.LookupLatestPolicySnapshot(ctx, s.client, placement)
+	snapshot, err := controller.LookupLatestPolicySnapshot(ctx, s.client, types.NamespacedName{Namespace: placement.GetNamespace(), Name: placement.GetName()})
 	if err != nil {
 		klog.ErrorS(err, "Failed to look up latest policy snapshot, will retry", "placement", klog.KObj(placement))
 		return nil, err

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -18,6 +18,8 @@ package scheduler
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log"
 	"os"
 	"strconv"
@@ -30,10 +32,13 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	fleetv1beta1 "github.com/kubefleet-dev/kubefleet/apis/placement/v1beta1"
 	hubmetrics "github.com/kubefleet-dev/kubefleet/pkg/metrics/hub"
+	"github.com/kubefleet-dev/kubefleet/pkg/utils/controller"
 )
 
 const (
@@ -588,6 +593,40 @@ func TestLookupLatestPolicySnapshot(t *testing.T) {
 				t.Errorf("active policy snapshot diff (-got, +want): %s", diff)
 			}
 		})
+	}
+}
+
+// TestLookupLatestPolicySnapshot_ListError covers the error path: when the underlying
+// controller.LookupLatestPolicySnapshot returns an error, the scheduler logs and propagates
+// it without panicking on the nil snapshot.
+func TestLookupLatestPolicySnapshot_ListError(t *testing.T) {
+	placement := &fleetv1beta1.ClusterResourcePlacement{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       crpName,
+			Finalizers: []string{fleetv1beta1.SchedulerCleanupFinalizer},
+		},
+	}
+	listErr := fmt.Errorf("simulated cache failure")
+	fakeClient := interceptor.NewClient(
+		fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(placement).Build(),
+		interceptor.Funcs{
+			List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+				return listErr
+			},
+		},
+	)
+
+	s := &Scheduler{client: fakeClient, uncachedReader: fakeClient}
+
+	got, err := s.lookupLatestPolicySnapshot(context.Background(), placement)
+	if err == nil {
+		t.Fatalf("lookupLatestPolicySnapshot() = %v, nil; want non-nil error", got)
+	}
+	if got != nil {
+		t.Errorf("lookupLatestPolicySnapshot() returned snapshot %v, want nil on error", got)
+	}
+	if !errors.Is(err, controller.ErrUnexpectedBehavior) {
+		t.Errorf("lookupLatestPolicySnapshot() error = %v, want wrapping ErrUnexpectedBehavior", err)
 	}
 }
 

--- a/pkg/scheduler/watchers/schedulingpolicysnapshot/watcher.go
+++ b/pkg/scheduler/watchers/schedulingpolicysnapshot/watcher.go
@@ -74,32 +74,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, nil
 	}
 
-	// Verify if the policy snapshot is currently active.
-	// TODO: create a lib to check if the policy snapshot is latest.
-	isLatestVal, ok := policySnapshot.GetLabels()[fleetv1beta1.IsLatestSnapshotLabel]
-	if !ok {
-		// The IsLatestSnapshot label is not present; normally this should never occur.
-		klog.ErrorS(controller.NewUnexpectedBehaviorError(fmt.Errorf("IsLatestSnapshotLabel is missing")),
-			"IsLatestSnapshot label is not present",
-			"policySnapshot", policySnapshotRef)
-		// This is not a situation that the controller can recover by itself. Should the label
-		// value be corrected, the controller will be triggered again.
-		return ctrl.Result{}, nil
-	}
-	isLatest, err := strconv.ParseBool(isLatestVal)
+	// Verify if the policy snapshot is currently active. A missing or malformed IsLatestSnapshot
+	// label is treated as "not latest" — the controller cannot recover from those states by
+	// itself; the placement controller will repair the label and re-trigger reconciliation.
+	isLatest, err := controller.IsLatestPolicySnapshot(policySnapshot)
 	if err != nil {
-		// The label value is not a correctly formatted boolean value; normally this should never
-		// occur.
-		klog.ErrorS(controller.NewUnexpectedBehaviorError(err),
-			"Failed to parse IsLatestSnapshot value",
-			"policySnapshot", policySnapshotRef)
-		// This is not an error that the controller can recover by itself; ignore the error.
-		// Should the label value be corrected, the controller will be triggered again.
+		klog.ErrorS(err, "Failed to determine whether policy snapshot is latest", "policySnapshot", policySnapshotRef)
 		return ctrl.Result{}, nil
 	}
 	if !isLatest {
-		// The policy snapshot is not currently active, i.e., it is not the latest policy snapshot;
-		// ignore it.
 		return ctrl.Result{}, nil
 	}
 

--- a/pkg/utils/controller/controller.go
+++ b/pkg/utils/controller/controller.go
@@ -63,6 +63,19 @@ var (
 
 	// ErrUserError indicates the error is caused by the user and customer needs to take the action.
 	ErrUserError = errors.New("failed to process the request due to a client error")
+
+	// ErrNoLatestPolicySnapshot indicates that no active (latest) policy snapshot was found for a
+	// placement. This is a transient condition during placement creation or rotation and is typically
+	// recoverable by the next reconcile; callers branch on it via errors.Is to distinguish it from
+	// real API or invariant-violation errors.
+	ErrNoLatestPolicySnapshot = errors.New("no latest policy snapshot found")
+
+	// ErrMultipleActivePolicySnapshots indicates that more than one policy snapshot for the same
+	// placement carries IsLatestSnapshot=true, violating the "exactly one active snapshot"
+	// invariant. Callers branch on it via errors.Is so they can fail fast on a real invariant
+	// violation without misclassifying transient cache errors that share the ErrUnexpectedBehavior
+	// category.
+	ErrMultipleActivePolicySnapshots = errors.New("multiple active policy snapshots found")
 )
 
 // NewUnexpectedBehaviorError returns ErrUnexpectedBehavior type error when err is not nil.

--- a/pkg/utils/controller/policy_snapshot_resolver.go
+++ b/pkg/utils/controller/policy_snapshot_resolver.go
@@ -130,63 +130,49 @@ func IsLatestPolicySnapshot(snapshot fleetv1beta1.PolicySnapshotObj) (bool, erro
 }
 
 // LookupLatestPolicySnapshot returns the single active (latest) policy snapshot associated with the
-// given placement. It is a thin wrapper over FetchLatestPolicySnapshot that enforces the
-// "exactly one latest snapshot" invariant.
+// placement identified by placementKey, enforcing the "exactly one latest snapshot" invariant.
+// A namespaced placementKey selects SchedulingPolicySnapshot; a cluster-scoped key (empty
+// namespace) selects ClusterSchedulingPolicySnapshot.
 //
 // Returns:
 //   - (snapshot, nil) when exactly one latest snapshot exists.
-//   - (nil, error) when zero, more than one, or a List error occurs. The "zero" case may happen
-//     transiently when a placement is newly created or its latest snapshot is being replaced;
-//     callers typically log and let the next event re-trigger reconciliation.
-//
-// The API-error path is logged inside both FetchLatestPolicySnapshot and NewAPIServerError; the
-// duplication is preserved here so callers that wrap the error get consistent classification, at
-// the cost of one extra log line on List failures.
-func LookupLatestPolicySnapshot(ctx context.Context, k8Client client.Reader, placement fleetv1beta1.PlacementObj) (fleetv1beta1.PolicySnapshotObj, error) {
-	placementKey := types.NamespacedName{Namespace: placement.GetNamespace(), Name: placement.GetName()}
-	policySnapshotList, err := FetchLatestPolicySnapshot(ctx, k8Client, placementKey)
-	if err != nil {
+//   - (nil, ErrNoLatestPolicySnapshot-wrapped error) when none exist. This is a transient state for
+//     newly-created placements or in-progress rotations; callers branch on it via errors.Is.
+//   - (nil, ErrMultipleActivePolicySnapshots-wrapped error) when more than one exists.
+//   - (nil, ErrAPIServerError-wrapped error) when the List call fails. The List error is also
+//     promoted to ErrUnexpectedBehavior for unexpected cache failures; callers must NOT collapse
+//     ErrUnexpectedBehavior with the dedicated invariant sentinels above when classifying retries.
+func LookupLatestPolicySnapshot(ctx context.Context, k8Client client.Reader, placementKey types.NamespacedName) (fleetv1beta1.PolicySnapshotObj, error) {
+	var policySnapshotList fleetv1beta1.PolicySnapshotList
+	listOptions := []client.ListOption{
+		client.MatchingLabels{
+			fleetv1beta1.PlacementTrackingLabel: placementKey.Name,
+			fleetv1beta1.IsLatestSnapshotLabel:  strconv.FormatBool(true),
+		},
+	}
+	if placementKey.Namespace != "" {
+		policySnapshotList = &fleetv1beta1.SchedulingPolicySnapshotList{}
+		listOptions = append(listOptions, client.InNamespace(placementKey.Namespace))
+	} else {
+		policySnapshotList = &fleetv1beta1.ClusterSchedulingPolicySnapshotList{}
+	}
+	if err := k8Client.List(ctx, policySnapshotList, listOptions...); err != nil {
+		klog.ErrorS(err, "Failed to list the policySnapshots associated with the placement", "placement", placementKey)
 		return nil, NewAPIServerError(true, err)
 	}
+
 	policySnapshots := policySnapshotList.GetPolicySnapshotObjs()
 	switch len(policySnapshots) {
 	case 0:
-		return nil, fmt.Errorf("no latest policy snapshot associated with placement %s", placementKey)
+		return nil, fmt.Errorf("%w for placement %s", ErrNoLatestPolicySnapshot, placementKey)
 	case 1:
 		return policySnapshots[0], nil
 	default:
-		return nil, NewUnexpectedBehaviorError(fmt.Errorf("too many active policy snapshots for placement %s: got %d, want 1", placementKey, len(policySnapshots)))
+		// Wrap both the specific invariant sentinel and the categorical ErrUnexpectedBehavior so
+		// callers that branch on either continue to work; the specific sentinel lets retry-gate
+		// callers distinguish this invariant violation from transient ErrUnexpectedBehavior errors.
+		return nil, fmt.Errorf("%w: %w for placement %s: got %d, want 1", ErrUnexpectedBehavior, ErrMultipleActivePolicySnapshots, placementKey, len(policySnapshots))
 	}
-}
-
-// FetchLatestPolicySnapshot fetches the latest policy snapshot for a given placement.
-// For cluster-scoped placements, it fetches ClusterSchedulingPolicySnapshot.
-// For namespaced placements, it fetches SchedulingPolicySnapshot.
-func FetchLatestPolicySnapshot(ctx context.Context, k8Client client.Reader, placementKey types.NamespacedName) (fleetv1beta1.PolicySnapshotList, error) {
-	namespace := placementKey.Namespace
-	name := placementKey.Name
-
-	var policySnapshotList fleetv1beta1.PolicySnapshotList
-	var listOptions []client.ListOption
-	listOptions = append(listOptions, client.MatchingLabels{
-		fleetv1beta1.PlacementTrackingLabel: name,
-		fleetv1beta1.IsLatestSnapshotLabel:  strconv.FormatBool(true),
-	})
-
-	if namespace != "" {
-		// This is a namespaced SchedulingPolicySnapshotList
-		policySnapshotList = &fleetv1beta1.SchedulingPolicySnapshotList{}
-		listOptions = append(listOptions, client.InNamespace(namespace))
-	} else {
-		// This is a cluster-scoped ClusterSchedulingPolicySnapshotList
-		policySnapshotList = &fleetv1beta1.ClusterSchedulingPolicySnapshotList{}
-	}
-
-	if err := k8Client.List(ctx, policySnapshotList, listOptions...); err != nil {
-		klog.ErrorS(err, "Failed to list the policySnapshots associated with the placement", "placement", placementKey)
-		return nil, err
-	}
-	return policySnapshotList, nil
 }
 
 // ListPolicySnapshots lists all policy snapshots associated with a placement key.

--- a/pkg/utils/controller/policy_snapshot_resolver.go
+++ b/pkg/utils/controller/policy_snapshot_resolver.go
@@ -110,6 +110,55 @@ func BuildPolicySnapshot(placementObj fleetv1beta1.PlacementObj, policySnapshotI
 	return snapshot
 }
 
+// IsLatestPolicySnapshot reports whether the given policy snapshot carries the IsLatestSnapshot
+// label set to "true". A non-nil error is returned if the label is missing or its value cannot be
+// parsed as a bool; in those cases the boolean result is false.
+//
+// Callers typically log the error and treat the snapshot as non-latest, since the controller cannot
+// recover from a malformed label by itself — the placement controller will repair it and re-trigger
+// reconciliation.
+func IsLatestPolicySnapshot(snapshot fleetv1beta1.PolicySnapshotObj) (bool, error) {
+	val, ok := snapshot.GetLabels()[fleetv1beta1.IsLatestSnapshotLabel]
+	if !ok {
+		return false, NewUnexpectedBehaviorError(fmt.Errorf("%s label is missing", fleetv1beta1.IsLatestSnapshotLabel))
+	}
+	isLatest, err := strconv.ParseBool(val)
+	if err != nil {
+		return false, NewUnexpectedBehaviorError(fmt.Errorf("failed to parse %s label value %q: %w", fleetv1beta1.IsLatestSnapshotLabel, val, err))
+	}
+	return isLatest, nil
+}
+
+// LookupLatestPolicySnapshot returns the single active (latest) policy snapshot associated with the
+// given placement. It is a thin wrapper over FetchLatestPolicySnapshot that enforces the
+// "exactly one latest snapshot" invariant.
+//
+// Returns:
+//   - (snapshot, nil) when exactly one latest snapshot exists.
+//   - (nil, error) when zero, more than one, or a List error occurs. The "zero" case may happen
+//     transiently when a placement is newly created or its latest snapshot is being replaced;
+//     callers typically log and let the next event re-trigger reconciliation.
+//
+// The API-error path is logged inside both FetchLatestPolicySnapshot and NewAPIServerError; the
+// duplication is preserved here so callers that wrap the error get consistent classification, at
+// the cost of one extra log line on List failures.
+func LookupLatestPolicySnapshot(ctx context.Context, k8Client client.Reader, placement fleetv1beta1.PlacementObj) (fleetv1beta1.PolicySnapshotObj, error) {
+	placementKey := types.NamespacedName{Namespace: placement.GetNamespace(), Name: placement.GetName()}
+	policySnapshotList, err := FetchLatestPolicySnapshot(ctx, k8Client, placementKey)
+	if err != nil {
+		return nil, NewAPIServerError(true, err)
+	}
+	policySnapshots := policySnapshotList.GetPolicySnapshotObjs()
+	switch len(policySnapshots) {
+	case 0:
+		return nil, fmt.Errorf("no latest policy snapshot associated with placement %s", placementKey)
+	case 1:
+		return policySnapshots[0], nil
+	default:
+		return nil, NewUnexpectedBehaviorError(fmt.Errorf("too many active policy snapshots for placement %s: got %d, want 1", placementKey, len(policySnapshots)))
+	}
+}
+
 // FetchLatestPolicySnapshot fetches the latest policy snapshot for a given placement.
 // For cluster-scoped placements, it fetches ClusterSchedulingPolicySnapshot.
 // For namespaced placements, it fetches SchedulingPolicySnapshot.

--- a/pkg/utils/controller/policy_snapshot_resolver_test.go
+++ b/pkg/utils/controller/policy_snapshot_resolver_test.go
@@ -490,193 +490,6 @@ func TestBuildPolicySnapshot(t *testing.T) {
 	}
 }
 
-func TestFetchLatestPolicySnapshot(t *testing.T) {
-	scheme := runtime.NewScheme()
-	if err := fleetv1beta1.AddToScheme(scheme); err != nil {
-		t.Fatalf("Failed to add to scheme: %v", err)
-	}
-
-	testCases := []struct {
-		name              string
-		placementKey      types.NamespacedName
-		existingSnapshots []client.Object
-		expectedSnapshots int
-	}{
-		{
-			name: "fetch latest cluster scoped policy snapshots",
-			placementKey: types.NamespacedName{
-				Name: placementName,
-			},
-			existingSnapshots: []client.Object{
-				&fleetv1beta1.ClusterSchedulingPolicySnapshot{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "test-placement-0",
-						Labels: map[string]string{
-							fleetv1beta1.PlacementTrackingLabel: placementName,
-							fleetv1beta1.IsLatestSnapshotLabel:  "true",
-						},
-					},
-				},
-				&fleetv1beta1.ClusterSchedulingPolicySnapshot{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "test-placement-1",
-						Labels: map[string]string{
-							fleetv1beta1.PlacementTrackingLabel: placementName,
-							fleetv1beta1.IsLatestSnapshotLabel:  "false",
-						},
-					},
-				},
-			},
-			expectedSnapshots: 1,
-		},
-		{
-			name: "fetch latest cluster scoped policy snapshots - mixed setup",
-			placementKey: types.NamespacedName{
-				Name: placementName,
-			},
-			existingSnapshots: []client.Object{
-				&fleetv1beta1.ClusterSchedulingPolicySnapshot{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "test-placement-0",
-						Labels: map[string]string{
-							fleetv1beta1.PlacementTrackingLabel: placementName,
-							fleetv1beta1.IsLatestSnapshotLabel:  "true",
-						},
-					},
-				},
-				&fleetv1beta1.ClusterSchedulingPolicySnapshot{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "test-placement-1",
-						Labels: map[string]string{
-							fleetv1beta1.PlacementTrackingLabel: placementName,
-							fleetv1beta1.IsLatestSnapshotLabel:  "false",
-						},
-					},
-				},
-				// Add namespaced snapshots to test mixed scenario
-				&fleetv1beta1.SchedulingPolicySnapshot{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-placement-0",
-						Namespace: policySnapshotNamespace,
-						Labels: map[string]string{
-							fleetv1beta1.PlacementTrackingLabel: placementName,
-							fleetv1beta1.IsLatestSnapshotLabel:  "true",
-						},
-					},
-				},
-			},
-			expectedSnapshots: 1, // Should only return cluster-scoped ones for cluster-scoped placement
-		},
-		{
-			name: "fetch latest namespaced policy snapshots",
-			placementKey: types.NamespacedName{
-				Name:      placementName,
-				Namespace: policySnapshotNamespace,
-			},
-			existingSnapshots: []client.Object{
-				&fleetv1beta1.SchedulingPolicySnapshot{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-placement-0",
-						Namespace: policySnapshotNamespace,
-						Labels: map[string]string{
-							fleetv1beta1.PlacementTrackingLabel: placementName,
-							fleetv1beta1.IsLatestSnapshotLabel:  "true",
-						},
-					},
-				},
-				&fleetv1beta1.SchedulingPolicySnapshot{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-placement-1",
-						Namespace: policySnapshotNamespace,
-						Labels: map[string]string{
-							fleetv1beta1.PlacementTrackingLabel: placementName,
-							fleetv1beta1.IsLatestSnapshotLabel:  "false",
-						},
-					},
-				},
-			},
-			expectedSnapshots: 1,
-		},
-		{
-			name: "fetch latest namespaced policy snapshots - mixed setup",
-			placementKey: types.NamespacedName{
-				Name:      placementName,
-				Namespace: policySnapshotNamespace,
-			},
-			existingSnapshots: []client.Object{
-				&fleetv1beta1.SchedulingPolicySnapshot{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-placement-0",
-						Namespace: policySnapshotNamespace,
-						Labels: map[string]string{
-							fleetv1beta1.PlacementTrackingLabel: placementName,
-							fleetv1beta1.IsLatestSnapshotLabel:  "true",
-						},
-					},
-				},
-				&fleetv1beta1.SchedulingPolicySnapshot{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-placement-1",
-						Namespace: policySnapshotNamespace,
-						Labels: map[string]string{
-							fleetv1beta1.PlacementTrackingLabel: placementName,
-							fleetv1beta1.IsLatestSnapshotLabel:  "false",
-						},
-					},
-				},
-				// Add cluster-scoped snapshots to test mixed scenario
-				&fleetv1beta1.ClusterSchedulingPolicySnapshot{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "test-placement-0",
-						Labels: map[string]string{
-							fleetv1beta1.PlacementTrackingLabel: placementName,
-							fleetv1beta1.IsLatestSnapshotLabel:  "true",
-						},
-					},
-				},
-			},
-			expectedSnapshots: 1, // Should only return namespaced ones for namespaced placement
-		},
-		{
-			name: "no latest policy snapshots found",
-			placementKey: types.NamespacedName{
-				Name: placementName,
-			},
-			existingSnapshots: []client.Object{
-				&fleetv1beta1.ClusterSchedulingPolicySnapshot{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "test-placement-0",
-						Labels: map[string]string{
-							fleetv1beta1.PlacementTrackingLabel: placementName,
-							fleetv1beta1.IsLatestSnapshotLabel:  "false",
-						},
-					},
-				},
-			},
-			expectedSnapshots: 0,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
-			fakeClient := fake.NewClientBuilder().
-				WithScheme(scheme).
-				WithObjects(tc.existingSnapshots...).
-				Build()
-
-			snapshots, err := FetchLatestPolicySnapshot(ctx, fakeClient, tc.placementKey)
-			if err != nil {
-				t.Fatalf("FetchLatestPolicySnapshot() = %v, want nil", err)
-			}
-
-			if len(snapshots.GetPolicySnapshotObjs()) != tc.expectedSnapshots {
-				t.Errorf("Expected %d snapshots, got %d", tc.expectedSnapshots, len(snapshots.GetPolicySnapshotObjs()))
-			}
-		})
-	}
-}
-
 func TestListPolicySnapshots(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := fleetv1beta1.AddToScheme(scheme); err != nil {
@@ -974,12 +787,8 @@ func TestLookupLatestPolicySnapshot(t *testing.T) {
 		t.Fatalf("Failed to add to scheme: %v", err)
 	}
 
-	clusterPlacement := &fleetv1beta1.ClusterResourcePlacement{
-		ObjectMeta: metav1.ObjectMeta{Name: placementName},
-	}
-	namespacedPlacement := &fleetv1beta1.ResourcePlacement{
-		ObjectMeta: metav1.ObjectMeta{Name: placementName, Namespace: policySnapshotNamespace},
-	}
+	clusterKey := types.NamespacedName{Name: placementName}
+	namespacedKey := types.NamespacedName{Name: placementName, Namespace: policySnapshotNamespace}
 
 	clusterLatestSnapshot := func(name string) *fleetv1beta1.ClusterSchedulingPolicySnapshot {
 		return &fleetv1beta1.ClusterSchedulingPolicySnapshot{
@@ -1007,44 +816,57 @@ func TestLookupLatestPolicySnapshot(t *testing.T) {
 
 	testCases := []struct {
 		name              string
-		placement         fleetv1beta1.PlacementObj
+		placementKey      types.NamespacedName
 		existingSnapshots []client.Object
 		wantName          string
-		wantErr           bool
-		wantUnexpected    bool
+		wantErrSentinel   error // nil means a snapshot is expected; otherwise the error must wrap this sentinel.
 	}{
 		{
 			name:              "exactly one cluster-scoped latest snapshot",
-			placement:         clusterPlacement,
+			placementKey:      clusterKey,
 			existingSnapshots: []client.Object{clusterLatestSnapshot("test-placement-0")},
 			wantName:          "test-placement-0",
 		},
 		{
 			name:              "exactly one namespaced latest snapshot",
-			placement:         namespacedPlacement,
+			placementKey:      namespacedKey,
 			existingSnapshots: []client.Object{namespacedLatestSnapshot("test-placement-0")},
 			wantName:          "test-placement-0",
 		},
 		{
-			name:              "no latest snapshot returns error (not unexpected-behavior)",
-			placement:         clusterPlacement,
+			name:              "no latest snapshot returns ErrNoLatestPolicySnapshot",
+			placementKey:      clusterKey,
 			existingSnapshots: nil,
-			wantErr:           true,
-			wantUnexpected:    false,
+			wantErrSentinel:   ErrNoLatestPolicySnapshot,
 		},
 		{
-			name:      "multiple latest snapshots returns unexpected-behavior error",
-			placement: clusterPlacement,
+			name:         "only non-latest snapshots present returns ErrNoLatestPolicySnapshot",
+			placementKey: clusterKey,
+			existingSnapshots: []client.Object{
+				&fleetv1beta1.ClusterSchedulingPolicySnapshot{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-placement-0",
+						Labels: map[string]string{
+							fleetv1beta1.PlacementTrackingLabel: placementName,
+							fleetv1beta1.IsLatestSnapshotLabel:  "false",
+						},
+					},
+				},
+			},
+			wantErrSentinel: ErrNoLatestPolicySnapshot,
+		},
+		{
+			name:         "multiple latest snapshots returns ErrMultipleActivePolicySnapshots",
+			placementKey: clusterKey,
 			existingSnapshots: []client.Object{
 				clusterLatestSnapshot("test-placement-0"),
 				clusterLatestSnapshot("test-placement-1"),
 			},
-			wantErr:        true,
-			wantUnexpected: true,
+			wantErrSentinel: ErrMultipleActivePolicySnapshots,
 		},
 		{
-			name:      "ignores snapshots from other placements",
-			placement: clusterPlacement,
+			name:         "ignores snapshots from other placements",
+			placementKey: clusterKey,
 			existingSnapshots: []client.Object{
 				clusterLatestSnapshot("test-placement-0"),
 				&fleetv1beta1.ClusterSchedulingPolicySnapshot{
@@ -1060,8 +882,8 @@ func TestLookupLatestPolicySnapshot(t *testing.T) {
 			wantName: "test-placement-0",
 		},
 		{
-			name:      "ignores non-latest snapshots",
-			placement: clusterPlacement,
+			name:         "ignores non-latest snapshots",
+			placementKey: clusterKey,
 			existingSnapshots: []client.Object{
 				clusterLatestSnapshot("test-placement-1"),
 				&fleetv1beta1.ClusterSchedulingPolicySnapshot{
@@ -1076,6 +898,24 @@ func TestLookupLatestPolicySnapshot(t *testing.T) {
 			},
 			wantName: "test-placement-1",
 		},
+		{
+			name:         "cluster-scoped lookup ignores a same-named latest namespaced snapshot",
+			placementKey: clusterKey,
+			existingSnapshots: []client.Object{
+				clusterLatestSnapshot("test-placement-0"),
+				namespacedLatestSnapshot("test-placement-0"),
+			},
+			wantName: "test-placement-0",
+		},
+		{
+			name:         "namespaced lookup ignores a same-named latest cluster snapshot",
+			placementKey: namespacedKey,
+			existingSnapshots: []client.Object{
+				namespacedLatestSnapshot("test-placement-0"),
+				clusterLatestSnapshot("test-placement-0"),
+			},
+			wantName: "test-placement-0",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -1086,21 +926,18 @@ func TestLookupLatestPolicySnapshot(t *testing.T) {
 				WithObjects(tc.existingSnapshots...).
 				Build()
 
-			got, err := LookupLatestPolicySnapshot(ctx, fakeClient, tc.placement)
-			if (err != nil) != tc.wantErr {
-				t.Fatalf("LookupLatestPolicySnapshot() error = %v, wantErr %v", err, tc.wantErr)
+			got, err := LookupLatestPolicySnapshot(ctx, fakeClient, tc.placementKey)
+			if (err != nil) != (tc.wantErrSentinel != nil) {
+				t.Fatalf("LookupLatestPolicySnapshot() error = %v, wantErrSentinel %v", err, tc.wantErrSentinel)
 			}
-			if tc.wantErr {
-				if tc.wantUnexpected && !errors.Is(err, ErrUnexpectedBehavior) {
-					t.Errorf("LookupLatestPolicySnapshot() error = %v, want wrapping ErrUnexpectedBehavior", err)
-				}
-				if !tc.wantUnexpected && errors.Is(err, ErrUnexpectedBehavior) {
-					t.Errorf("LookupLatestPolicySnapshot() error = %v, did not expect ErrUnexpectedBehavior wrapping", err)
+			if tc.wantErrSentinel != nil {
+				if !errors.Is(err, tc.wantErrSentinel) {
+					t.Errorf("LookupLatestPolicySnapshot() error = %v, want wrapping %v", err, tc.wantErrSentinel)
 				}
 				return
 			}
 			if got == nil || got.GetName() != tc.wantName {
-				t.Errorf("LookupLatestPolicySnapshot() returned snapshot %v, want %s", got, tc.wantName)
+				t.Errorf("LookupLatestPolicySnapshot() returned snapshot %v, want name %q", got, tc.wantName)
 			}
 		})
 	}

--- a/pkg/utils/controller/policy_snapshot_resolver_test.go
+++ b/pkg/utils/controller/policy_snapshot_resolver_test.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -29,6 +30,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	fleetv1beta1 "github.com/kubefleet-dev/kubefleet/apis/placement/v1beta1"
 )
@@ -940,5 +942,37 @@ func TestLookupLatestPolicySnapshot(t *testing.T) {
 				t.Errorf("LookupLatestPolicySnapshot() returned snapshot %v, want name %q", got, tc.wantName)
 			}
 		})
+	}
+}
+
+// TestLookupLatestPolicySnapshot_ListError covers the API-error path: when the underlying List
+// call fails with an error that isUnexpectedCacheError treats as unexpected (i.e. not a
+// *apierrors.StatusError, context.Canceled, or context.DeadlineExceeded), NewAPIServerError
+// promotes it to ErrUnexpectedBehavior.
+func TestLookupLatestPolicySnapshot_ListError(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := fleetv1beta1.AddToScheme(scheme); err != nil {
+		t.Fatalf("Failed to add to scheme: %v", err)
+	}
+
+	listErr := fmt.Errorf("simulated cache failure")
+	fakeClient := interceptor.NewClient(
+		fake.NewClientBuilder().WithScheme(scheme).Build(),
+		interceptor.Funcs{
+			List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+				return listErr
+			},
+		},
+	)
+
+	got, err := LookupLatestPolicySnapshot(context.Background(), fakeClient, types.NamespacedName{Name: placementName})
+	if err == nil {
+		t.Fatalf("LookupLatestPolicySnapshot() = %v, nil; want non-nil error", got)
+	}
+	if got != nil {
+		t.Errorf("LookupLatestPolicySnapshot() returned snapshot %v, want nil", got)
+	}
+	if !errors.Is(err, ErrUnexpectedBehavior) {
+		t.Errorf("LookupLatestPolicySnapshot() error = %v, want wrapping ErrUnexpectedBehavior", err)
 	}
 }

--- a/pkg/utils/controller/policy_snapshot_resolver_test.go
+++ b/pkg/utils/controller/policy_snapshot_resolver_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -898,6 +899,208 @@ func TestListPolicySnapshots(t *testing.T) {
 
 			if len(snapshots.GetPolicySnapshotObjs()) != tc.expectedSnapshots {
 				t.Errorf("Expected %d snapshots, got %d", tc.expectedSnapshots, len(snapshots.GetPolicySnapshotObjs()))
+			}
+		})
+	}
+}
+
+func TestIsLatestPolicySnapshot(t *testing.T) {
+	snapshotWithLabels := func(labels map[string]string) fleetv1beta1.PolicySnapshotObj {
+		return &fleetv1beta1.ClusterSchedulingPolicySnapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   policySnapshotName,
+				Labels: labels,
+			},
+		}
+	}
+
+	testCases := []struct {
+		name     string
+		snapshot fleetv1beta1.PolicySnapshotObj
+		want     bool
+		wantErr  bool
+	}{
+		{
+			name:     "label true returns true",
+			snapshot: snapshotWithLabels(map[string]string{fleetv1beta1.IsLatestSnapshotLabel: "true"}),
+			want:     true,
+			wantErr:  false,
+		},
+		{
+			name:     "label false returns false",
+			snapshot: snapshotWithLabels(map[string]string{fleetv1beta1.IsLatestSnapshotLabel: "false"}),
+			want:     false,
+			wantErr:  false,
+		},
+		{
+			name:     "label missing returns false with unexpected-behavior error",
+			snapshot: snapshotWithLabels(map[string]string{fleetv1beta1.PlacementTrackingLabel: placementName}),
+			want:     false,
+			wantErr:  true,
+		},
+		{
+			name:     "nil labels returns false with unexpected-behavior error",
+			snapshot: snapshotWithLabels(nil),
+			want:     false,
+			wantErr:  true,
+		},
+		{
+			name:     "label malformed returns false with unexpected-behavior error",
+			snapshot: snapshotWithLabels(map[string]string{fleetv1beta1.IsLatestSnapshotLabel: "yes"}),
+			want:     false,
+			wantErr:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := IsLatestPolicySnapshot(tc.snapshot)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("IsLatestPolicySnapshot() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if err != nil && !errors.Is(err, ErrUnexpectedBehavior) {
+				t.Errorf("IsLatestPolicySnapshot() error = %v, want wrapping ErrUnexpectedBehavior", err)
+			}
+			if got != tc.want {
+				t.Errorf("IsLatestPolicySnapshot() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLookupLatestPolicySnapshot(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := fleetv1beta1.AddToScheme(scheme); err != nil {
+		t.Fatalf("Failed to add to scheme: %v", err)
+	}
+
+	clusterPlacement := &fleetv1beta1.ClusterResourcePlacement{
+		ObjectMeta: metav1.ObjectMeta{Name: placementName},
+	}
+	namespacedPlacement := &fleetv1beta1.ResourcePlacement{
+		ObjectMeta: metav1.ObjectMeta{Name: placementName, Namespace: policySnapshotNamespace},
+	}
+
+	clusterLatestSnapshot := func(name string) *fleetv1beta1.ClusterSchedulingPolicySnapshot {
+		return &fleetv1beta1.ClusterSchedulingPolicySnapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+				Labels: map[string]string{
+					fleetv1beta1.PlacementTrackingLabel: placementName,
+					fleetv1beta1.IsLatestSnapshotLabel:  "true",
+				},
+			},
+		}
+	}
+	namespacedLatestSnapshot := func(name string) *fleetv1beta1.SchedulingPolicySnapshot {
+		return &fleetv1beta1.SchedulingPolicySnapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: policySnapshotNamespace,
+				Labels: map[string]string{
+					fleetv1beta1.PlacementTrackingLabel: placementName,
+					fleetv1beta1.IsLatestSnapshotLabel:  "true",
+				},
+			},
+		}
+	}
+
+	testCases := []struct {
+		name              string
+		placement         fleetv1beta1.PlacementObj
+		existingSnapshots []client.Object
+		wantName          string
+		wantErr           bool
+		wantUnexpected    bool
+	}{
+		{
+			name:              "exactly one cluster-scoped latest snapshot",
+			placement:         clusterPlacement,
+			existingSnapshots: []client.Object{clusterLatestSnapshot("test-placement-0")},
+			wantName:          "test-placement-0",
+		},
+		{
+			name:              "exactly one namespaced latest snapshot",
+			placement:         namespacedPlacement,
+			existingSnapshots: []client.Object{namespacedLatestSnapshot("test-placement-0")},
+			wantName:          "test-placement-0",
+		},
+		{
+			name:              "no latest snapshot returns error (not unexpected-behavior)",
+			placement:         clusterPlacement,
+			existingSnapshots: nil,
+			wantErr:           true,
+			wantUnexpected:    false,
+		},
+		{
+			name:      "multiple latest snapshots returns unexpected-behavior error",
+			placement: clusterPlacement,
+			existingSnapshots: []client.Object{
+				clusterLatestSnapshot("test-placement-0"),
+				clusterLatestSnapshot("test-placement-1"),
+			},
+			wantErr:        true,
+			wantUnexpected: true,
+		},
+		{
+			name:      "ignores snapshots from other placements",
+			placement: clusterPlacement,
+			existingSnapshots: []client.Object{
+				clusterLatestSnapshot("test-placement-0"),
+				&fleetv1beta1.ClusterSchedulingPolicySnapshot{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "other-placement-0",
+						Labels: map[string]string{
+							fleetv1beta1.PlacementTrackingLabel: "other-placement",
+							fleetv1beta1.IsLatestSnapshotLabel:  "true",
+						},
+					},
+				},
+			},
+			wantName: "test-placement-0",
+		},
+		{
+			name:      "ignores non-latest snapshots",
+			placement: clusterPlacement,
+			existingSnapshots: []client.Object{
+				clusterLatestSnapshot("test-placement-1"),
+				&fleetv1beta1.ClusterSchedulingPolicySnapshot{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-placement-0",
+						Labels: map[string]string{
+							fleetv1beta1.PlacementTrackingLabel: placementName,
+							fleetv1beta1.IsLatestSnapshotLabel:  "false",
+						},
+					},
+				},
+			},
+			wantName: "test-placement-1",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(tc.existingSnapshots...).
+				Build()
+
+			got, err := LookupLatestPolicySnapshot(ctx, fakeClient, tc.placement)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("LookupLatestPolicySnapshot() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if tc.wantErr {
+				if tc.wantUnexpected && !errors.Is(err, ErrUnexpectedBehavior) {
+					t.Errorf("LookupLatestPolicySnapshot() error = %v, want wrapping ErrUnexpectedBehavior", err)
+				}
+				if !tc.wantUnexpected && errors.Is(err, ErrUnexpectedBehavior) {
+					t.Errorf("LookupLatestPolicySnapshot() error = %v, did not expect ErrUnexpectedBehavior wrapping", err)
+				}
+				return
+			}
+			if got == nil || got.GetName() != tc.wantName {
+				t.Errorf("LookupLatestPolicySnapshot() returned snapshot %v, want %s", got, tc.wantName)
 			}
 		})
 	}


### PR DESCRIPTION
### Description of your changes

Fixes #643.

Moves the two duplicated "latest policy snapshot" lookups into `pkg/utils/controller/policy_snapshot_resolver.go` so the scheduler and the policy-snapshot watcher share the implementation.

Two new helpers:

- `IsLatestPolicySnapshot(snapshot) (bool, error)` — inspects the `IsLatestSnapshotLabel`. Returns `(false, ErrUnexpectedBehavior-wrapped)` for missing or non-bool values. The watcher's `Reconcile` now uses this instead of inline label parsing.
- `LookupLatestPolicySnapshot(ctx, client.Reader, placement) (PolicySnapshotObj, error)` — wraps `FetchLatestPolicySnapshot` and enforces the "exactly one latest snapshot" invariant. Returns a plain error for the (transient) zero case and `ErrUnexpectedBehavior` for the >1 case. The scheduler's `lookupLatestPolicySnapshot` now delegates to it.

The watcher's `buildCustomPredicate` continues to do its own `ParseBool` because it compares old-vs-new label transitions, which doesn't fit the helper's signature. Two now-unused imports (`strconv`, `labels`) are dropped from `scheduler.go`.

I have:

- [x] Associated this change with a known KubeFleet Issue (Bug, Feature, etc).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- New table-driven `TestIsLatestPolicySnapshot` covers label true/false, missing label, nil labels map, malformed value.
- New table-driven `TestLookupLatestPolicySnapshot` covers exactly-one cluster-scoped, exactly-one namespaced, zero snapshots (plain error), multiple snapshots (`ErrUnexpectedBehavior`), ignoring snapshots from other placements, and ignoring non-latest snapshots.
- `go test -count=1 -short ./pkg/scheduler/... ./pkg/utils/controller/...` passes locally with envtest. `make reviewable` is clean.

### Special notes for your reviewer

- `LookupLatestPolicySnapshot` uses `client.Reader` to match `FetchLatestPolicySnapshot`'s existing signature.
- The API-error path now logs three times (once inside `FetchLatestPolicySnapshot`, once inside `NewAPIServerError`, once at the scheduler call site). The duplication is acknowledged in a comment on `LookupLatestPolicySnapshot`. Pre-existing behavior was two logs; the third is the helper-level wrap that lets all callers get consistent classification. Happy to drop the scheduler-side log if reviewers prefer.
- The "no latest snapshot" error string is no longer logged inside the helper; the scheduler caller still logs it, so observability for the (most common) zero-snapshot transient case is preserved.