### PR TITLE
feat: harden property selector validation

### DIFF
--- a/pkg/utils/controller/resource_selector_resolver.go
+++ b/pkg/utils/controller/resource_selector_resolver.go
@@ -201,9 +201,9 @@ func generateRawContent(object *unstructured.Unstructured) ([]byte, error) {
 
 		vals, found, err := unstructured.NestedFieldNoCopy(object.Object, "spec", "ports")
 		if found && err == nil {
-			if ports, ok := vals.([]interface{}); ok {
+			if ports, ok := vals.([]any); ok {
 				for i := range ports {
-					if each, ok := ports[i].(map[string]interface{}); ok {
+					if each, ok := ports[i].(map[string]any); ok {
 						delete(each, "nodePort")
 					}
 				}
@@ -523,7 +523,8 @@ func (rs *ResourceSelectorResolver) fetchResources(selector placementv1beta1.Res
 
 	lister := rs.InformerManager.Lister(gvr)
 
-	// TODO: validator should enforce the mutual exclusiveness between the `name` and `labelSelector` fields
+	// Mutual exclusiveness between `name` and `labelSelector` is enforced by the placement
+	// validator (see pkg/utils/validator/placement.go validatePlacement).
 	if len(selector.Name) != 0 {
 		var obj runtime.Object
 		var err error
@@ -553,7 +554,9 @@ func (rs *ResourceSelectorResolver) fetchResources(selector placementv1beta1.Res
 	if selector.LabelSelector == nil {
 		labelSelector = labels.Everything()
 	} else {
-		// TODO: validator should enforce the validity of the labelSelector
+		// LabelSelector validity is enforced by the placement validator (see
+		// pkg/utils/validator/placement.go validateLabelSelector). The conversion error path
+		// remains as a defensive guard.
 		labelSelector, err = metav1.LabelSelectorAsSelector(selector.LabelSelector)
 		if err != nil {
 			return nil, NewUnexpectedBehaviorError(fmt.Errorf("cannot convert the label selector to a selector: %w", err))

--- a/pkg/utils/validator/placement.go
+++ b/pkg/utils/validator/placement.go
@@ -450,17 +450,22 @@ func validatePropertySelector(propertySelector *placementv1beta1.PropertySelecto
 
 func validatePropertySelectorRequirements(propertySelectorRequirements []placementv1beta1.PropertySelectorRequirement) error {
 	var allErr []error
+	// Group requirements by property name so we can also check cross-requirement
+	// contradictions (e.g., Eq 5 alongside Eq 10, or Gt 10 alongside Lt 5).
+	byName := make(map[string][]placementv1beta1.PropertySelectorRequirement, len(propertySelectorRequirements))
 	for _, req := range propertySelectorRequirements {
 		if err := validateName(req.Name); err != nil {
 			allErr = append(allErr, fmt.Errorf("invalid property name %s: %w", req.Name, err))
 		}
-		if err := validateOperator(req.Operator, req.Values); err != nil {
-			allErr = append(allErr, err)
+		if err := validateOperatorAndValues(req.Operator, req.Values); err != nil {
+			allErr = append(allErr, fmt.Errorf("invalid requirement on property %s: %w", req.Name, err))
 		}
-		if err := validateValues(req.Values); err != nil {
-			allErr = append(allErr, fmt.Errorf("invalid values for property %s: %w", req.Name, err))
+		byName[req.Name] = append(byName[req.Name], req)
+	}
+	for name, reqs := range byName {
+		if err := validateRequirementsConsistency(reqs); err != nil {
+			allErr = append(allErr, fmt.Errorf("inconsistent requirements on property %s: %w", name, err))
 		}
-		// TODO: Check for logical contradictions
 	}
 	return apiErrors.NewAggregate(allErr)
 }
@@ -530,26 +535,188 @@ func validateName(name string) error {
 	return nil
 }
 
-func validateOperator(op placementv1beta1.PropertySelectorOperator, values []string) error {
-	// TODO: Restructure for Eq (bundle operator and value validation logic)
-	validOperators := map[placementv1beta1.PropertySelectorOperator]bool{
-		placementv1beta1.PropertySelectorGreaterThan:          true,
-		placementv1beta1.PropertySelectorGreaterThanOrEqualTo: true,
-		placementv1beta1.PropertySelectorLessThan:             true,
-		placementv1beta1.PropertySelectorLessThanOrEqualTo:    true,
-		placementv1beta1.PropertySelectorEqualTo:              true,
-		placementv1beta1.PropertySelectorNotEqualTo:           true,
+// supportedPropertyOperators lists the operators recognised on a PropertySelectorRequirement.
+// All currently-supported operators take exactly one resource.Quantity value; this table is the
+// single source of truth for both the operator validity check and the per-operator value rules.
+var supportedPropertyOperators = map[placementv1beta1.PropertySelectorOperator]struct {
+	requiredValueCount int
+}{
+	placementv1beta1.PropertySelectorGreaterThan:          {requiredValueCount: 1},
+	placementv1beta1.PropertySelectorGreaterThanOrEqualTo: {requiredValueCount: 1},
+	placementv1beta1.PropertySelectorLessThan:             {requiredValueCount: 1},
+	placementv1beta1.PropertySelectorLessThanOrEqualTo:    {requiredValueCount: 1},
+	placementv1beta1.PropertySelectorEqualTo:              {requiredValueCount: 1},
+	placementv1beta1.PropertySelectorNotEqualTo:           {requiredValueCount: 1},
+}
+
+// validateOperatorAndValues bundles operator and value validation: the operator must be one we
+// recognise, the value count must match the per-operator spec, and every value must be a valid
+// resource.Quantity.
+func validateOperatorAndValues(op placementv1beta1.PropertySelectorOperator, values []string) error {
+	spec, ok := supportedPropertyOperators[op]
+	if !ok {
+		return fmt.Errorf("unsupported operator %s", op)
 	}
-	if validOperators[op] && len(values) != 1 {
-		return fmt.Errorf("operator %s requires exactly one value, got %d", op, len(values))
+	if len(values) != spec.requiredValueCount {
+		// Preserve the historical wording for the count==1 case (every supported operator today).
+		if spec.requiredValueCount == 1 {
+			return fmt.Errorf("operator %s requires exactly one value, got %d", op, len(values))
+		}
+		return fmt.Errorf("operator %s requires exactly %d values, got %d", op, spec.requiredValueCount, len(values))
+	}
+	for _, value := range values {
+		if _, err := resource.ParseQuantity(value); err != nil {
+			return fmt.Errorf("value %q is not a valid resource.Quantity: %w", value, err)
+		}
 	}
 	return nil
 }
 
-func validateValues(values []string) error {
-	for _, value := range values {
-		if _, err := resource.ParseQuantity(value); err != nil {
-			return fmt.Errorf("value %s is not a valid resource.Quantity: %w", value, err)
+// boundary represents a numeric bound on a property selector requirement. `strict` is true for
+// strict-inequality operators (Gt, Lt) and false for inclusive ones (Gte, Lte).
+type boundary struct {
+	q      resource.Quantity
+	strict bool
+}
+
+// requirementBounds is the parsed, normalised view of all requirements on a single property.
+// `lower` is the most-restrictive (largest) lower bound, `upper` the most-restrictive (smallest)
+// upper bound. `eqVal` is the unique Eq target if any. `neVals` collects all Ne values.
+type requirementBounds struct {
+	lower  *boundary
+	upper  *boundary
+	eqVal  *resource.Quantity
+	neVals []resource.Quantity
+}
+
+// validateRequirementsConsistency reports an error when a set of requirements on the same property
+// is logically unsatisfiable. Only requirements that pass validateOperatorAndValues are considered;
+// malformed inputs are skipped so callers see one error per requirement rather than cascades.
+//
+// Cases detected:
+//   - two Eq requirements with different values
+//   - Eq and Ne requirements with the same value
+//   - the most-restrictive lower bound exceeds the most-restrictive upper bound (empty interval),
+//     including boundary cases Gt x + Lt x, Gt x + Lte x, Gte x + Lt x
+//   - an Eq value that violates the most-restrictive lower or upper bound
+func validateRequirementsConsistency(reqs []placementv1beta1.PropertySelectorRequirement) error {
+	if len(reqs) < 2 {
+		return nil
+	}
+	bounds, err := collectRequirementBounds(reqs)
+	if err != nil {
+		return err
+	}
+	if err := bounds.checkEqVsNe(); err != nil {
+		return err
+	}
+	if err := bounds.checkInterval(); err != nil {
+		return err
+	}
+	return bounds.checkEqInsideBounds()
+}
+
+// collectRequirementBounds parses each well-formed requirement into the normalised bounds view.
+// It returns early with an error if it sees two Eq requirements with different values; this is
+// a first-error-wins design, consistent with the rest of validateRequirementsConsistency. Other
+// inconsistencies are reported by the bound-checking helpers.
+func collectRequirementBounds(reqs []placementv1beta1.PropertySelectorRequirement) (*requirementBounds, error) {
+	out := &requirementBounds{}
+	for _, req := range reqs {
+		if _, ok := supportedPropertyOperators[req.Operator]; !ok || len(req.Values) != 1 {
+			continue
+		}
+		q, err := resource.ParseQuantity(req.Values[0])
+		if err != nil {
+			continue
+		}
+		switch req.Operator {
+		case placementv1beta1.PropertySelectorEqualTo:
+			if out.eqVal != nil && out.eqVal.Cmp(q) != 0 {
+				return nil, fmt.Errorf("conflicting Eq values %s and %s", out.eqVal.String(), q.String())
+			}
+			out.eqVal = &q
+		case placementv1beta1.PropertySelectorNotEqualTo:
+			out.neVals = append(out.neVals, q)
+		case placementv1beta1.PropertySelectorGreaterThan:
+			out.tightenLower(boundary{q: q, strict: true})
+		case placementv1beta1.PropertySelectorGreaterThanOrEqualTo:
+			out.tightenLower(boundary{q: q, strict: false})
+		case placementv1beta1.PropertySelectorLessThan:
+			out.tightenUpper(boundary{q: q, strict: true})
+		case placementv1beta1.PropertySelectorLessThanOrEqualTo:
+			out.tightenUpper(boundary{q: q, strict: false})
+		}
+	}
+	return out, nil
+}
+
+// tightenLower keeps the most restrictive (largest, strict-preferred at ties) lower bound.
+func (rb *requirementBounds) tightenLower(b boundary) {
+	if rb.lower == nil || isMoreRestrictiveLower(b, *rb.lower) {
+		rb.lower = &b
+	}
+}
+
+// tightenUpper keeps the most restrictive (smallest, strict-preferred at ties) upper bound.
+func (rb *requirementBounds) tightenUpper(b boundary) {
+	if rb.upper == nil || isMoreRestrictiveUpper(b, *rb.upper) {
+		rb.upper = &b
+	}
+}
+
+func isMoreRestrictiveLower(a, b boundary) bool {
+	if c := a.q.Cmp(b.q); c != 0 {
+		return c > 0
+	}
+	return a.strict && !b.strict
+}
+
+func isMoreRestrictiveUpper(a, b boundary) bool {
+	if c := a.q.Cmp(b.q); c != 0 {
+		return c < 0
+	}
+	return a.strict && !b.strict
+}
+
+func (rb *requirementBounds) checkEqVsNe() error {
+	if rb.eqVal == nil {
+		return nil
+	}
+	for _, ne := range rb.neVals {
+		if rb.eqVal.Cmp(ne) == 0 {
+			return fmt.Errorf("conflicting Eq and Ne on same value %s", rb.eqVal.String())
+		}
+	}
+	return nil
+}
+
+func (rb *requirementBounds) checkInterval() error {
+	if rb.lower == nil || rb.upper == nil {
+		return nil
+	}
+	cmp := rb.lower.q.Cmp(rb.upper.q)
+	if cmp > 0 || (cmp == 0 && (rb.lower.strict || rb.upper.strict)) {
+		return fmt.Errorf("lower bound (%s) and upper bound (%s) exclude all values",
+			rb.lower.q.String(), rb.upper.q.String())
+	}
+	return nil
+}
+
+func (rb *requirementBounds) checkEqInsideBounds() error {
+	if rb.eqVal == nil {
+		return nil
+	}
+	if rb.lower != nil {
+		cmp := rb.eqVal.Cmp(rb.lower.q)
+		if cmp < 0 || (cmp == 0 && rb.lower.strict) {
+			return fmt.Errorf("eq value %s violates lower bound %s", rb.eqVal.String(), rb.lower.q.String())
+		}
+	}
+	if rb.upper != nil {
+		cmp := rb.eqVal.Cmp(rb.upper.q)
+		if cmp > 0 || (cmp == 0 && rb.upper.strict) {
+			return fmt.Errorf("eq value %s violates upper bound %s", rb.eqVal.String(), rb.upper.q.String())
 		}
 	}
 	return nil

--- a/pkg/utils/validator/placement.go
+++ b/pkg/utils/validator/placement.go
@@ -646,7 +646,7 @@ func validateRequirementsConsistency(reqs []placementv1beta1.PropertySelectorReq
 
 // collectRequirementBounds parses each well-formed requirement into the normalised bounds view by
 // dispatching to the operator's applyToBounds. Malformed inputs (unknown operator, wrong value
-// count, unparseable quantity) are skipped so validateOperatorAndValues remains the sole source
+// count, unparsable quantity) are skipped so validateOperatorAndValues remains the sole source
 // of those errors.
 func collectRequirementBounds(reqs []placementv1beta1.PropertySelectorRequirement) (*requirementBounds, error) {
 	out := &requirementBounds{}

--- a/pkg/utils/validator/placement.go
+++ b/pkg/utils/validator/placement.go
@@ -66,21 +66,53 @@ var (
 	resourceCapacityTypes             = supportedResourceCapacityTypes()
 )
 
-// singleValueRequired is the number of values every supported PropertySelector operator accepts
-// today. All operators in supportedPropertyOperators are single-value; revisit this and the
-// related error wording in validateOperatorAndValues when adding a multi-value operator.
-const singleValueRequired = 1
+type operatorSpec struct {
+	requiredValueCount int
+	applyToBounds      func(*requirementBounds, resource.Quantity) error
+}
 
-// supportedPropertyOperators is the set of operators recognised on a PropertySelectorRequirement.
-// It is the single source of truth for which operators the validator accepts; per-operator
-// behaviour (bounds tightening, Eq/Ne handling) lives in collectRequirementBounds.
-var supportedPropertyOperators = map[placementv1beta1.PropertySelectorOperator]struct{}{
-	placementv1beta1.PropertySelectorGreaterThan:          {},
-	placementv1beta1.PropertySelectorGreaterThanOrEqualTo: {},
-	placementv1beta1.PropertySelectorLessThan:             {},
-	placementv1beta1.PropertySelectorLessThanOrEqualTo:    {},
-	placementv1beta1.PropertySelectorEqualTo:              {},
-	placementv1beta1.PropertySelectorNotEqualTo:           {},
+// supportedPropertyOperators is the single source of truth for which PropertySelector operators
+// are accepted and how each one folds into requirementBounds.
+var supportedPropertyOperators = map[placementv1beta1.PropertySelectorOperator]operatorSpec{
+	placementv1beta1.PropertySelectorGreaterThan: {
+		requiredValueCount: 1,
+		applyToBounds: func(rb *requirementBounds, q resource.Quantity) error {
+			rb.tightenLower(boundary{q: q, strict: true})
+			return nil
+		},
+	},
+	placementv1beta1.PropertySelectorGreaterThanOrEqualTo: {
+		requiredValueCount: 1,
+		applyToBounds: func(rb *requirementBounds, q resource.Quantity) error {
+			rb.tightenLower(boundary{q: q, strict: false})
+			return nil
+		},
+	},
+	placementv1beta1.PropertySelectorLessThan: {
+		requiredValueCount: 1,
+		applyToBounds: func(rb *requirementBounds, q resource.Quantity) error {
+			rb.tightenUpper(boundary{q: q, strict: true})
+			return nil
+		},
+	},
+	placementv1beta1.PropertySelectorLessThanOrEqualTo: {
+		requiredValueCount: 1,
+		applyToBounds: func(rb *requirementBounds, q resource.Quantity) error {
+			rb.tightenUpper(boundary{q: q, strict: false})
+			return nil
+		},
+	},
+	placementv1beta1.PropertySelectorEqualTo: {
+		requiredValueCount: 1,
+		applyToBounds:      (*requirementBounds).applyEq,
+	},
+	placementv1beta1.PropertySelectorNotEqualTo: {
+		requiredValueCount: 1,
+		applyToBounds: func(rb *requirementBounds, q resource.Quantity) error {
+			rb.neVals = append(rb.neVals, q)
+			return nil
+		},
+	},
 }
 
 // hasNamespaceWithResourceSelectorsMode checks if any namespace selector has NamespaceWithResourceSelectors mode.
@@ -552,14 +584,12 @@ func validateName(name string) error {
 	return nil
 }
 
-// validateOperatorAndValues bundles operator and value validation: the operator must be one we
-// recognise, the value count must match singleValueRequired, and every value must be a valid
-// resource.Quantity.
 func validateOperatorAndValues(op placementv1beta1.PropertySelectorOperator, values []string) error {
-	if _, ok := supportedPropertyOperators[op]; !ok {
+	spec, ok := supportedPropertyOperators[op]
+	if !ok {
 		return fmt.Errorf("unsupported operator %s", op)
 	}
-	if len(values) != singleValueRequired {
+	if len(values) != spec.requiredValueCount {
 		return fmt.Errorf("operator %s requires exactly one value, got %d", op, len(values))
 	}
 	for _, value := range values {
@@ -614,44 +644,39 @@ func validateRequirementsConsistency(reqs []placementv1beta1.PropertySelectorReq
 	return bounds.checkEqInsideBounds()
 }
 
-// collectRequirementBounds parses each well-formed requirement into the normalised bounds view.
-// It returns early with an error if it sees two Eq requirements with different values; this is
-// a first-error-wins design, consistent with the rest of validateRequirementsConsistency. Other
-// inconsistencies are reported by the bound-checking helpers.
+// collectRequirementBounds parses each well-formed requirement into the normalised bounds view by
+// dispatching to the operator's applyToBounds. Malformed inputs (unknown operator, wrong value
+// count, unparseable quantity) are skipped so validateOperatorAndValues remains the sole source
+// of those errors.
 func collectRequirementBounds(reqs []placementv1beta1.PropertySelectorRequirement) (*requirementBounds, error) {
 	out := &requirementBounds{}
 	for _, req := range reqs {
-		if _, ok := supportedPropertyOperators[req.Operator]; !ok || len(req.Values) != singleValueRequired {
+		spec, ok := supportedPropertyOperators[req.Operator]
+		if !ok || len(req.Values) != spec.requiredValueCount {
 			continue
 		}
 		q, err := resource.ParseQuantity(req.Values[0])
 		if err != nil {
 			continue
 		}
-		// Each operator listed in supportedPropertyOperators must have a case below; the default
-		// arm fires only if an operator is added to the map without a matching case here (value-
-		// count and parse-quantity mismatches are already filtered out by the continue above).
-		switch req.Operator {
-		case placementv1beta1.PropertySelectorEqualTo:
-			if out.eqVal != nil && out.eqVal.Cmp(q) != 0 {
-				return nil, fmt.Errorf("conflicting Eq values %s and %s", out.eqVal.String(), q.String())
-			}
-			out.eqVal = &q
-		case placementv1beta1.PropertySelectorNotEqualTo:
-			out.neVals = append(out.neVals, q)
-		case placementv1beta1.PropertySelectorGreaterThan:
-			out.tightenLower(boundary{q: q, strict: true})
-		case placementv1beta1.PropertySelectorGreaterThanOrEqualTo:
-			out.tightenLower(boundary{q: q, strict: false})
-		case placementv1beta1.PropertySelectorLessThan:
-			out.tightenUpper(boundary{q: q, strict: true})
-		case placementv1beta1.PropertySelectorLessThanOrEqualTo:
-			out.tightenUpper(boundary{q: q, strict: false})
-		default:
+		if spec.applyToBounds == nil {
 			return nil, fmt.Errorf("internal: operator %s is in supportedPropertyOperators but has no bounds handler", req.Operator)
+		}
+		if err := spec.applyToBounds(out, q); err != nil {
+			return nil, err
 		}
 	}
 	return out, nil
+}
+
+// applyEq is a method (not a closure) so the spec table can reference it as
+// (*requirementBounds).applyEq.
+func (rb *requirementBounds) applyEq(q resource.Quantity) error {
+	if rb.eqVal != nil && rb.eqVal.Cmp(q) != 0 {
+		return fmt.Errorf("conflicting Eq values %s and %s", rb.eqVal.String(), q.String())
+	}
+	rb.eqVal = &q
+	return nil
 }
 
 // tightenLower keeps the most restrictive (largest, strict-preferred at ties) lower bound.

--- a/pkg/utils/validator/placement.go
+++ b/pkg/utils/validator/placement.go
@@ -66,6 +66,23 @@ var (
 	resourceCapacityTypes             = supportedResourceCapacityTypes()
 )
 
+// singleValueRequired is the number of values every supported PropertySelector operator accepts
+// today. All operators in supportedPropertyOperators are single-value; revisit this and the
+// related error wording in validateOperatorAndValues when adding a multi-value operator.
+const singleValueRequired = 1
+
+// supportedPropertyOperators is the set of operators recognised on a PropertySelectorRequirement.
+// It is the single source of truth for which operators the validator accepts; per-operator
+// behaviour (bounds tightening, Eq/Ne handling) lives in collectRequirementBounds.
+var supportedPropertyOperators = map[placementv1beta1.PropertySelectorOperator]struct{}{
+	placementv1beta1.PropertySelectorGreaterThan:          {},
+	placementv1beta1.PropertySelectorGreaterThanOrEqualTo: {},
+	placementv1beta1.PropertySelectorLessThan:             {},
+	placementv1beta1.PropertySelectorLessThanOrEqualTo:    {},
+	placementv1beta1.PropertySelectorEqualTo:              {},
+	placementv1beta1.PropertySelectorNotEqualTo:           {},
+}
+
 // hasNamespaceWithResourceSelectorsMode checks if any namespace selector has NamespaceWithResourceSelectors mode.
 func hasNamespaceWithResourceSelectorsMode(resourceSelectors []placementv1beta1.ResourceSelectorTerm) bool {
 	for _, selector := range resourceSelectors {
@@ -535,34 +552,15 @@ func validateName(name string) error {
 	return nil
 }
 
-// supportedPropertyOperators lists the operators recognised on a PropertySelectorRequirement.
-// All currently-supported operators take exactly one resource.Quantity value; this table is the
-// single source of truth for both the operator validity check and the per-operator value rules.
-var supportedPropertyOperators = map[placementv1beta1.PropertySelectorOperator]struct {
-	requiredValueCount int
-}{
-	placementv1beta1.PropertySelectorGreaterThan:          {requiredValueCount: 1},
-	placementv1beta1.PropertySelectorGreaterThanOrEqualTo: {requiredValueCount: 1},
-	placementv1beta1.PropertySelectorLessThan:             {requiredValueCount: 1},
-	placementv1beta1.PropertySelectorLessThanOrEqualTo:    {requiredValueCount: 1},
-	placementv1beta1.PropertySelectorEqualTo:              {requiredValueCount: 1},
-	placementv1beta1.PropertySelectorNotEqualTo:           {requiredValueCount: 1},
-}
-
 // validateOperatorAndValues bundles operator and value validation: the operator must be one we
-// recognise, the value count must match the per-operator spec, and every value must be a valid
+// recognise, the value count must match singleValueRequired, and every value must be a valid
 // resource.Quantity.
 func validateOperatorAndValues(op placementv1beta1.PropertySelectorOperator, values []string) error {
-	spec, ok := supportedPropertyOperators[op]
-	if !ok {
+	if _, ok := supportedPropertyOperators[op]; !ok {
 		return fmt.Errorf("unsupported operator %s", op)
 	}
-	if len(values) != spec.requiredValueCount {
-		// Preserve the historical wording for the count==1 case (every supported operator today).
-		if spec.requiredValueCount == 1 {
-			return fmt.Errorf("operator %s requires exactly one value, got %d", op, len(values))
-		}
-		return fmt.Errorf("operator %s requires exactly %d values, got %d", op, spec.requiredValueCount, len(values))
+	if len(values) != singleValueRequired {
+		return fmt.Errorf("operator %s requires exactly one value, got %d", op, len(values))
 	}
 	for _, value := range values {
 		if _, err := resource.ParseQuantity(value); err != nil {
@@ -623,13 +621,16 @@ func validateRequirementsConsistency(reqs []placementv1beta1.PropertySelectorReq
 func collectRequirementBounds(reqs []placementv1beta1.PropertySelectorRequirement) (*requirementBounds, error) {
 	out := &requirementBounds{}
 	for _, req := range reqs {
-		if _, ok := supportedPropertyOperators[req.Operator]; !ok || len(req.Values) != 1 {
+		if _, ok := supportedPropertyOperators[req.Operator]; !ok || len(req.Values) != singleValueRequired {
 			continue
 		}
 		q, err := resource.ParseQuantity(req.Values[0])
 		if err != nil {
 			continue
 		}
+		// Each operator listed in supportedPropertyOperators must have a case below; the default
+		// arm fires only if an operator is added to the map without a matching case here (value-
+		// count and parse-quantity mismatches are already filtered out by the continue above).
 		switch req.Operator {
 		case placementv1beta1.PropertySelectorEqualTo:
 			if out.eqVal != nil && out.eqVal.Cmp(q) != 0 {
@@ -646,6 +647,8 @@ func collectRequirementBounds(reqs []placementv1beta1.PropertySelectorRequiremen
 			out.tightenUpper(boundary{q: q, strict: true})
 		case placementv1beta1.PropertySelectorLessThanOrEqualTo:
 			out.tightenUpper(boundary{q: q, strict: false})
+		default:
+			return nil, fmt.Errorf("internal: operator %s is in supportedPropertyOperators but has no bounds handler", req.Operator)
 		}
 	}
 	return out, nil

--- a/pkg/utils/validator/placement_test.go
+++ b/pkg/utils/validator/placement_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -2048,4 +2049,122 @@ func TestValidateResourcePlacement(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateOperatorAndValues(t *testing.T) {
+	tests := []struct {
+		name    string
+		op      placementv1beta1.PropertySelectorOperator
+		values  []string
+		wantErr bool
+	}{
+		{name: "Eq with one valid value", op: placementv1beta1.PropertySelectorEqualTo, values: []string{"5"}, wantErr: false},
+		{name: "Gt with one valid value", op: placementv1beta1.PropertySelectorGreaterThan, values: []string{"100Mi"}, wantErr: false},
+		{name: "Lte with one valid value", op: placementv1beta1.PropertySelectorLessThanOrEqualTo, values: []string{"2.5"}, wantErr: false},
+		{name: "unsupported operator", op: placementv1beta1.PropertySelectorOperator("In"), values: []string{"5"}, wantErr: true},
+		{name: "Eq with zero values", op: placementv1beta1.PropertySelectorEqualTo, values: nil, wantErr: true},
+		{name: "Eq with two values", op: placementv1beta1.PropertySelectorEqualTo, values: []string{"5", "10"}, wantErr: true},
+		{name: "Lt with malformed quantity", op: placementv1beta1.PropertySelectorLessThan, values: []string{"five"}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateOperatorAndValues(tt.op, tt.values)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateOperatorAndValues(%v, %v) error = %v, wantErr %v", tt.op, tt.values, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateRequirementsConsistency(t *testing.T) {
+	req := func(op placementv1beta1.PropertySelectorOperator, value string) placementv1beta1.PropertySelectorRequirement {
+		return placementv1beta1.PropertySelectorRequirement{Name: "p", Operator: op, Values: []string{value}}
+	}
+
+	tests := []struct {
+		name    string
+		reqs    []placementv1beta1.PropertySelectorRequirement
+		wantErr bool
+		errSub  string
+	}{
+		// Trivially-satisfied inputs.
+		{name: "empty input", reqs: nil, wantErr: false},
+		{name: "single requirement", reqs: []placementv1beta1.PropertySelectorRequirement{req(placementv1beta1.PropertySelectorEqualTo, "5")}, wantErr: false},
+		{name: "two compatible Eq with same value", reqs: []placementv1beta1.PropertySelectorRequirement{req(placementv1beta1.PropertySelectorEqualTo, "5"), req(placementv1beta1.PropertySelectorEqualTo, "5")}, wantErr: false},
+		{name: "Eq + Ne with different values", reqs: []placementv1beta1.PropertySelectorRequirement{req(placementv1beta1.PropertySelectorEqualTo, "5"), req(placementv1beta1.PropertySelectorNotEqualTo, "10")}, wantErr: false},
+		{name: "two Ne", reqs: []placementv1beta1.PropertySelectorRequirement{req(placementv1beta1.PropertySelectorNotEqualTo, "5"), req(placementv1beta1.PropertySelectorNotEqualTo, "10")}, wantErr: false},
+		{name: "Gt + Lt with non-empty interval", reqs: []placementv1beta1.PropertySelectorRequirement{req(placementv1beta1.PropertySelectorGreaterThan, "5"), req(placementv1beta1.PropertySelectorLessThan, "10")}, wantErr: false},
+		{name: "Gte x + Lte x pinpoints x", reqs: []placementv1beta1.PropertySelectorRequirement{req(placementv1beta1.PropertySelectorGreaterThanOrEqualTo, "10"), req(placementv1beta1.PropertySelectorLessThanOrEqualTo, "10")}, wantErr: false},
+		{name: "Eq inside bounds", reqs: []placementv1beta1.PropertySelectorRequirement{req(placementv1beta1.PropertySelectorGreaterThanOrEqualTo, "5"), req(placementv1beta1.PropertySelectorEqualTo, "7"), req(placementv1beta1.PropertySelectorLessThanOrEqualTo, "10")}, wantErr: false},
+		{name: "redundant lower bounds keep most restrictive (compatible)", reqs: []placementv1beta1.PropertySelectorRequirement{req(placementv1beta1.PropertySelectorGreaterThan, "5"), req(placementv1beta1.PropertySelectorGreaterThan, "10"), req(placementv1beta1.PropertySelectorLessThan, "20")}, wantErr: false},
+		{name: "value with units (memory quantity)", reqs: []placementv1beta1.PropertySelectorRequirement{req(placementv1beta1.PropertySelectorGreaterThanOrEqualTo, "100Mi"), req(placementv1beta1.PropertySelectorLessThan, "1Gi")}, wantErr: false},
+
+		// Conflicts.
+		{name: "two Eq with different values", reqs: []placementv1beta1.PropertySelectorRequirement{req(placementv1beta1.PropertySelectorEqualTo, "5"), req(placementv1beta1.PropertySelectorEqualTo, "10")}, wantErr: true, errSub: "conflicting Eq values"},
+		{name: "Eq + Ne with same value", reqs: []placementv1beta1.PropertySelectorRequirement{req(placementv1beta1.PropertySelectorEqualTo, "5"), req(placementv1beta1.PropertySelectorNotEqualTo, "5")}, wantErr: true, errSub: "conflicting Eq and Ne"},
+		{name: "Gt 10 + Lt 5", reqs: []placementv1beta1.PropertySelectorRequirement{req(placementv1beta1.PropertySelectorGreaterThan, "10"), req(placementv1beta1.PropertySelectorLessThan, "5")}, wantErr: true, errSub: "exclude all values"},
+		{name: "Gt x + Lt x boundary", reqs: []placementv1beta1.PropertySelectorRequirement{req(placementv1beta1.PropertySelectorGreaterThan, "10"), req(placementv1beta1.PropertySelectorLessThan, "10")}, wantErr: true, errSub: "exclude all values"},
+		{name: "Gt x + Lte x boundary", reqs: []placementv1beta1.PropertySelectorRequirement{req(placementv1beta1.PropertySelectorGreaterThan, "10"), req(placementv1beta1.PropertySelectorLessThanOrEqualTo, "10")}, wantErr: true, errSub: "exclude all values"},
+		{name: "Gte x + Lt x boundary", reqs: []placementv1beta1.PropertySelectorRequirement{req(placementv1beta1.PropertySelectorGreaterThanOrEqualTo, "10"), req(placementv1beta1.PropertySelectorLessThan, "10")}, wantErr: true, errSub: "exclude all values"},
+		{name: "least-restrictive lower hides contradiction (still detected via most-restrictive)",
+			reqs:    []placementv1beta1.PropertySelectorRequirement{req(placementv1beta1.PropertySelectorGreaterThan, "10"), req(placementv1beta1.PropertySelectorGreaterThan, "5"), req(placementv1beta1.PropertySelectorLessThan, "7")},
+			wantErr: true, errSub: "exclude all values"},
+		{name: "Eq below lower bound", reqs: []placementv1beta1.PropertySelectorRequirement{req(placementv1beta1.PropertySelectorGreaterThanOrEqualTo, "10"), req(placementv1beta1.PropertySelectorEqualTo, "5")}, wantErr: true, errSub: "violates lower bound"},
+		{name: "Eq above upper bound", reqs: []placementv1beta1.PropertySelectorRequirement{req(placementv1beta1.PropertySelectorLessThanOrEqualTo, "10"), req(placementv1beta1.PropertySelectorEqualTo, "20")}, wantErr: true, errSub: "violates upper bound"},
+		{name: "Eq equals strict lower bound", reqs: []placementv1beta1.PropertySelectorRequirement{req(placementv1beta1.PropertySelectorGreaterThan, "10"), req(placementv1beta1.PropertySelectorEqualTo, "10")}, wantErr: true, errSub: "violates lower bound"},
+		{name: "Eq equals strict upper bound", reqs: []placementv1beta1.PropertySelectorRequirement{req(placementv1beta1.PropertySelectorLessThan, "10"), req(placementv1beta1.PropertySelectorEqualTo, "10")}, wantErr: true, errSub: "violates upper bound"},
+
+		// Malformed inputs are skipped, not surfaced — that's validateOperatorAndValues' job.
+		{name: "malformed value is ignored for consistency check", reqs: []placementv1beta1.PropertySelectorRequirement{req(placementv1beta1.PropertySelectorEqualTo, "not-a-number"), req(placementv1beta1.PropertySelectorEqualTo, "5")}, wantErr: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateRequirementsConsistency(tt.reqs)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateRequirementsConsistency(%v) error = %v, wantErr %v", tt.reqs, err, tt.wantErr)
+			}
+			if tt.wantErr && err != nil && !strings.Contains(err.Error(), tt.errSub) {
+				t.Errorf("validateRequirementsConsistency(%v) error = %q, want substring %q", tt.reqs, err.Error(), tt.errSub)
+			}
+		})
+	}
+}
+
+func TestRequirementBoundsTighten(t *testing.T) {
+	q := func(s string) resource.Quantity { return resource.MustParse(s) }
+
+	t.Run("lower keeps largest value", func(t *testing.T) {
+		rb := &requirementBounds{}
+		rb.tightenLower(boundary{q: q("5")})
+		rb.tightenLower(boundary{q: q("10")})
+		rb.tightenLower(boundary{q: q("3")})
+		if rb.lower.q.Cmp(q("10")) != 0 {
+			t.Errorf("lower = %s, want 10", rb.lower.q.String())
+		}
+	})
+	t.Run("lower prefers strict at tie", func(t *testing.T) {
+		rb := &requirementBounds{}
+		rb.tightenLower(boundary{q: q("10"), strict: false})
+		rb.tightenLower(boundary{q: q("10"), strict: true})
+		if !rb.lower.strict {
+			t.Errorf("lower.strict = false, want true")
+		}
+	})
+	t.Run("upper keeps smallest value", func(t *testing.T) {
+		rb := &requirementBounds{}
+		rb.tightenUpper(boundary{q: q("10")})
+		rb.tightenUpper(boundary{q: q("5")})
+		rb.tightenUpper(boundary{q: q("8")})
+		if rb.upper.q.Cmp(q("5")) != 0 {
+			t.Errorf("upper = %s, want 5", rb.upper.q.String())
+		}
+	})
+	t.Run("upper prefers strict at tie", func(t *testing.T) {
+		rb := &requirementBounds{}
+		rb.tightenUpper(boundary{q: q("10"), strict: false})
+		rb.tightenUpper(boundary{q: q("10"), strict: true})
+		if !rb.upper.strict {
+			t.Errorf("upper.strict = false, want true")
+		}
+	})
 }

--- a/pkg/utils/validator/placement_test.go
+++ b/pkg/utils/validator/placement_test.go
@@ -2116,6 +2116,11 @@ func TestValidateRequirementsConsistency(t *testing.T) {
 
 		// Malformed inputs are skipped, not surfaced — that's validateOperatorAndValues' job.
 		{name: "malformed value is ignored for consistency check", reqs: []placementv1beta1.PropertySelectorRequirement{req(placementv1beta1.PropertySelectorEqualTo, "not-a-number"), req(placementv1beta1.PropertySelectorEqualTo, "5")}, wantErr: false},
+
+		// checkEqVsNe and checkEqInsideBounds must use Quantity.Cmp, not string equality, so
+		// canonically-equal cross-format inputs still produce the right conflict verdict.
+		{name: "Eq + Ne with same canonical value but different format", reqs: []placementv1beta1.PropertySelectorRequirement{req(placementv1beta1.PropertySelectorEqualTo, "1000m"), req(placementv1beta1.PropertySelectorNotEqualTo, "1")}, wantErr: true, errSub: "conflicting Eq and Ne"},
+		{name: "Eq + Lt bound with same canonical value but different format", reqs: []placementv1beta1.PropertySelectorRequirement{req(placementv1beta1.PropertySelectorLessThan, "1024"), req(placementv1beta1.PropertySelectorEqualTo, "1Ki")}, wantErr: true, errSub: "violates upper bound"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -2169,17 +2174,52 @@ func TestRequirementBoundsTighten(t *testing.T) {
 	})
 }
 
-// TestCollectRequirementBoundsUnhandledOperator guards the invariant that every operator listed
-// in supportedPropertyOperators has a matching arm in the collectRequirementBounds switch. A
-// future change that adds an operator to the map but forgets the switch arm must fail loudly.
-//
-// The test mutates the package-level supportedPropertyOperators map and restores it via
-// t.Cleanup. This is safe because no test in this package runs in parallel; introducing
-// t.Parallel() to any sibling test that touches the operator registry would require revisiting
-// this approach (e.g. dependency-injecting the operator set into collectRequirementBounds).
+func TestApplyEq(t *testing.T) {
+	q := func(s string) resource.Quantity { return resource.MustParse(s) }
+
+	t.Run("first call sets eqVal", func(t *testing.T) {
+		rb := &requirementBounds{}
+		if err := rb.applyEq(q("5")); err != nil {
+			t.Fatalf("applyEq(5) error = %v, want nil", err)
+		}
+		if rb.eqVal == nil || rb.eqVal.Cmp(q("5")) != 0 {
+			t.Errorf("eqVal = %v, want 5", rb.eqVal)
+		}
+	})
+	t.Run("second call with equal value returns nil", func(t *testing.T) {
+		rb := &requirementBounds{}
+		if err := rb.applyEq(q("1")); err != nil {
+			t.Fatalf("setup applyEq(1) error = %v, want nil", err)
+		}
+		if err := rb.applyEq(q("1000m")); err != nil {
+			t.Errorf("applyEq(1000m) on rb with eqVal=1 error = %v, want nil", err)
+		}
+		if rb.eqVal == nil || rb.eqVal.Cmp(q("1")) != 0 {
+			t.Errorf("eqVal = %v, want value equal to 1", rb.eqVal)
+		}
+	})
+	t.Run("second call with different value errors", func(t *testing.T) {
+		rb := &requirementBounds{}
+		if err := rb.applyEq(q("5")); err != nil {
+			t.Fatalf("setup applyEq(5) error = %v, want nil", err)
+		}
+		err := rb.applyEq(q("10"))
+		if err == nil || !strings.Contains(err.Error(), "conflicting Eq values") {
+			t.Errorf("applyEq(10) on rb with eqVal=5 error = %v, want 'conflicting Eq values'", err)
+		}
+		// eqVal must be preserved on the error path.
+		if rb.eqVal == nil || rb.eqVal.Cmp(q("5")) != 0 {
+			t.Errorf("eqVal after failed applyEq(10) = %v, want value equal to 5", rb.eqVal)
+		}
+	})
+}
+
+// TestCollectRequirementBoundsUnhandledOperator covers the nil-applyToBounds runtime guard.
+// Mutates the package-level registry, which is safe only because no test in this package runs
+// with t.Parallel().
 func TestCollectRequirementBoundsUnhandledOperator(t *testing.T) {
 	const fakeOp placementv1beta1.PropertySelectorOperator = "FakeOpForTest"
-	supportedPropertyOperators[fakeOp] = struct{}{}
+	supportedPropertyOperators[fakeOp] = operatorSpec{requiredValueCount: 1}
 	t.Cleanup(func() { delete(supportedPropertyOperators, fakeOp) })
 
 	reqs := []placementv1beta1.PropertySelectorRequirement{
@@ -2190,11 +2230,22 @@ func TestCollectRequirementBoundsUnhandledOperator(t *testing.T) {
 	if err == nil {
 		t.Fatalf("collectRequirementBounds(%v) error = nil, want non-nil for unhandled operator", reqs)
 	}
-	// Bind both to the error source ("internal:") and content ("no bounds handler") so the test
-	// fails distinctly from any other validation error that might surface from this function.
 	for _, wantSub := range []string{"internal:", "no bounds handler"} {
 		if !strings.Contains(err.Error(), wantSub) {
 			t.Errorf("collectRequirementBounds(%v) error = %q, want substring %q", reqs, err.Error(), wantSub)
+		}
+	}
+}
+
+// TestSupportedPropertyOperatorsRegistryComplete fails at test time if any spec has a
+// non-positive requiredValueCount or a nil applyToBounds.
+func TestSupportedPropertyOperatorsRegistryComplete(t *testing.T) {
+	for op, spec := range supportedPropertyOperators {
+		if spec.requiredValueCount <= 0 {
+			t.Errorf("supportedPropertyOperators[%s].requiredValueCount = %d, want > 0", op, spec.requiredValueCount)
+		}
+		if spec.applyToBounds == nil {
+			t.Errorf("supportedPropertyOperators[%s].applyToBounds is nil, want non-nil", op)
 		}
 	}
 }

--- a/pkg/utils/validator/placement_test.go
+++ b/pkg/utils/validator/placement_test.go
@@ -2168,3 +2168,33 @@ func TestRequirementBoundsTighten(t *testing.T) {
 		}
 	})
 }
+
+// TestCollectRequirementBoundsUnhandledOperator guards the invariant that every operator listed
+// in supportedPropertyOperators has a matching arm in the collectRequirementBounds switch. A
+// future change that adds an operator to the map but forgets the switch arm must fail loudly.
+//
+// The test mutates the package-level supportedPropertyOperators map and restores it via
+// t.Cleanup. This is safe because no test in this package runs in parallel; introducing
+// t.Parallel() to any sibling test that touches the operator registry would require revisiting
+// this approach (e.g. dependency-injecting the operator set into collectRequirementBounds).
+func TestCollectRequirementBoundsUnhandledOperator(t *testing.T) {
+	const fakeOp placementv1beta1.PropertySelectorOperator = "FakeOpForTest"
+	supportedPropertyOperators[fakeOp] = struct{}{}
+	t.Cleanup(func() { delete(supportedPropertyOperators, fakeOp) })
+
+	reqs := []placementv1beta1.PropertySelectorRequirement{
+		{Name: "p", Operator: placementv1beta1.PropertySelectorEqualTo, Values: []string{"5"}},
+		{Name: "p", Operator: fakeOp, Values: []string{"7"}},
+	}
+	_, err := collectRequirementBounds(reqs)
+	if err == nil {
+		t.Fatalf("collectRequirementBounds(%v) error = nil, want non-nil for unhandled operator", reqs)
+	}
+	// Bind both to the error source ("internal:") and content ("no bounds handler") so the test
+	// fails distinctly from any other validation error that might surface from this function.
+	for _, wantSub := range []string{"internal:", "no bounds handler"} {
+		if !strings.Contains(err.Error(), wantSub) {
+			t.Errorf("collectRequirementBounds(%v) error = %q, want substring %q", reqs, err.Error(), wantSub)
+		}
+	}
+}


### PR DESCRIPTION
### Description of your changes

Fixes #646.

Addresses the four validator-hardening TODOs from the issue. Two were stale (the validator already enforced them); two are real and now have implementations + thorough tests.

**Real changes**

- Bundle operator and value validation into `validateOperatorAndValues` driven by a single `supportedPropertyOperators` table. Replaces the prior split `validateOperator` / `validateValues`. Preserves the historical "operator X requires exactly one value, got N" wording so existing tests stay stable.
- Add per-property logical-contradiction detection (`validateRequirementsConsistency`). Split into named helpers per reviewer feedback: `collectRequirementBounds`, `tightenLower`/`tightenUpper` (with strict-preferred tiebreak), `checkEqVsNe`, `checkInterval`, `checkEqInsideBounds`. Detects:
  - two `Eq` with different values,
  - `Eq` + `Ne` on the same value,
  - empty intervals from the most-restrictive lower vs the most-restrictive upper (incl. boundary cases `Gt x + Lt x`, `Gt x + Lte x`, `Gte x + Lt x`),
  - `Eq` value violating the most-restrictive lower or upper bound.

  More elaborate cases (sparse `Ne` exclusion sets, complex inequality normalisation) are intentionally left for the property-selector evaluator at scheduling time.

**Stale TODOs removed**

- `resource_selector_resolver.go:526` — mutual exclusiveness of `Name` vs `LabelSelector` is already enforced in `pkg/utils/validator/placement.go:92-95` (`validatePlacement`). Replaced with a pointer-comment.
- `resource_selector_resolver.go:556` — `labelSelector` validity is already enforced in `validateLabelSelector` (`placement.go:394`). Replaced with a pointer-comment.

I have:

- [x] Associated this change with a known KubeFleet Issue (Bug, Feature, etc).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- `TestValidateOperatorAndValues` (7 cases including unsupported operator, malformed quantity, count mismatch).
- `TestValidateRequirementsConsistency` (~20 cases: each contradiction variant plus negative controls and malformed-input skipping).
- `TestRequirementBoundsTighten` (4 cases for "most restrictive wins" + strict tiebreak).
- Full `pkg/utils/validator/...` and `pkg/utils/controller/...` suites pass; `make reviewable` clean.

### Special notes for your reviewer

- `validateRequirementsConsistency` is **first-error-wins** by design — once `collectRequirementBounds` hits a conflicting Eq it returns; downstream interval/Ne contradictions on the same property won't be reported in the same admission response. Documented in the function comment.
- Boy Scout: also switched two `interface{}` → `any` in the Service `nodePort` stripping block in `resource_selector_resolver.go` since I was already in that file.