### PR TITLE
docs: clarify hub-agent cert secret default

### DIFF
--- a/charts/hub-agent/README.md
+++ b/charts/hub-agent/README.md
@@ -164,7 +164,8 @@ helm install hub-agent oci://ghcr.io/kubefleet-dev/kubefleet/charts/hub-agent \
   --create-namespace \
   --set useCertManager=true \
   --set enableWorkload=true \
-  --set enableWebhook=true
+  --set enableWebhook=true \
+  --set webhookCertSecretName=fleet-webhook-server-cert
 
 # Or using traditional repository
 helm install hub-agent kubefleet/hub-agent \
@@ -172,12 +173,13 @@ helm install hub-agent kubefleet/hub-agent \
   --create-namespace \
   --set useCertManager=true \
   --set enableWorkload=true \
-  --set enableWebhook=true
+  --set enableWebhook=true \
+  --set webhookCertSecretName=fleet-webhook-server-cert
 ```
 
 The `webhookCertSecretName` parameter specifies the Secret name for the certificate:
-- Default: `fleet-webhook-server-cert`
-- When using cert-manager, this is where cert-manager stores the certificate
+- Default: `unset`; there is no default in `values.yaml`
+- When using cert-manager, set this to the Secret where cert-manager stores the certificate
 - Must match the secret name referenced in the deployment volume mount
 
 Example with custom secret name:

--- a/charts/hub-agent/values.yaml
+++ b/charts/hub-agent/values.yaml
@@ -23,6 +23,7 @@ enableWorkload: false
 useCertManager: false
 # webhookCertSecretName is ONLY used when useCertManager=true
 # It specifies the name of the Secret where cert-manager stores the certificate
+# Example:
 # webhookCertSecretName: fleet-webhook-server-cert
 
 forceDeleteWaitTime: 15m0s


### PR DESCRIPTION
### Description of your changes

Clarifies that `webhookCertSecretName` is unset by default in the hub-agent chart, and updates the cert-manager install examples to pass an explicit secret name.

Fixes #585

I have:

- [x] Associated this change with a known KubeFleet Issue (Bug, Feature, etc).
- [ ] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- `helm lint charts/hub-agent`
- `helm template hub-agent charts/hub-agent --set useCertManager=true --set enableWorkload=true --set enableWebhook=true --set webhookCertSecretName=fleet-webhook-server-cert`
- README/default consistency checks with `rg`
- `git diff --check`

`make reviewable` was not run because this is limited to Helm README/comment text and the focused chart validation above covers the touched area.

### Special notes for your reviewer

None.
