### PR TITLE
fix: add pod/rs guardrail check consistently

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -641,12 +641,9 @@ func (w *Config) buildFleetGuardRailValidatingWebhooks() []admv1.ValidatingWebho
 
 	// Build core v1 resources list, conditionally including pods if workload is enabled
 	coreV1Resources := []string{bindingResourceName, configMapResourceName, endPointResourceName,
-		limitRangeResourceName, persistentVolumeClaimsName, persistentVolumeClaimsName + "/status", podTemplateResourceName,
+		limitRangeResourceName, persistentVolumeClaimsName, persistentVolumeClaimsName + "/status", podTemplateResourceName, podResourceName, podResourceName + "/status",
 		replicationControllerResourceName, replicationControllerResourceName + "/status", resourceQuotaResourceName, resourceQuotaResourceName + "/status", secretResourceName,
 		serviceAccountResourceName, servicesResourceName, servicesResourceName + "/status"}
-	if w.enableWorkload {
-		coreV1Resources = append(coreV1Resources, podResourceName, podResourceName+"/status")
-	}
 
 	namespacedResourcesRules = append(namespacedResourcesRules, admv1.RuleWithOperations{
 		Operations: cuOperations,
@@ -654,11 +651,8 @@ func (w *Config) buildFleetGuardRailValidatingWebhooks() []admv1.ValidatingWebho
 	})
 
 	// Build apps/v1 resources list, conditionally including replicasets if workload is enabled
-	appsV1Resources := []string{controllerRevisionResourceName, daemonSetResourceName, daemonSetResourceName + "/status",
+	appsV1Resources := []string{controllerRevisionResourceName, daemonSetResourceName, daemonSetResourceName + "/status", replicaSetResourceName, replicaSetResourceName + "/status",
 		deploymentResourceName, deploymentResourceName + "/status", statefulSetResourceName, statefulSetResourceName + "/status"}
-	if w.enableWorkload {
-		appsV1Resources = append(appsV1Resources, replicaSetResourceName, replicaSetResourceName+"/status")
-	}
 
 	namespacedResourcesRules = append(namespacedResourcesRules, admv1.RuleWithOperations{
 		Operations: cuOperations,


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that have a clear purpose. If yours fix an issue,
please uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Discovered a bug found in https://github.com/Azure/fleet/actions/runs/25028101218/job/73303685367?pr=1298. We should always enable pod/relicaset guardrail validation regardless of whether workload is enabled or not. The guardrail webhook blocks regular uses from creating pods or replicasets in `kube-*` and `fleet-system` reserved namespaces. Given that we already blocked deployment/daemonset/statefulsets, it makes sense to block pods and replicasets too.

Fixes #

I have:

- [ ] Associated this change with a known KubeFleet Issue (Bug, Feature, etc).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
