### PR TITLE
feat: add new error handling utilities

### DIFF
--- a/pkg/utils/errors/errors.go
+++ b/pkg/utils/errors/errors.go
@@ -82,15 +82,6 @@ func (e *Error) categoryWithDefault() ErrCategory {
 // Note the output intentionally does not include the additional attributes, so as to keep the cardinality
 // low; to print them out, pass them explicitly to the klog functions.
 func (e *Error) Error() string {
-	// Build a bitmap to determine the error template to use.
-	var bitmap int
-	if e.wrapped != nil {
-		bitmap |= 1 << 0
-	}
-	if len(e.desc) > 0 {
-		bitmap |= 1 << 1
-	}
-
 	switch {
 	case e.wrapped != nil && len(e.desc) == 0:
 		// With wrapped error but no description.
@@ -120,11 +111,13 @@ func Wraps(err error, desc string, kvs ...interface{}) *Error {
 	// Find if any of error down in the chain is already an *Error; if so, use its category and surface its
 	// attributes to the current level.
 	var category ErrCategory
+	var mergedKVs []interface{}
 	var childError *Error
 	if errors.As(err, &childError) {
 		category = childError.category
-		kvs = append(childError.attrs, kvs...)
+		mergedKVs = append(mergedKVs, childError.attrs...)
 	}
+	mergedKVs = append(mergedKVs, kvs...)
 	if len(category) == 0 {
 		category = ErrCategoryUncategorized
 	}
@@ -133,7 +126,7 @@ func Wraps(err error, desc string, kvs ...interface{}) *Error {
 		category: category,
 		wrapped:  err,
 		desc:     desc,
-		attrs:    kvs,
+		attrs:    mergedKVs,
 	}
 }
 
@@ -196,7 +189,7 @@ func NewUnexpectedError(err error, desc string, kvs ...interface{}) *Error {
 	// For unexpected errors, collect the caller frames.
 	//
 	// Note (chenyu1): previously for unexpected errors, we use the debug.Stack() to print out a full stack
-	// trace in the logs. Effective as it is, the operation is expensive and it always captuires the full stack,
+	// trace in the logs. Effective as it is, the operation is expensive and it always captures the full stack,
 	// where the top of the stack is always the error handling utility function/method itself rather than
 	// the actual caller site where the error originates. Furthermore, as debug.Stack() returns a multi-line string,
 	// often the logging backend cannot render it properly, making it difficult to read/summarize. To address this,

--- a/pkg/utils/errors/errors.go
+++ b/pkg/utils/errors/errors.go
@@ -42,7 +42,7 @@ const (
 
 	// An error is considered of the API server error category when it arises during a call
 	// to the Kubernetes API server.
-	ErrCategoryAPIServer ErrCategory = "Kubernetes API server"
+	ErrCategoryAPIServer ErrCategory = "APIserver"
 
 	// An error is considered of the user error category when it arises due to some
 	// incorrect input or action from the user side and can resolve when the
@@ -68,8 +68,6 @@ type Error struct {
 
 	// attrs are the additional attributes associated with the wrapped error.
 	attrs []interface{}
-
-	isRootLevel bool
 }
 
 func (e *Error) categoryWithDefault() ErrCategory {
@@ -92,33 +90,19 @@ func (e *Error) Error() string {
 	if len(e.desc) > 0 {
 		bitmap |= 1 << 1
 	}
-	if e.isRootLevel {
-		bitmap |= 1 << 2
-	}
 
-	switch bitmap {
-	case 1:
-		// With wrapped error, no description, and not a root level error.
+	switch {
+	case e.wrapped != nil && len(e.desc) == 0:
+		// With wrapped error but no description.
 		return e.wrapped.Error()
-	case 2:
-		// No wrapped error, with description, and not a root level error.
-		return e.desc
-	case 3:
-		// With wrapped error, with description, and not a root level error.
+	case e.wrapped != nil:
+		// With wrapped error, with description.
 		return fmt.Sprintf("%s: %s", e.desc, e.wrapped.Error())
-	case 5:
-		// With wrapped error, no description, and is a root level error.
-		return fmt.Sprintf("a/an %s error occurred: %s", e.categoryWithDefault(), e.wrapped.Error())
-	case 6:
-		// No wrapped error, with description, and is a root level error.
-		return fmt.Sprintf("a/an %s error occurred: %s", e.categoryWithDefault(), e.desc)
-	case 7:
-		// With wrapped error, with description, and is a root level error.
-		return fmt.Sprintf("a/an %s error occurred: %s: %s", e.categoryWithDefault(), e.desc, e.wrapped.Error())
+	case e.wrapped == nil && len(e.desc) > 0:
+		// No wrapped error but with description.
+		return e.desc
 	default:
-		// The following cases would trigger this output:
-		// * bitmap 0: no wrapped error, no description, and not a root level error.
-		// * bitmap 4: no wrapped error, no description, and is a root level error.
+		// No wrapped error and no description.
 		return "an unknown error occurred"
 	}
 }
@@ -140,18 +124,16 @@ func Wraps(err error, desc string, kvs ...interface{}) *Error {
 	if errors.As(err, &childError) {
 		category = childError.category
 		kvs = append(childError.attrs, kvs...)
-		childError.isRootLevel = false
 	}
 	if len(category) == 0 {
 		category = ErrCategoryUncategorized
 	}
 
 	return &Error{
-		category:    category,
-		wrapped:     err,
-		desc:        desc,
-		attrs:       kvs,
-		isRootLevel: true,
+		category: category,
+		wrapped:  err,
+		desc:     desc,
+		attrs:    kvs,
 	}
 }
 
@@ -166,11 +148,15 @@ func Wraps(err error, desc string, kvs ...interface{}) *Error {
 //
 // klog.ErrorS(err, "additional top-level error description", append(Args(err), "k", "v")...).
 func Args(err error, kvs ...interface{}) []interface{} {
+	var compositeKVs []interface{}
 	var childError *Error
 	if errors.As(err, &childError) {
-		kvs = append(childError.attrs, kvs...)
+		// Make sure that the error category is always included as the first kv pair.
+		compositeKVs = append(compositeKVs, "errCategory", childError.categoryWithDefault())
+		compositeKVs = append(compositeKVs, childError.attrs...)
+		compositeKVs = append(compositeKVs, kvs...)
 	}
-	return kvs
+	return compositeKVs
 }
 
 // CallerFrameOverview is a simple struct that summarizes a single call frame.

--- a/pkg/utils/errors/errors.go
+++ b/pkg/utils/errors/errors.go
@@ -1,0 +1,261 @@
+/*
+Copyright 2026 The KubeFleet Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// TO-DO: apply the new error pattern incrementally when it is ready to do so.
+
+// errors features custom error categorizing, wrapping and string formatting logic
+// used in the KubeFleet project.
+package errors
+
+import (
+	"errors"
+	"fmt"
+	"runtime"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+type ErrCategory string
+
+const (
+	// An error is considered of the unexpected error category when a KubeFleet controller
+	// encounters a situation that it does not know how to handle and cannot be resolved
+	// by itself or by user fixing their inputs.
+	ErrCategoryUnexpected ErrCategory = "unexpected"
+
+	// An error is considered of the transient error category when a KubeFleet controller
+	// encounters a situation that would self-resolve soon, e.g., cache not sync'd yet.
+	ErrCategoryTransient ErrCategory = "transient"
+
+	// An error is considered of the API server error category when it arises during a call
+	// to the Kubernetes API server.
+	ErrCategoryAPIServer ErrCategory = "Kubernetes API server"
+
+	// An error is considered of the user error category when it arises due to some
+	// incorrect input or action from the user side and can resolve when the
+	// user fixes their inputs.
+	ErrCategoryUser ErrCategory = "user"
+
+	// An error is considered uncategorized when it does not fit into any of the other
+	// predefined error categories or no category has been explicitly assigned.
+	ErrCategoryUncategorized ErrCategory = "uncategorized"
+)
+
+var _ error = &Error{}
+
+type Error struct {
+	// category is the category of the error.
+	category ErrCategory
+
+	// wrapped is an error that this error wraps.
+	wrapped error
+
+	// desc is the additional description about the wrapped error.
+	desc string
+
+	// attrs are the additional attributes associated with the wrapped error.
+	attrs []interface{}
+
+	isRootLevel bool
+}
+
+func (e *Error) categoryWithDefault() ErrCategory {
+	if len(e.category) == 0 {
+		return ErrCategoryUncategorized
+	}
+	return e.category
+}
+
+// Error implements the error interface.
+//
+// Note the output intentionally does not include the additional attributes, so as to keep the cardinality
+// low; to print them out, pass them explicitly to the klog functions.
+func (e *Error) Error() string {
+	// Build a bitmap to determine the error template to use.
+	var bitmap int
+	if e.wrapped != nil {
+		bitmap |= 1 << 0
+	}
+	if len(e.desc) > 0 {
+		bitmap |= 1 << 1
+	}
+	if e.isRootLevel {
+		bitmap |= 1 << 2
+	}
+
+	switch bitmap {
+	case 1:
+		// With wrapped error, no description, and not a root level error.
+		return e.wrapped.Error()
+	case 2:
+		// No wrapped error, with description, and not a root level error.
+		return e.desc
+	case 3:
+		// With wrapped error, with description, and not a root level error.
+		return fmt.Sprintf("%s: %s", e.desc, e.wrapped.Error())
+	case 5:
+		// With wrapped error, no description, and is a root level error.
+		return fmt.Sprintf("a/an %s error occurred: %s", e.categoryWithDefault(), e.wrapped.Error())
+	case 6:
+		// No wrapped error, with description, and is a root level error.
+		return fmt.Sprintf("a/an %s error occurred: %s", e.categoryWithDefault(), e.desc)
+	case 7:
+		// With wrapped error, with description, and is a root level error.
+		return fmt.Sprintf("a/an %s error occurred: %s: %s", e.categoryWithDefault(), e.desc, e.wrapped.Error())
+	default:
+		// The following cases would trigger this output:
+		// * bitmap 0: no wrapped error, no description, and not a root level error.
+		// * bitmap 4: no wrapped error, no description, and is a root level error.
+		return "an unknown error occurred"
+	}
+}
+
+// Unwrap returns the wrapped error, so that errors.Is and errors.As can traverse the error chain as
+// expected.
+func (e *Error) Unwrap() error {
+	return e.wrapped
+}
+
+// Wraps wraps an existing error with a higher-level description and optional key-value attributes,
+// and returns a new *Error. If the existing error (or its children) is already an *Error,
+// Wraps will surface the category and the attributes to the top-level.
+func Wraps(err error, desc string, kvs ...interface{}) *Error {
+	// Find if any of error down in the chain is already an *Error; if so, use its category and surface its
+	// attributes to the current level.
+	var category ErrCategory
+	var childError *Error
+	if errors.As(err, &childError) {
+		category = childError.category
+		kvs = append(childError.attrs, kvs...)
+		childError.isRootLevel = false
+	}
+	if len(category) == 0 {
+		category = ErrCategoryUncategorized
+	}
+
+	return &Error{
+		category:    category,
+		wrapped:     err,
+		desc:        desc,
+		attrs:       kvs,
+		isRootLevel: true,
+	}
+}
+
+// Args returns the k-v attributes associated with an *Error (and its children).
+//
+// The function is designed to work with klog calls; to use it, call klog.ErrorS with:
+//
+// klog.ErrorS(err, "additional top-level error description", Args(err)...).
+//
+// If you need to add additional key-value attributes at the top level in addition to those
+// already captured from the error chain, append them to Args as follows:
+//
+// klog.ErrorS(err, "additional top-level error description", append(Args(err), "k", "v")...).
+func Args(err error, kvs ...interface{}) []interface{} {
+	var childError *Error
+	if errors.As(err, &childError) {
+		kvs = append(childError.attrs, kvs...)
+	}
+	return kvs
+}
+
+// CallerFrameOverview is a simple struct that summarizes a single call frame.
+type CallerFrameOverview struct {
+	Function string
+	File     string
+	Line     int
+}
+
+// captureCallers captures the current call stack and returns a slice of CallerFrameOverview
+// summarizing each frame in the stack, skipping the top 3 frames for simplicity.
+func captureCallers() []CallerFrameOverview {
+	pcs := make([]uintptr, 32)
+	// Skip 3 frames (the runtime.Callers function itself, this utility function, and the caller of this utility)
+	// when capturing the call stack for simplicity reasons.
+	n := runtime.Callers(3, pcs)
+	frames := runtime.CallersFrames(pcs[:n])
+	var callerFrames []CallerFrameOverview
+	for {
+		frame, more := frames.Next()
+		callerFrames = append(callerFrames, CallerFrameOverview{
+			Function: frame.Function,
+			File:     frame.File,
+			Line:     frame.Line,
+		})
+		if !more {
+			break
+		}
+	}
+	return callerFrames
+}
+
+// NewUnexpectedError creates a new Error categorized as ErrCategoryUnexpected. It is supposed to be called
+// at the lowest level possible, where the error category can be determined. The error can then be returned
+// and wrapped (w/ additional attributes if applicable).
+func NewUnexpectedError(err error, desc string, kvs ...interface{}) *Error {
+	// For unexpected errors, collect the caller frames.
+	//
+	// Note (chenyu1): previously for unexpected errors, we use the debug.Stack() to print out a full stack
+	// trace in the logs. Effective as it is, the operation is expensive and it always captuires the full stack,
+	// where the top of the stack is always the error handling utility function/method itself rather than
+	// the actual caller site where the error originates. Furthermore, as debug.Stack() returns a multi-line string,
+	// often the logging backend cannot render it properly, making it difficult to read/summarize. To address this,
+	// in this new implementation we switch to runtime.Callers and runtime.CallersFrames to capture the call stack
+	// in a structured way with the unrelated stacks skipped.
+	frames := captureCallers()
+	kvs = append(kvs, "callers", frames)
+
+	newErr := Wraps(err, desc, kvs...)
+	newErr.category = ErrCategoryUnexpected
+	return newErr
+}
+
+// NewTransientError creates a new Error categorized as ErrCategoryTransient. It is supposed to be called
+// at the lowest level possible, where the error category can be determined. The error can then be returned
+// and wrapped (w/ additional attributes if applicable).
+func NewTransientError(err error, desc string, kvs ...interface{}) *Error {
+	newErr := Wraps(err, desc, kvs...)
+	newErr.category = ErrCategoryTransient
+	return newErr
+}
+
+// NewUserError creates a new Error categorized as ErrCategoryUser. It is supposed to be called
+// at the lowest level possible, where the error category can be determined. The error can then be returned
+// and wrapped (w/ additional attributes if applicable).
+func NewUserError(err error, desc string, kvs ...interface{}) *Error {
+	newErr := Wraps(err, desc, kvs...)
+	newErr.category = ErrCategoryUser
+	return newErr
+}
+
+// NewAPIServerError creates a new Error categorized as ErrCategoryAPIServer. It is supposed to be called
+// at the lowest level possible, where the error category can be determined. The error can then be returned
+// and wrapped (w/ additional attributes if applicable).
+func NewAPIServerError(err error, desc string, cached bool, kvs ...interface{}) *Error {
+	// For API server errors, collect caching and HTTP response related information.
+	kvs = append(kvs, "cached", cached)
+	kvs = append(kvs, "APIServerErrReason", apierrors.ReasonForError(err))
+
+	apiErr, ok := err.(apierrors.APIStatus)
+	if ok {
+		kvs = append(kvs, "APIServerResHTTPCode", apiErr.Status().Code)
+	}
+
+	newErr := Wraps(err, desc, kvs...)
+	newErr.category = ErrCategoryAPIServer
+	return newErr
+}

--- a/pkg/utils/errors/errors_test.go
+++ b/pkg/utils/errors/errors_test.go
@@ -25,17 +25,20 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
+	"github.com/google/go-cmp/cmp"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
 )
 
+// TestCommonUsePatterns demonstrates how the common error handling patterns are enabled by the errors package.
 func TestCommonUsePatterns(t *testing.T) {
 	var bytesBuf bytes.Buffer
 	slogHandler := slog.NewTextHandler(&bytesBuf, &slog.HandlerOptions{Level: slog.LevelDebug})
 	logger := logr.FromSlogHandler(slogHandler)
 	klog.SetLogger(logger)
 
+	// Example 1: handling API server errors with rich context and structured logging.
 	rawAPIServerErr := apierrors.NewAlreadyExists(schema.GroupResource{Group: "", Resource: "namespaces"}, "work")
 	categorizedAPIServerErr := NewAPIServerError(rawAPIServerErr, "failed to create namespace", false, "k1", "v1")
 	wrappedErr := Wraps(categorizedAPIServerErr, "additional high-level error description", "k2", "v2", "k3", "v3")
@@ -44,19 +47,14 @@ func TestCommonUsePatterns(t *testing.T) {
 	// klog.ErrorS(wrappedErr, "additional top/controller-level error description", append(Args(wrappedErr), "k4", "v4", "k5", "v5")...)
 	klog.Flush()
 
-	output := make([]byte, 500)
-	n, err := bytesBuf.Read(output)
-	if err != nil && err != io.EOF {
-		t.Fatalf("Failed to read from bytes buffer: %v", err)
-	}
-	output = output[:n]
-	outputStr := string(output)
+	outputStr := readFromBuffer(t, &bytesBuf)
 
 	// The full error output looks like the follows:
-	// errors_test.go:53: time=2026-04-29T02:39:44.853+10:00 level=ERROR msg="additional top/controller-level error description" err="a/an Kubernetes API server error occurred: additional high-level error description: failed to create namespace: namespaces \"work\" already exists" k1=v1 cached=false APIServerErrReason=AlreadyExists APIServerResHTTPCode=409 k2=v2 k3=v3
+	// errors_test.go:53: time=2026-04-29T02:39:44.853+10:00 level=ERROR msg="additional top/controller-level error description" err="additional high-level error description: failed to create namespace: namespaces \"work\" already exists" errCategory=APIserver k1=v1 cached=false APIServerErrReason=AlreadyExists APIServerResHTTPCode=409 k2=v2 k3=v3
 	wantSubStrings := []string{
 		"msg=\"additional top/controller-level error description\"",
-		"err=\"a/an Kubernetes API server error occurred: additional high-level error description: failed to create namespace: namespaces \\\"work\\\" already exists\"",
+		"err=\"additional high-level error description: failed to create namespace: namespaces \\\"work\\\" already exists\"",
+		"errCategory=APIserver",
 		"k1=v1",
 		"k2=v2",
 		"k3=v3",
@@ -70,25 +68,21 @@ func TestCommonUsePatterns(t *testing.T) {
 		}
 	}
 
+	// Example 2: handling unexpected errors with rich context and structured logging.
 	rawUtilityCallErr := fmt.Errorf("cannot calculate resource hash")
 	categorizedUnexpectedErr := NewUnexpectedError(rawUtilityCallErr, "additional low-level error description", "k1", "v1")
 	wrappedUnexpectedErr := Wraps(categorizedUnexpectedErr, "additional high-level error description", "k2", "v2")
 	klog.ErrorS(wrappedUnexpectedErr, "additional top/controller-level error description", Args(wrappedUnexpectedErr)...)
 	klog.Flush()
 
-	output = make([]byte, 1000)
-	n, err = bytesBuf.Read(output)
-	if err != nil && err != io.EOF {
-		t.Fatalf("Failed to read from bytes buffer: %v", err)
-	}
-	output = output[:n]
-	outputStr = string(output)
+	outputStr = readFromBuffer(t, &bytesBuf)
 
 	// The full error output looks like the follows:
-	// errors_test.go:86: time=2026-04-29T02:49:04.560+10:00 level=ERROR msg="additional top/controller-level error description" err="a/an unexpected error occurred: additional high-level error description: additional low-level error description: cannot calculate resource hash" k1=v1 callers="[{Function:github.com/kubefleet-dev/kubefleet/pkg/utils/errors.TestCommonUsePatterns File:SomeFilePath Line:74} {Function:testing.tRunner File:SomeFilePath Line:1934} {Function:runtime.goexit File:SomeFilePath Line:1268}]" k2=v2
+	// errors_test.go:86: time=2026-04-29T02:49:04.560+10:00 level=ERROR msg="additional top/controller-level error description" err="additional high-level error description: additional low-level error description: cannot calculate resource hash" errCategory=unexpected k1=v1 callers="[{Function:github.com/kubefleet-dev/kubefleet/pkg/utils/errors.TestCommonUsePatterns File:SomeFilePath Line:74} {Function:testing.tRunner File:SomeFilePath Line:1934} {Function:runtime.goexit File:SomeFilePath Line:1268}]" k2=v2
 	wantSubStrings = []string{
 		"msg=\"additional top/controller-level error description\"",
-		"err=\"a/an unexpected error occurred: additional high-level error description: additional low-level error description: cannot calculate resource hash\"",
+		"err=\"additional high-level error description: additional low-level error description: cannot calculate resource hash\"",
+		"errCategory=unexpected",
 		"k1=v1",
 		"callers=",
 		"Function:github.com/kubefleet-dev/kubefleet/pkg/utils/errors.TestCommonUsePatterns",
@@ -99,4 +93,202 @@ func TestCommonUsePatterns(t *testing.T) {
 			t.Errorf("got %s\nwant to contain %s\n", outputStr, subStr)
 		}
 	}
+
+	// Example 3: handling uncategorized errors with rich context and structured logging.
+	rawErr := fmt.Errorf("something went wrong")
+	uncategorizedErr := Wraps(rawErr, "additional low-level error description", "k1", "v1")
+	wrappedUncategorizedErr := Wraps(uncategorizedErr, "additional high-level error description", "k2", "v2")
+	klog.ErrorS(wrappedUncategorizedErr, "additional top/controller-level error description", Args(wrappedUncategorizedErr)...)
+	klog.Flush()
+
+	outputStr = readFromBuffer(t, &bytesBuf)
+
+	// The full error output looks like the follows:
+	// errors_test.go:119: time=2026-04-29T02:59:04.560+10:00 level=ERROR msg="additional top/controller-level error description" err="additional high-level error description: additional low-level error description: something went wrong" errCategory=uncategorized k1=v1 k2=v2
+	wantSubStrings = []string{
+		"msg=\"additional top/controller-level error description\"",
+		"err=\"additional high-level error description: additional low-level error description: something went wrong\"",
+		"errCategory=uncategorized",
+		"k1=v1",
+		"k2=v2",
+	}
+	for _, subStr := range wantSubStrings {
+		if strings.Contains(outputStr, subStr) == false {
+			t.Errorf("got %s\nwant to contain %s\n", outputStr, subStr)
+		}
+	}
+}
+
+func TestErrorStringer(t *testing.T) {
+	wrappedErr := fmt.Errorf("something went wrong")
+
+	testCases := []struct {
+		name    string
+		err     *Error
+		wantMsg string
+	}{
+		{
+			name:    "no wrapped error, no description",
+			err:     &Error{},
+			wantMsg: "an unknown error occurred",
+		},
+		{
+			name:    "no wrapped error, with description",
+			err:     &Error{desc: "operation failed"},
+			wantMsg: "operation failed",
+		},
+		{
+			name:    "with wrapped error, no description",
+			err:     &Error{wrapped: wrappedErr},
+			wantMsg: "something went wrong",
+		},
+		{
+			name:    "with wrapped error, with description",
+			err:     &Error{wrapped: wrappedErr, desc: "operation failed"},
+			wantMsg: "operation failed: something went wrong",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.err.Error()
+			if got != tc.wantMsg {
+				t.Errorf("Error() = %q, want %q", got, tc.wantMsg)
+			}
+		})
+	}
+}
+
+func TestWraps(t *testing.T) {
+	plainErr := fmt.Errorf("plain error")
+	categorizedChildErr := &Error{
+		category: ErrCategoryUser,
+		desc:     "child desc",
+		attrs:    []interface{}{"ck1", "cv1"},
+	}
+
+	testCases := []struct {
+		name    string
+		err     error
+		desc    string
+		kvs     []interface{}
+		wantErr *Error
+	}{
+		{
+			name: "wrapping a plain error, no kvs",
+			err:  plainErr,
+			desc: "high level desc",
+			wantErr: &Error{
+				category: ErrCategoryUncategorized,
+				wrapped:  plainErr,
+				desc:     "high level desc",
+			},
+		},
+		{
+			name: "wrapping a plain error, with kvs",
+			err:  plainErr,
+			desc: "high level desc",
+			kvs:  []interface{}{"k1", "v1"},
+			wantErr: &Error{
+				category: ErrCategoryUncategorized,
+				wrapped:  plainErr,
+				desc:     "high level desc",
+				attrs:    []interface{}{"k1", "v1"},
+			},
+		},
+		{
+			name: "wrapping an *Error, no extra kvs",
+			err:  categorizedChildErr,
+			desc: "high level desc",
+			wantErr: &Error{
+				category: ErrCategoryUser,
+				wrapped:  categorizedChildErr,
+				desc:     "high level desc",
+				attrs:    []interface{}{"ck1", "cv1"},
+			},
+		},
+		{
+			name: "wrapping an *Error, with extra kvs",
+			err:  categorizedChildErr,
+			desc: "high level desc",
+			kvs:  []interface{}{"k2", "v2"},
+			wantErr: &Error{
+				category: ErrCategoryUser,
+				wrapped:  categorizedChildErr,
+				desc:     "high level desc",
+				attrs:    []interface{}{"ck1", "cv1", "k2", "v2"},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotErr := Wraps(tc.err, tc.desc, tc.kvs...)
+			if diff := cmp.Diff(gotErr, tc.wantErr,
+				cmp.AllowUnexported(Error{}),
+				// Compare the wrapped error field by pointer equality so that cmp does not
+				// need to recurse into unexported fields of standard-library error types.
+				cmp.FilterPath(func(p cmp.Path) bool {
+					return p.Last().String() == ".wrapped"
+				}, cmp.Comparer(func(x, y error) bool {
+					return x == y
+				})),
+			); diff != "" {
+				t.Errorf("Wraps() mismatch (-got, +want):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestArgs(t *testing.T) {
+	testCases := []struct {
+		name    string
+		err     error
+		kvs     []interface{}
+		wantKVs []interface{}
+	}{
+		{
+			name:    "plain error (not an *Error)",
+			err:     fmt.Errorf("plain error"),
+			wantKVs: nil,
+		},
+		{
+			name:    "*Error with no category set, no attrs, no extra kvs",
+			err:     &Error{},
+			wantKVs: []interface{}{"errCategory", ErrCategoryUncategorized},
+		},
+		{
+			name:    "*Error with explicit category, no attrs, no extra kvs",
+			err:     &Error{category: ErrCategoryUser},
+			wantKVs: []interface{}{"errCategory", ErrCategoryUser},
+		},
+		{
+			name:    "*Error with explicit category and attrs, no extra kvs",
+			err:     &Error{category: ErrCategoryAPIServer, attrs: []interface{}{"k1", "v1", "k2", "v2"}},
+			wantKVs: []interface{}{"errCategory", ErrCategoryAPIServer, "k1", "v1", "k2", "v2"},
+		},
+		{
+			name:    "*Error with explicit category and attrs, with extra kvs",
+			err:     &Error{category: ErrCategoryUnexpected, attrs: []interface{}{"k1", "v1"}},
+			kvs:     []interface{}{"k2", "v2"},
+			wantKVs: []interface{}{"errCategory", ErrCategoryUnexpected, "k1", "v1", "k2", "v2"},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotKVs := Args(tc.err, tc.kvs...)
+			if diff := cmp.Diff(gotKVs, tc.wantKVs); diff != "" {
+				t.Errorf("Args() mismatch (-got, +want):\n%s", diff)
+			}
+		})
+	}
+}
+
+func readFromBuffer(t *testing.T, buf *bytes.Buffer) string {
+	output := make([]byte, 1000)
+	n, err := buf.Read(output)
+	if err != nil && err != io.EOF {
+		t.Fatalf("Failed to read from bytes buffer: %v", err)
+	}
+	output = output[:n]
+	outputStr := string(output)
+	return outputStr
 }

--- a/pkg/utils/errors/errors_test.go
+++ b/pkg/utils/errors/errors_test.go
@@ -36,7 +36,7 @@ var (
 	// avoiding the need to recurse into unexported fields of standard-library error types.
 	wrappedErrComparer = cmp.FilterPath(
 		func(p cmp.Path) bool { return p.Last().String() == ".wrapped" },
-		cmp.Comparer(func(x, y error) bool { return x == y }),
+		cmp.Comparer(func(x, y error) bool { return x == y }), //nolint:errorlint
 	)
 )
 
@@ -306,7 +306,8 @@ func TestUnwrap(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			gotErr := tc.err.Unwrap()
-			if gotErr != tc.wantErr {
+			// Note: here we actually want to just compare the error values by pointer equality.
+			if gotErr != tc.wantErr { //nolint:errorlint
 				t.Errorf("Unwrap() = %v, want %v", gotErr, tc.wantErr)
 			}
 		})

--- a/pkg/utils/errors/errors_test.go
+++ b/pkg/utils/errors/errors_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2026 The KubeFleet Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
+)
+
+func TestCommonUsePatterns(t *testing.T) {
+	var bytesBuf bytes.Buffer
+	slogHandler := slog.NewTextHandler(&bytesBuf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	logger := logr.FromSlogHandler(slogHandler)
+	klog.SetLogger(logger)
+
+	rawAPIServerErr := apierrors.NewAlreadyExists(schema.GroupResource{Group: "", Resource: "namespaces"}, "work")
+	categorizedAPIServerErr := NewAPIServerError(rawAPIServerErr, "failed to create namespace", false, "k1", "v1")
+	wrappedErr := Wraps(categorizedAPIServerErr, "additional high-level error description", "k2", "v2", "k3", "v3")
+	klog.ErrorS(wrappedErr, "additional top/controller-level error description", Args(wrappedErr)...)
+	// If there needs to be kv attributes at the top level as well:
+	// klog.ErrorS(wrappedErr, "additional top/controller-level error description", append(Args(wrappedErr), "k4", "v4", "k5", "v5")...)
+	klog.Flush()
+
+	output := make([]byte, 500)
+	n, err := bytesBuf.Read(output)
+	if err != nil && err != io.EOF {
+		t.Fatalf("Failed to read from bytes buffer: %v", err)
+	}
+	output = output[:n]
+	outputStr := string(output)
+
+	// The full error output looks like the follows:
+	// errors_test.go:53: time=2026-04-29T02:39:44.853+10:00 level=ERROR msg="additional top/controller-level error description" err="a/an Kubernetes API server error occurred: additional high-level error description: failed to create namespace: namespaces \"work\" already exists" k1=v1 cached=false APIServerErrReason=AlreadyExists APIServerResHTTPCode=409 k2=v2 k3=v3
+	wantSubStrings := []string{
+		"msg=\"additional top/controller-level error description\"",
+		"err=\"a/an Kubernetes API server error occurred: additional high-level error description: failed to create namespace: namespaces \\\"work\\\" already exists\"",
+		"k1=v1",
+		"k2=v2",
+		"k3=v3",
+		"cached=false",
+		"APIServerErrReason=AlreadyExists",
+		"APIServerResHTTPCode=409",
+	}
+	for _, subStr := range wantSubStrings {
+		if strings.Contains(outputStr, subStr) == false {
+			t.Errorf("got %s\nwant to contain %s\n", outputStr, subStr)
+		}
+	}
+
+	rawUtilityCallErr := fmt.Errorf("cannot calculate resource hash")
+	categorizedUnexpectedErr := NewUnexpectedError(rawUtilityCallErr, "additional low-level error description", "k1", "v1")
+	wrappedUnexpectedErr := Wraps(categorizedUnexpectedErr, "additional high-level error description", "k2", "v2")
+	klog.ErrorS(wrappedUnexpectedErr, "additional top/controller-level error description", Args(wrappedUnexpectedErr)...)
+	klog.Flush()
+
+	output = make([]byte, 1000)
+	n, err = bytesBuf.Read(output)
+	if err != nil && err != io.EOF {
+		t.Fatalf("Failed to read from bytes buffer: %v", err)
+	}
+	output = output[:n]
+	outputStr = string(output)
+
+	// The full error output looks like the follows:
+	// errors_test.go:86: time=2026-04-29T02:49:04.560+10:00 level=ERROR msg="additional top/controller-level error description" err="a/an unexpected error occurred: additional high-level error description: additional low-level error description: cannot calculate resource hash" k1=v1 callers="[{Function:github.com/kubefleet-dev/kubefleet/pkg/utils/errors.TestCommonUsePatterns File:SomeFilePath Line:74} {Function:testing.tRunner File:SomeFilePath Line:1934} {Function:runtime.goexit File:SomeFilePath Line:1268}]" k2=v2
+	wantSubStrings = []string{
+		"msg=\"additional top/controller-level error description\"",
+		"err=\"a/an unexpected error occurred: additional high-level error description: additional low-level error description: cannot calculate resource hash\"",
+		"k1=v1",
+		"callers=",
+		"Function:github.com/kubefleet-dev/kubefleet/pkg/utils/errors.TestCommonUsePatterns",
+		"k2=v2",
+	}
+	for _, subStr := range wantSubStrings {
+		if strings.Contains(outputStr, subStr) == false {
+			t.Errorf("got %s\nwant to contain %s\n", outputStr, subStr)
+		}
+	}
+}

--- a/pkg/utils/errors/errors_test.go
+++ b/pkg/utils/errors/errors_test.go
@@ -31,6 +31,15 @@ import (
 	"k8s.io/klog/v2"
 )
 
+var (
+	// wrappedErrComparer is a cmp option that compares the .wrapped field by pointer equality,
+	// avoiding the need to recurse into unexported fields of standard-library error types.
+	wrappedErrComparer = cmp.FilterPath(
+		func(p cmp.Path) bool { return p.Last().String() == ".wrapped" },
+		cmp.Comparer(func(x, y error) bool { return x == y }),
+	)
+)
+
 // TestCommonUsePatterns demonstrates how the common error handling patterns are enabled by the errors package.
 func TestCommonUsePatterns(t *testing.T) {
 	var bytesBuf bytes.Buffer
@@ -224,13 +233,7 @@ func TestWraps(t *testing.T) {
 			gotErr := Wraps(tc.err, tc.desc, tc.kvs...)
 			if diff := cmp.Diff(gotErr, tc.wantErr,
 				cmp.AllowUnexported(Error{}),
-				// Compare the wrapped error field by pointer equality so that cmp does not
-				// need to recurse into unexported fields of standard-library error types.
-				cmp.FilterPath(func(p cmp.Path) bool {
-					return p.Last().String() == ".wrapped"
-				}, cmp.Comparer(func(x, y error) bool {
-					return x == y
-				})),
+				wrappedErrComparer,
 			); diff != "" {
 				t.Errorf("Wraps() mismatch (-got, +want):\n%s", diff)
 			}
@@ -280,6 +283,287 @@ func TestArgs(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestUnwrap(t *testing.T) {
+	innerErr := fmt.Errorf("inner error")
+	testCases := []struct {
+		name    string
+		err     *Error
+		wantErr error
+	}{
+		{
+			name:    "nil wrapped error",
+			err:     &Error{},
+			wantErr: nil,
+		},
+		{
+			name:    "non-nil wrapped error",
+			err:     &Error{wrapped: innerErr},
+			wantErr: innerErr,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotErr := tc.err.Unwrap()
+			if gotErr != tc.wantErr {
+				t.Errorf("Unwrap() = %v, want %v", gotErr, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestNewTransientError(t *testing.T) {
+	plainErr := fmt.Errorf("plain error")
+	categorizedChildErr := &Error{
+		category: ErrCategoryUser,
+		desc:     "child desc",
+		attrs:    []interface{}{"ck1", "cv1"},
+	}
+
+	testCases := []struct {
+		name    string
+		err     error
+		desc    string
+		kvs     []interface{}
+		wantErr *Error
+	}{
+		{
+			name: "plain error, no kvs",
+			err:  plainErr,
+			desc: "transient condition",
+			wantErr: &Error{
+				category: ErrCategoryTransient,
+				wrapped:  plainErr,
+				desc:     "transient condition",
+			},
+		},
+		{
+			name: "plain error, with kvs",
+			err:  plainErr,
+			desc: "transient condition",
+			kvs:  []interface{}{"k1", "v1"},
+			wantErr: &Error{
+				category: ErrCategoryTransient,
+				wrapped:  plainErr,
+				desc:     "transient condition",
+				attrs:    []interface{}{"k1", "v1"},
+			},
+		},
+		// This is technically speaking possible, but in practice users should not need to override categories.
+		{
+			name: "wrapping an *Error, category overridden to transient",
+			err:  categorizedChildErr,
+			desc: "transient condition",
+			kvs:  []interface{}{"k2", "v2"},
+			wantErr: &Error{
+				category: ErrCategoryTransient,
+				wrapped:  categorizedChildErr,
+				desc:     "transient condition",
+				attrs:    []interface{}{"ck1", "cv1", "k2", "v2"},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotErr := NewTransientError(tc.err, tc.desc, tc.kvs...)
+			if diff := cmp.Diff(gotErr, tc.wantErr,
+				cmp.AllowUnexported(Error{}),
+				wrappedErrComparer,
+			); diff != "" {
+				t.Errorf("NewTransientError() mismatch (-got, +want):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestNewUserError(t *testing.T) {
+	plainErr := fmt.Errorf("plain error")
+	categorizedChildErr := &Error{
+		category: ErrCategoryTransient,
+		desc:     "child desc",
+		attrs:    []interface{}{"ck1", "cv1"},
+	}
+
+	testCases := []struct {
+		name    string
+		err     error
+		desc    string
+		kvs     []interface{}
+		wantErr *Error
+	}{
+		{
+			name: "plain error, no kvs",
+			err:  plainErr,
+			desc: "invalid input",
+			wantErr: &Error{
+				category: ErrCategoryUser,
+				wrapped:  plainErr,
+				desc:     "invalid input",
+			},
+		},
+		{
+			name: "plain error, with kvs",
+			err:  plainErr,
+			desc: "invalid input",
+			kvs:  []interface{}{"k1", "v1"},
+			wantErr: &Error{
+				category: ErrCategoryUser,
+				wrapped:  plainErr,
+				desc:     "invalid input",
+				attrs:    []interface{}{"k1", "v1"},
+			},
+		},
+		{
+			// This is technically speaking possible, but in practice users should not need to override categories.
+			name: "wrapping an *Error, category overridden to user",
+			err:  categorizedChildErr,
+			desc: "invalid input",
+			kvs:  []interface{}{"k2", "v2"},
+			wantErr: &Error{
+				category: ErrCategoryUser,
+				wrapped:  categorizedChildErr,
+				desc:     "invalid input",
+				attrs:    []interface{}{"ck1", "cv1", "k2", "v2"},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotErr := NewUserError(tc.err, tc.desc, tc.kvs...)
+			if diff := cmp.Diff(gotErr, tc.wantErr,
+				cmp.AllowUnexported(Error{}),
+				wrappedErrComparer,
+			); diff != "" {
+				t.Errorf("NewUserError() mismatch (-got, +want):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestNewAPIServerError(t *testing.T) {
+	apiServerErr := apierrors.NewAlreadyExists(schema.GroupResource{Group: "", Resource: "namespaces"}, "fleet")
+	plainErr := fmt.Errorf("plain error")
+
+	testCases := []struct {
+		name    string
+		err     error
+		desc    string
+		cached  bool
+		kvs     []interface{}
+		wantErr *Error
+	}{
+		{
+			name:   "API server error, not cached, no extra kvs",
+			err:    apiServerErr,
+			desc:   "failed to create namespace",
+			cached: false,
+			wantErr: &Error{
+				category: ErrCategoryAPIServer,
+				wrapped:  apiServerErr,
+				desc:     "failed to create namespace",
+				attrs: []interface{}{
+					"cached", false,
+					"APIServerErrReason", apierrors.ReasonForError(apiServerErr),
+					"APIServerResHTTPCode", apiServerErr.Status().Code,
+				},
+			},
+		},
+		{
+			name:   "API server error, cached, with extra kvs",
+			err:    apiServerErr,
+			desc:   "failed to create namespace",
+			cached: true,
+			kvs:    []interface{}{"k1", "v1"},
+			wantErr: &Error{
+				category: ErrCategoryAPIServer,
+				wrapped:  apiServerErr,
+				desc:     "failed to create namespace",
+				attrs: []interface{}{
+					"k1", "v1",
+					"cached", true,
+					"APIServerErrReason", apierrors.ReasonForError(apiServerErr),
+					"APIServerResHTTPCode", apiServerErr.Status().Code,
+				},
+			},
+		},
+		{
+			name:   "non API server error, no HTTPCode in attrs",
+			err:    plainErr,
+			desc:   "unexpected failure",
+			cached: false,
+			wantErr: &Error{
+				category: ErrCategoryAPIServer,
+				wrapped:  plainErr,
+				desc:     "unexpected failure",
+				attrs: []interface{}{
+					"cached", false,
+					"APIServerErrReason", apierrors.ReasonForError(plainErr),
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotErr := NewAPIServerError(tc.err, tc.desc, tc.cached, tc.kvs...)
+			if diff := cmp.Diff(gotErr, tc.wantErr,
+				cmp.AllowUnexported(Error{}),
+				wrappedErrComparer,
+			); diff != "" {
+				t.Errorf("NewAPIServerError() mismatch (-got, +want):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestNewUnexpectedError(t *testing.T) {
+	plainErr := fmt.Errorf("plain error")
+	gotErr := NewUnexpectedError(plainErr, "low-level desc", "k1", "v1")
+
+	// Verify the category.
+	if gotErr.category != ErrCategoryUnexpected {
+		t.Errorf("NewUnexpectedError() category = %v, want %v", gotErr.category, ErrCategoryUnexpected)
+	}
+	// Verify wrapped error and description via Error().
+	wantMsg := "low-level desc: plain error"
+	if got := gotErr.Error(); got != wantMsg {
+		t.Errorf("NewUnexpectedError() Error() = %q, want %q", got, wantMsg)
+	}
+	// Verify that the user-provided kvs appear at the start of attrs.
+	if len(gotErr.attrs) < 2 || gotErr.attrs[0] != "k1" || gotErr.attrs[1] != "v1" {
+		t.Errorf("NewUnexpectedError() attrs = %v, want k1=v1 at start", gotErr.attrs)
+	}
+	// Verify that the callers key is present in attrs and its frame count is not zero.
+	found := false
+	canCast := false
+	var frames []CallerFrameOverview
+	for i := 0; i < len(gotErr.attrs)-1; i++ {
+		if gotErr.attrs[i] == "callers" {
+			found = true
+			frames, canCast = gotErr.attrs[i+1].([]CallerFrameOverview)
+			break
+		}
+	}
+	if !found {
+		t.Errorf("NewUnexpectedError() attrs = %v, want callers key present", gotErr.attrs)
+	}
+	if !canCast {
+		t.Errorf("NewUnexpectedError() callers value has type %T, want []CallerFrameOverview", gotErr.attrs)
+	}
+	if len(frames) == 0 {
+		t.Errorf("NewUnexpectedError() callers = %v, want non-zero frame count", frames)
+	}
+
+	// Verify the first frame (the current test code).
+	callerFunc := frames[0].Function
+	if callerFunc != "github.com/kubefleet-dev/kubefleet/pkg/utils/errors.TestNewUnexpectedError" {
+		t.Errorf("NewUnexpectedError() first caller function = %s, want TestNewUnexpectedError", callerFunc)
+	}
+	callerFile := frames[0].File
+	if !strings.HasSuffix(callerFile, "pkg/utils/errors/errors_test.go") {
+		t.Errorf("NewUnexpectedError() first caller file = %s, want to end with pkg/utils/errors/errors_test.go", callerFile)
+	}
+	// Note: skip verifying the exact line number as it may change with code edits.
 }
 
 func readFromBuffer(t *testing.T, buf *bytes.Buffer) string {


### PR DESCRIPTION
### Description of your changes

EXPERIMENTAL PR: posted for discussion.

This PR adds some utilities that allows better error handling.

The goal is primarily to:

* facilitate an error handling pattern where errors are wrapped in the caller chain, and logged with `klog.ErrorS` at the top level.
* enable additional k-v attribute bookkeeping at each level, so that contextual information can be recorded without having to call `klog.ErrorS` at each level.
* enable error categorization at the bottom level, where categorization should happen, but write the category as part of the output only at the top-level
* enable additional k-v attribute auto-capturing for specific categories

Refs #627 

I have:

- [x] Associated this change with a known KubeFleet Issue (Bug, Feature, etc).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

N/A -> posted for discussion only; if the pattern is OK, tests will be added later.

### Special notes for your reviewer


