### PR TITLE
fix: specify which object failed in override error message

### DIFF
--- a/pkg/controllers/workgenerator/controller_integration_test.go
+++ b/pkg/controllers/workgenerator/controller_integration_test.go
@@ -57,10 +57,12 @@ var (
 	validClusterResourceOverrideSnapshotName   = "cro-1"
 	validResourceOverrideSnapshotName          = "ro-1"
 	invalidClusterResourceOverrideSnapshotName = "cro-2" // the overridden manifest is invalid
+	invalidResourceOverrideSnapshotName        = "ro-2"  // the overridden manifest is invalid
 
 	validClusterResourceOverrideSnapshot   placementv1beta1.ClusterResourceOverrideSnapshot
 	validResourceOverrideSnapshot          placementv1beta1.ResourceOverrideSnapshot
 	invalidClusterResourceOverrideSnapshot placementv1beta1.ClusterResourceOverrideSnapshot
+	invalidResourceOverrideSnapshot        placementv1beta1.ResourceOverrideSnapshot
 
 	bindingStatusCmpOpts = cmp.Options{
 		cmpopts.SortSlices(utils.LessFuncConditionByType),
@@ -280,7 +282,7 @@ var _ = Describe("Test Work Generator Controller for clusterResourcePlacement", 
 			// delete the binding
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: binding.Name}, binding)).Should(Succeed())
 			Expect(k8sClient.Delete(ctx, binding)).Should(Succeed())
-			By(fmt.Sprintf("resource binding  %s is deleted", binding.Name))
+			By(fmt.Sprintf("resource binding %s is deleted", binding.Name))
 			// check the binding is deleted
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, types.NamespacedName{Name: binding.Name}, binding)
@@ -302,7 +304,7 @@ var _ = Describe("Test Work Generator Controller for clusterResourcePlacement", 
 					testResourceCRD, testNameSpace, testResource,
 				})
 				Expect(k8sClient.Create(ctx, masterSnapshot)).Should(Succeed())
-				By(fmt.Sprintf("master resource snapshot  %s created", masterSnapshot.Name))
+				By(fmt.Sprintf("master resource snapshot %s created", masterSnapshot.Name))
 				spec := placementv1beta1.ResourceBindingSpec{
 					State:                placementv1beta1.BindingStateBound,
 					ResourceSnapshotName: masterSnapshot.Name,
@@ -383,7 +385,7 @@ var _ = Describe("Test Work Generator Controller for clusterResourcePlacement", 
 				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: binding.Name}, binding)).Should(Succeed())
 				binding.Spec.State = placementv1beta1.BindingStateUnscheduled
 				Expect(k8sClient.Update(ctx, binding)).Should(Succeed())
-				By(fmt.Sprintf("resource binding  %s updated to be unscheduled", binding.Name))
+				By(fmt.Sprintf("resource binding %s updated to be unscheduled", binding.Name))
 				updateRolloutStartedGeneration(&binding)
 				Consistently(func() error {
 					return k8sClient.Get(ctx, types.NamespacedName{Name: fmt.Sprintf(placementv1beta1.FirstWorkNameFmt, testCRPName), Namespace: memberClusterNamespaceName}, &work)
@@ -589,7 +591,7 @@ var _ = Describe("Test Work Generator Controller for clusterResourcePlacement", 
 					testConfigMap, testResourceEnvelope, testResourceCRD, testNameSpace,
 				})
 				Expect(k8sClient.Create(ctx, masterSnapshot)).Should(Succeed())
-				By(fmt.Sprintf("master resource snapshot  %s created", masterSnapshot.Name))
+				By(fmt.Sprintf("master resource snapshot %s created", masterSnapshot.Name))
 				spec := placementv1beta1.ResourceBindingSpec{
 					State:                placementv1beta1.BindingStateBound,
 					ResourceSnapshotName: masterSnapshot.Name,
@@ -692,12 +694,12 @@ var _ = Describe("Test Work Generator Controller for clusterResourcePlacement", 
 					testResourceEnvelope2, testResourceCRD, testNameSpace,
 				})
 				Expect(k8sClient.Create(ctx, masterSnapshot)).Should(Succeed())
-				By(fmt.Sprintf("another master resource snapshot  %s created", masterSnapshot.Name))
+				By(fmt.Sprintf("another master resource snapshot %s created", masterSnapshot.Name))
 				// update binding
 				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: binding.Name}, binding)).Should(Succeed())
 				binding.Spec.ResourceSnapshotName = masterSnapshot.Name
 				Expect(k8sClient.Update(ctx, binding)).Should(Succeed())
-				By(fmt.Sprintf("resource binding  %s updated", binding.Name))
+				By(fmt.Sprintf("resource binding %s updated", binding.Name))
 				updateRolloutStartedGeneration(&binding)
 				// check the binding status till the bound condition is true for the second generation
 				Eventually(func() bool {
@@ -711,7 +713,7 @@ var _ = Describe("Test Work Generator Controller for clusterResourcePlacement", 
 					return condition.IsConditionStatusTrue(
 						meta.FindStatusCondition(binding.Status.Conditions, string(placementv1beta1.ResourceBindingWorkSynchronized)), binding.GetGeneration())
 				}, timeout, interval).Should(BeTrue(), fmt.Sprintf("binding(%s) condition should be true", binding.Name))
-				By(fmt.Sprintf("resource binding  %s is reconciled", binding.Name))
+				By(fmt.Sprintf("resource binding %s is reconciled", binding.Name))
 				// check the work that contains none enveloped object is updated
 				work := placementv1beta1.Work{}
 				Eventually(func() error {
@@ -790,12 +792,12 @@ var _ = Describe("Test Work Generator Controller for clusterResourcePlacement", 
 					testResourceCRD, testNameSpace,
 				})
 				Expect(k8sClient.Create(ctx, masterSnapshot)).Should(Succeed())
-				By(fmt.Sprintf("another master resource snapshot  %s created", masterSnapshot.Name))
+				By(fmt.Sprintf("another master resource snapshot %s created", masterSnapshot.Name))
 				// update binding
 				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: binding.Name}, binding)).Should(Succeed())
 				binding.Spec.ResourceSnapshotName = masterSnapshot.Name
 				Expect(k8sClient.Update(ctx, binding)).Should(Succeed())
-				By(fmt.Sprintf("resource binding  %s updated", binding.Name))
+				By(fmt.Sprintf("resource binding %s updated", binding.Name))
 				updateRolloutStartedGeneration(&binding)
 				// check the binding status till the bound condition is true for the second binding generation
 				Eventually(func() bool {
@@ -809,7 +811,7 @@ var _ = Describe("Test Work Generator Controller for clusterResourcePlacement", 
 					return condition.IsConditionStatusTrue(
 						meta.FindStatusCondition(binding.Status.Conditions, string(placementv1beta1.ResourceBindingWorkSynchronized)), binding.GetGeneration())
 				}, timeout, interval).Should(BeTrue(), fmt.Sprintf("binding(%s) condition should be true", binding.Name))
-				By(fmt.Sprintf("resource binding  %s is reconciled", binding.Name))
+				By(fmt.Sprintf("resource binding %s is reconciled", binding.Name))
 				// check the enveloped work is deleted
 				Eventually(func() error {
 					envelopWorkLabelMatcher := client.MatchingLabels{
@@ -839,7 +841,7 @@ var _ = Describe("Test Work Generator Controller for clusterResourcePlacement", 
 					testClusterScopedEnvelope, testResourceCRD, testNameSpace,
 				})
 				Expect(k8sClient.Create(ctx, masterSnapshot)).Should(Succeed())
-				By(fmt.Sprintf("master resource snapshot  %s created", masterSnapshot.Name))
+				By(fmt.Sprintf("master resource snapshot %s created", masterSnapshot.Name))
 				spec := placementv1beta1.ResourceBindingSpec{
 					State:                placementv1beta1.BindingStateBound,
 					ResourceSnapshotName: masterSnapshot.Name,
@@ -942,12 +944,12 @@ var _ = Describe("Test Work Generator Controller for clusterResourcePlacement", 
 					testResourceCRD, testNameSpace,
 				})
 				Expect(k8sClient.Create(ctx, masterSnapshot)).Should(Succeed())
-				By(fmt.Sprintf("another master resource snapshot  %s created", masterSnapshot.Name))
+				By(fmt.Sprintf("another master resource snapshot %s created", masterSnapshot.Name))
 				// update binding
 				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: binding.Name}, binding)).Should(Succeed())
 				binding.Spec.ResourceSnapshotName = masterSnapshot.Name
 				Expect(k8sClient.Update(ctx, binding)).Should(Succeed())
-				By(fmt.Sprintf("resource binding  %s updated", binding.Name))
+				By(fmt.Sprintf("resource binding %s updated", binding.Name))
 				updateRolloutStartedGeneration(&binding)
 				// check the binding status till the bound condition is true for the second binding generation
 				Eventually(func() bool {
@@ -961,7 +963,7 @@ var _ = Describe("Test Work Generator Controller for clusterResourcePlacement", 
 					return condition.IsConditionStatusTrue(
 						meta.FindStatusCondition(binding.Status.Conditions, string(placementv1beta1.ResourceBindingWorkSynchronized)), binding.GetGeneration())
 				}, timeout, interval).Should(BeTrue(), fmt.Sprintf("binding(%s) condition should be true", binding.Name))
-				By(fmt.Sprintf("resource binding  %s is reconciled", binding.Name))
+				By(fmt.Sprintf("resource binding %s is reconciled", binding.Name))
 				// check the enveloped work is deleted
 				Eventually(func() error {
 					envelopWorkLabelMatcher := client.MatchingLabels{
@@ -990,7 +992,7 @@ var _ = Describe("Test Work Generator Controller for clusterResourcePlacement", 
 					testResourceCRD, testNameSpace, testResource,
 				})
 				Expect(k8sClient.Create(ctx, masterSnapshot)).Should(Succeed())
-				By(fmt.Sprintf("master resource snapshot  %s created", masterSnapshot.Name))
+				By(fmt.Sprintf("master resource snapshot %s created", masterSnapshot.Name))
 				// create binding
 				spec := placementv1beta1.ResourceBindingSpec{
 					State:                placementv1beta1.BindingStateBound,
@@ -1003,19 +1005,19 @@ var _ = Describe("Test Work Generator Controller for clusterResourcePlacement", 
 					testConfigMap, testPdb,
 				})
 				Expect(k8sClient.Create(ctx, secondSnapshot)).Should(Succeed())
-				By(fmt.Sprintf("secondary resource snapshot  %s created", secondSnapshot.Name))
+				By(fmt.Sprintf("secondary resource snapshot %s created", secondSnapshot.Name))
 			})
 
 			AfterEach(func() {
 				// delete the master resource snapshot
 				Expect(k8sClient.Delete(ctx, masterSnapshot)).Should(SatisfyAny(Succeed(), utils.NotFoundMatcher{}))
-				By(fmt.Sprintf("master resource snapshot  %s deleted", masterSnapshot.Name))
+				By(fmt.Sprintf("master resource snapshot %s deleted", masterSnapshot.Name))
 				// delete the second resource snapshot
 				Expect(k8sClient.Delete(ctx, secondSnapshot)).Should(SatisfyAny(Succeed(), utils.NotFoundMatcher{}))
-				By(fmt.Sprintf("secondary resource snapshot  %s deleted", secondSnapshot.Name))
+				By(fmt.Sprintf("secondary resource snapshot %s deleted", secondSnapshot.Name))
 				// delete the binding
 				Expect(k8sClient.Delete(ctx, binding)).Should(SatisfyAny(Succeed(), utils.NotFoundMatcher{}))
-				By(fmt.Sprintf("resource binding  %s deleted", binding.Name))
+				By(fmt.Sprintf("resource binding %s deleted", binding.Name))
 			})
 
 			It("Should create all the work in the target namespace after all the resource snapshot are created", func() {
@@ -1033,7 +1035,7 @@ var _ = Describe("Test Work Generator Controller for clusterResourcePlacement", 
 				}
 				diff := cmp.Diff(expectedManifest, work.Spec.Workload.Manifests)
 				Expect(diff).Should(BeEmpty(), fmt.Sprintf("work manifest(%s) mismatch (-want +got):\n%s", work.Name, diff))
-				// check the work for the secondary resource snapshot is created, it's name is crp-subindex
+				// check the work for the secondary resource snapshot is created, its name is crp-subindex
 				secondWork := placementv1beta1.Work{}
 				Eventually(func() error {
 					return k8sClient.Get(ctx, types.NamespacedName{Name: fmt.Sprintf(placementv1beta1.WorkNameWithSubindexFmt, testCRPName, 1), Namespace: memberClusterNamespaceName}, &secondWork)
@@ -1099,7 +1101,7 @@ var _ = Describe("Test Work Generator Controller for clusterResourcePlacement", 
 				}
 				diff := cmp.Diff(expectedManifest, work.Spec.Workload.Manifests)
 				Expect(diff).Should(BeEmpty(), fmt.Sprintf("work manifest(%s) mismatch (-want +got):\n%s", work.Name, diff))
-				// check the work for the secondary resource snapshot is created, it's name is crp-subindex
+				// check the work for the secondary resource snapshot is created, its name is crp-subindex
 				secondWork := placementv1beta1.Work{}
 				Eventually(func() error {
 					return k8sClient.Get(ctx, types.NamespacedName{Name: fmt.Sprintf(placementv1beta1.WorkNameWithSubindexFmt, testCRPName, 1), Namespace: memberClusterNamespaceName}, &secondWork)
@@ -1155,7 +1157,7 @@ var _ = Describe("Test Work Generator Controller for clusterResourcePlacement", 
 					return k8sClient.Get(ctx, types.NamespacedName{Name: fmt.Sprintf(placementv1beta1.FirstWorkNameFmt, testCRPName), Namespace: memberClusterNamespaceName}, &work)
 				}, timeout, interval).Should(Succeed(), "Failed to get the expected work in hub cluster")
 				By(fmt.Sprintf("first work %s is created in %s", work.Name, work.Namespace))
-				// check the work for the secondary resource snapshot is created, it's name is crp-subindex
+				// check the work for the secondary resource snapshot is created, its name is crp-subindex
 				Eventually(func() error {
 					return k8sClient.Get(ctx, types.NamespacedName{Name: fmt.Sprintf(placementv1beta1.WorkNameWithSubindexFmt, testCRPName, 1), Namespace: memberClusterNamespaceName}, &work)
 				}, timeout, interval).Should(Succeed(), "Failed to get the expected work in hub cluster")
@@ -1165,25 +1167,25 @@ var _ = Describe("Test Work Generator Controller for clusterResourcePlacement", 
 					testResourceCRD, testNameSpace,
 				})
 				Expect(k8sClient.Create(ctx, masterSnapshot)).Should(Succeed())
-				By(fmt.Sprintf("new master resource snapshot  %s created", masterSnapshot.Name))
+				By(fmt.Sprintf("new master resource snapshot %s created", masterSnapshot.Name))
 				// update binding
 				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: binding.Name}, binding)).Should(Succeed())
 				binding.Spec.ResourceSnapshotName = masterSnapshot.Name
 				Expect(k8sClient.Update(ctx, binding)).Should(Succeed())
 				updateRolloutStartedGeneration(&binding)
-				By(fmt.Sprintf("resource binding  %s updated", binding.Name))
+				By(fmt.Sprintf("resource binding %s updated", binding.Name))
 				// Now create the second resource snapshot
 				secondSnapshot = generateClusterResourceSnapshot(3, 3, 1, [][]byte{
 					testResource, testConfigMap,
 				})
 				Expect(k8sClient.Create(ctx, secondSnapshot)).Should(Succeed())
-				By(fmt.Sprintf("new secondary resource snapshot  %s created", secondSnapshot.Name))
+				By(fmt.Sprintf("new secondary resource snapshot %s created", secondSnapshot.Name))
 				// Now create the third resource snapshot
 				thirdSnapshot := generateClusterResourceSnapshot(3, 3, 2, [][]byte{
 					testPdb,
 				})
 				Expect(k8sClient.Create(ctx, thirdSnapshot)).Should(Succeed())
-				By(fmt.Sprintf("third resource snapshot  %s created", secondSnapshot.Name))
+				By(fmt.Sprintf("third resource snapshot %s created", secondSnapshot.Name))
 				// check the work for the master resource snapshot is created
 				expectedManifest := []placementv1beta1.Manifest{
 					{RawExtension: runtime.RawExtension{Raw: testResourceCRD}},
@@ -1201,7 +1203,7 @@ var _ = Describe("Test Work Generator Controller for clusterResourcePlacement", 
 					return nil
 				}, timeout, interval).Should(Succeed(), "Failed to get the expected work in hub cluster")
 				By(fmt.Sprintf("first work %s is updated in %s", work.Name, work.Namespace))
-				// check the work for the secondary resource snapshot is created, it's name is crp-subindex
+				// check the work for the secondary resource snapshot is created, its name is crp-subindex
 				expectedManifest = []placementv1beta1.Manifest{
 					{RawExtension: runtime.RawExtension{Raw: testResource}},
 					{RawExtension: runtime.RawExtension{Raw: testConfigMap}},
@@ -1220,7 +1222,7 @@ var _ = Describe("Test Work Generator Controller for clusterResourcePlacement", 
 					return nil
 				}, timeout, interval).Should(Succeed(), "Failed to get the expected work in hub cluster")
 				By(fmt.Sprintf("second work %s is updated in %s", work.Name, work.Namespace))
-				// check the work for the third resource snapshot is created, it's name is crp-subindex
+				// check the work for the third resource snapshot is created, its name is crp-subindex
 				expectedManifest = []placementv1beta1.Manifest{
 					{RawExtension: runtime.RawExtension{Raw: testPdb}},
 				}
@@ -1247,7 +1249,7 @@ var _ = Describe("Test Work Generator Controller for clusterResourcePlacement", 
 					return k8sClient.Get(ctx, types.NamespacedName{Name: fmt.Sprintf(placementv1beta1.FirstWorkNameFmt, testCRPName), Namespace: memberClusterNamespaceName}, &work)
 				}, timeout, interval).Should(Succeed(), "Failed to get the expected work in hub cluster")
 				By(fmt.Sprintf("first work %s is created in %s", work.Name, work.Namespace))
-				// check the work for the secondary resource snapshot is created, it's name is crp-subindex
+				// check the work for the secondary resource snapshot is created, its name is crp-subindex
 				Eventually(func() error {
 					return k8sClient.Get(ctx, types.NamespacedName{Name: fmt.Sprintf(placementv1beta1.WorkNameWithSubindexFmt, testCRPName, 1), Namespace: memberClusterNamespaceName}, &work)
 				}, timeout, interval).Should(Succeed(), "Failed to get the expected work in hub cluster")
@@ -1257,13 +1259,13 @@ var _ = Describe("Test Work Generator Controller for clusterResourcePlacement", 
 					testResourceCRD, testNameSpace, testResource, testConfigMap, testPdb,
 				})
 				Expect(k8sClient.Create(ctx, masterSnapshot)).Should(Succeed())
-				By(fmt.Sprintf("new master resource snapshot  %s created", masterSnapshot.Name))
+				By(fmt.Sprintf("new master resource snapshot %s created", masterSnapshot.Name))
 				// update binding
 				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: binding.Name}, binding)).Should(Succeed())
 				binding.Spec.ResourceSnapshotName = masterSnapshot.Name
 				Expect(k8sClient.Update(ctx, binding)).Should(Succeed())
 				updateRolloutStartedGeneration(&binding)
-				By(fmt.Sprintf("resource binding  %s updated", binding.Name))
+				By(fmt.Sprintf("resource binding %s updated", binding.Name))
 				//inspect the work manifest that should have been updated to contain all
 				expectedManifest := []placementv1beta1.Manifest{
 					{RawExtension: runtime.RawExtension{Raw: testResourceCRD}},
@@ -1301,7 +1303,7 @@ var _ = Describe("Test Work Generator Controller for clusterResourcePlacement", 
 					return k8sClient.Get(ctx, types.NamespacedName{Name: fmt.Sprintf(placementv1beta1.FirstWorkNameFmt, testCRPName), Namespace: memberClusterNamespaceName}, &work)
 				}, timeout, interval).Should(Succeed(), "Failed to get the expected work in hub cluster")
 				By(fmt.Sprintf("first work %s is created in %s", work.Name, work.Namespace))
-				// check the work for the secondary resource snapshot is created, it's name is crp-subindex
+				// check the work for the secondary resource snapshot is created, its name is crp-subindex
 				work2 := placementv1beta1.Work{}
 				Eventually(func() error {
 					return k8sClient.Get(ctx, types.NamespacedName{Name: fmt.Sprintf(placementv1beta1.WorkNameWithSubindexFmt, testCRPName, 1), Namespace: memberClusterNamespaceName}, &work2)
@@ -1310,7 +1312,7 @@ var _ = Describe("Test Work Generator Controller for clusterResourcePlacement", 
 				// delete the binding
 				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: binding.Name}, binding)).Should(Succeed())
 				Expect(k8sClient.Delete(ctx, binding)).Should(Succeed())
-				By(fmt.Sprintf("resource binding  %s is deleted", binding.Name))
+				By(fmt.Sprintf("resource binding %s is deleted", binding.Name))
 
 				// verify that all associated works have been deleted
 				Eventually(func() error {
@@ -1352,7 +1354,7 @@ var _ = Describe("Test Work Generator Controller for clusterResourcePlacement", 
 					testResourceCRD, testNameSpace, testResource,
 				})
 				Expect(k8sClient.Create(ctx, masterSnapshot)).Should(Succeed())
-				By(fmt.Sprintf("master resource snapshot  %s created", masterSnapshot.Name))
+				By(fmt.Sprintf("master resource snapshot %s created", masterSnapshot.Name))
 				crolist := []string{validClusterResourceOverrideSnapshotName}
 				roList := []placementv1beta1.NamespacedName{
 					{
@@ -1446,7 +1448,7 @@ var _ = Describe("Test Work Generator Controller for clusterResourcePlacement", 
 				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: binding.Name}, binding)).Should(Succeed())
 				binding.Spec.State = placementv1beta1.BindingStateUnscheduled
 				Expect(k8sClient.Update(ctx, binding)).Should(Succeed())
-				By(fmt.Sprintf("resource binding  %s updated to be unscheduled", binding.Name))
+				By(fmt.Sprintf("resource binding %s updated to be unscheduled", binding.Name))
 				updateRolloutStartedGeneration(&binding)
 				Consistently(func() error {
 					return k8sClient.Get(ctx, types.NamespacedName{Name: fmt.Sprintf(placementv1beta1.FirstWorkNameFmt, testCRPName), Namespace: memberClusterNamespaceName}, &work)
@@ -1472,7 +1474,7 @@ var _ = Describe("Test Work Generator Controller for clusterResourcePlacement", 
 					testResourceCRD, testNameSpace, testResource,
 				})
 				Expect(k8sClient.Create(ctx, masterSnapshot)).Should(Succeed())
-				By(fmt.Sprintf("master resource snapshot  %s created", masterSnapshot.Name))
+				By(fmt.Sprintf("master resource snapshot %s created", masterSnapshot.Name))
 				spec := placementv1beta1.ResourceBindingSpec{
 					State:                placementv1beta1.BindingStateBound,
 					ResourceSnapshotName: masterSnapshot.Name,
@@ -1519,7 +1521,70 @@ var _ = Describe("Test Work Generator Controller for clusterResourcePlacement", 
 					}
 					return cmp.Diff(wantStatus, binding.Status, cmpConditionOption)
 				}, timeout, interval).Should(BeEmpty(), fmt.Sprintf("binding(%s) mismatch (-want +got)", binding.Name))
-				Expect(binding.GetCondition(string(placementv1beta1.ResourceBindingOverridden)).Message).Should(ContainSubstring("Failed to apply the override rules on the resources: add operation does not apply"))
+				message := binding.GetCondition(string(placementv1beta1.ResourceBindingOverridden)).Message
+				Expect(message).Should(MatchRegexp(`ClusterResourceOverrideSnapshot "[^"]+" failed to apply on \w+ "[^"]+".*: .*add operation does not apply`))
+			})
+		})
+
+		Context("Test Bound ClusterResourceBinding with a single resource snapshot and invalid resource override", func() {
+			var masterSnapshot *placementv1beta1.ClusterResourceSnapshot
+
+			BeforeEach(func() {
+				masterSnapshot = generateClusterResourceSnapshot(1, 1, 0, [][]byte{
+					testResourceCRD, testNameSpace, testResource,
+				})
+				Expect(k8sClient.Create(ctx, masterSnapshot)).Should(Succeed())
+				By(fmt.Sprintf("master resource snapshot %s created", masterSnapshot.Name))
+				spec := placementv1beta1.ResourceBindingSpec{
+					State:                placementv1beta1.BindingStateBound,
+					ResourceSnapshotName: masterSnapshot.Name,
+					TargetCluster:        memberClusterName,
+					ResourceOverrideSnapshots: []placementv1beta1.NamespacedName{
+						{
+							Name:      invalidResourceOverrideSnapshotName,
+							Namespace: appNamespaceName,
+						},
+					},
+				}
+				createClusterResourceBinding(&binding, spec)
+			})
+
+			AfterEach(func() {
+				By("Deleting master clusterResourceSnapshot")
+				Expect(k8sClient.Delete(ctx, masterSnapshot)).Should(SatisfyAny(Succeed(), utils.NotFoundMatcher{}))
+			})
+
+			It("Should not create the work in the target namespace and surface ResourceOverrideSnapshot identity in the condition message", func() {
+				work := placementv1beta1.Work{}
+				Consistently(func() bool {
+					err := k8sClient.Get(ctx, types.NamespacedName{Name: fmt.Sprintf(placementv1beta1.FirstWorkNameFmt, testCRPName), Namespace: memberClusterNamespaceName}, &work)
+					return errors.IsNotFound(err)
+				}, duration, interval).Should(BeTrue(), "controller should not create work in hub cluster when an override fails")
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: binding.Name}, binding)).Should(Succeed())
+				Expect(len(binding.Finalizers)).Should(Equal(1))
+
+				Eventually(func() string {
+					Expect(k8sClient.Get(ctx, types.NamespacedName{Name: binding.Name}, binding)).Should(Succeed())
+					wantStatus := placementv1beta1.ResourceBindingStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:               string(placementv1beta1.ResourceBindingRolloutStarted),
+								Status:             metav1.ConditionTrue,
+								Reason:             condition.RolloutStartedReason,
+								ObservedGeneration: binding.GetGeneration(),
+							},
+							{
+								Type:               string(placementv1beta1.ResourceBindingOverridden),
+								Status:             metav1.ConditionFalse,
+								Reason:             condition.OverriddenFailedReason,
+								ObservedGeneration: binding.GetGeneration(),
+							},
+						},
+					}
+					return cmp.Diff(wantStatus, binding.Status, cmpConditionOption)
+				}, timeout, interval).Should(BeEmpty(), fmt.Sprintf("binding(%s) mismatch (-want +got)", binding.Name))
+				message := binding.GetCondition(string(placementv1beta1.ResourceBindingOverridden)).Message
+				Expect(message).Should(MatchRegexp(`ResourceOverrideSnapshot "[^"]+" failed to apply on \w+ "[^"]+".*: .*add operation does not apply`))
 			})
 		})
 
@@ -1531,7 +1596,7 @@ var _ = Describe("Test Work Generator Controller for clusterResourcePlacement", 
 					testResourceCRD, testNameSpace, testResource,
 				})
 				Expect(k8sClient.Create(ctx, masterSnapshot)).Should(Succeed())
-				By(fmt.Sprintf("master resource snapshot  %s created", masterSnapshot.Name))
+				By(fmt.Sprintf("master resource snapshot %s created", masterSnapshot.Name))
 				spec := placementv1beta1.ResourceBindingSpec{
 					State:                placementv1beta1.BindingStateBound,
 					ResourceSnapshotName: masterSnapshot.Name,
@@ -1588,7 +1653,7 @@ var _ = Describe("Test Work Generator Controller for clusterResourcePlacement", 
 					testResourceCRD, testNameSpace, testResource,
 				})
 				Expect(k8sClient.Create(ctx, masterSnapshot)).Should(Succeed())
-				By(fmt.Sprintf("master resource snapshot  %s created", masterSnapshot.Name))
+				By(fmt.Sprintf("master resource snapshot %s created", masterSnapshot.Name))
 				spec := placementv1beta1.ResourceBindingSpec{
 					State:                placementv1beta1.BindingStateBound,
 					ResourceSnapshotName: masterSnapshot.Name,
@@ -1673,7 +1738,7 @@ var _ = Describe("Test Work Generator Controller for clusterResourcePlacement", 
 				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: binding.Name}, binding)).Should(Succeed())
 				binding.Spec.State = placementv1beta1.BindingStateUnscheduled
 				Expect(k8sClient.Update(ctx, binding)).Should(Succeed())
-				By(fmt.Sprintf("resource binding  %s updated to be unscheduled", binding.Name))
+				By(fmt.Sprintf("resource binding %s updated to be unscheduled", binding.Name))
 				updateRolloutStartedGeneration(&binding)
 				rolloutCond := binding.GetCondition(string(placementv1beta1.ResourceBindingRolloutStarted))
 				Consistently(func() error {

--- a/pkg/controllers/workgenerator/override.go
+++ b/pkg/controllers/workgenerator/override.go
@@ -35,6 +35,11 @@ import (
 	"github.com/kubefleet-dev/kubefleet/pkg/utils/overrider"
 )
 
+// fetchClusterResourceOverrideSnapshots returns the ClusterResourceOverrideSnapshots referenced
+// by the given binding, keyed by the ResourceIdentifier each snapshot's selectors target. The
+// returned map preserves the order in which the binding lists the snapshots, so the caller can
+// apply them in a deterministic sequence.
+//
 // TODO: combine the following two functions into one, as they are very similar.
 func (r *Reconciler) fetchClusterResourceOverrideSnapshots(ctx context.Context, resourceBinding placementv1beta1.BindingObj) (map[placementv1beta1.ResourceIdentifier][]*placementv1beta1.ClusterResourceOverrideSnapshot, error) {
 	croMap := make(map[placementv1beta1.ResourceIdentifier][]*placementv1beta1.ClusterResourceOverrideSnapshot)
@@ -70,6 +75,10 @@ func (r *Reconciler) fetchClusterResourceOverrideSnapshots(ctx context.Context, 
 	return croMap, nil
 }
 
+// fetchResourceOverrideSnapshots returns the ResourceOverrideSnapshots referenced by the given
+// binding, keyed by the ResourceIdentifier each snapshot's selectors target. The returned map
+// preserves the order in which the binding lists the snapshots, so the caller can apply them in
+// a deterministic sequence.
 func (r *Reconciler) fetchResourceOverrideSnapshots(ctx context.Context, resourceBinding placementv1beta1.BindingObj) (map[placementv1beta1.ResourceIdentifier][]*placementv1beta1.ResourceOverrideSnapshot, error) {
 	roMap := make(map[placementv1beta1.ResourceIdentifier][]*placementv1beta1.ResourceOverrideSnapshot)
 
@@ -127,11 +136,11 @@ func (r *Reconciler) applyOverrides(resource *placementv1beta1.ResourceContent, 
 		Kind:    gvk.Kind,
 		Name:    uResource.GetName(),
 	}
-	isClusterScopeResource := r.InformerManager.IsClusterScopedResources(gvk)
+	isClusterScopedResource := r.InformerManager.IsClusterScopedResources(gvk)
 
 	// For the namespace scoped resource, it could be selected by the namespace itself.
-	// use the namespace as the key
-	if !isClusterScopeResource {
+	// Use the namespace as the key.
+	if !isClusterScopedResource {
 		key = placementv1beta1.ResourceIdentifier{
 			Group:   utils.NamespaceMetaGVK.Group,
 			Version: utils.NamespaceMetaGVK.Version,
@@ -149,14 +158,15 @@ func (r *Reconciler) applyOverrides(resource *placementv1beta1.ResourceContent, 
 		}
 		if err := applyOverrideRules(resource, cluster, snapshot.Spec.OverrideSpec.Policy.OverrideRules); err != nil {
 			klog.ErrorS(err, "Failed to apply the override rules", "clusterResourceOverrideSnapshot", klog.KObj(snapshot))
-			return false, err
+			return false, fmt.Errorf("%w: ClusterResourceOverrideSnapshot %q failed to apply on %s: %s",
+				controller.ErrUserError, snapshot.Name, formatOverrideTarget(&uResource), err.Error())
 		}
 	}
 	klog.V(2).InfoS("Applied clusterResourceOverrideSnapshots", "resource", klog.KObj(&uResource), "numberOfOverrides", len(croMap[key]))
 
 	// If the resource is selected by both ClusterResourceOverride and ResourceOverride, ResourceOverride will win when resolving conflicts.
 	// Apply ResourceOverrideSnapshots.
-	if !isClusterScopeResource {
+	if !isClusterScopedResource {
 		key = placementv1beta1.ResourceIdentifier{
 			Group:     gvk.Group,
 			Version:   gvk.Version,
@@ -172,7 +182,8 @@ func (r *Reconciler) applyOverrides(resource *placementv1beta1.ResourceContent, 
 			}
 			if err := applyOverrideRules(resource, cluster, snapshot.Spec.OverrideSpec.Policy.OverrideRules); err != nil {
 				klog.ErrorS(err, "Failed to apply the override rules", "resourceOverrideSnapshot", klog.KObj(snapshot))
-				return false, err
+				return false, fmt.Errorf("%w: ResourceOverrideSnapshot %q failed to apply on %s: %s",
+					controller.ErrUserError, snapshot.Name, formatOverrideTarget(&uResource), err.Error())
 			}
 		}
 		klog.V(2).InfoS("Applied resourceOverrideSnapshots", "resource", klog.KObj(&uResource), "numberOfOverrides", len(roMap[key]))
@@ -180,12 +191,27 @@ func (r *Reconciler) applyOverrides(resource *placementv1beta1.ResourceContent, 
 	return resource.Raw == nil, nil
 }
 
+// formatOverrideTarget returns a human-readable identifier for the resource being overridden,
+// suitable for inclusion in a user-facing error message (e.g. `Deployment "my-app" in namespace "default"`).
+func formatOverrideTarget(target *unstructured.Unstructured) string {
+	kind := target.GetObjectKind().GroupVersionKind().Kind
+	if ns := target.GetNamespace(); ns != "" {
+		return fmt.Sprintf("%s %q in namespace %q", kind, target.GetName(), ns)
+	}
+	return fmt.Sprintf("%s %q", kind, target.GetName())
+}
+
+// applyOverrideRules applies the given override rules to the resource for the cluster. Rules
+// whose cluster selector does not match the cluster are skipped. A DeleteOverrideType rule
+// clears the resource and ends rule application; otherwise the rule's JSON patches are applied
+// in order. The first rule that fails returns its raw error to the caller, which is responsible
+// for tagging the failure as a user error.
 func applyOverrideRules(resource *placementv1beta1.ResourceContent, cluster *clusterv1beta1.MemberCluster, rules []placementv1beta1.OverrideRule) error {
 	for _, rule := range rules {
 		matched, err := overrider.IsClusterMatched(cluster, rule)
 		if err != nil {
 			klog.ErrorS(controller.NewUnexpectedBehaviorError(err), "Found an invalid override rule")
-			return controller.NewUserError(err) // should not happen though and should be rejected by the webhook
+			return err // should not happen though and should be rejected by the webhook
 		}
 		if !matched {
 			continue
@@ -198,7 +224,7 @@ func applyOverrideRules(resource *placementv1beta1.ResourceContent, cluster *clu
 		// Apply JSONPatchOverrides by default
 		if err = applyJSONPatchOverride(resource, cluster, rule.JSONPatchOverrides); err != nil {
 			klog.ErrorS(err, "Failed to apply JSON patch override")
-			return controller.NewUserError(err)
+			return err
 		}
 	}
 	return nil
@@ -207,11 +233,11 @@ func applyOverrideRules(resource *placementv1beta1.ResourceContent, cluster *clu
 // applyJSONPatchOverride applies a JSON patch on the selected resources following [RFC 6902](https://datatracker.ietf.org/doc/html/rfc6902).
 func applyJSONPatchOverride(resourceContent *placementv1beta1.ResourceContent, cluster *clusterv1beta1.MemberCluster, overrides []placementv1beta1.JSONPatchOverride) error {
 	var err error
-	if len(overrides) == 0 { // do nothing
+	if len(overrides) == 0 {
 		return nil
 	}
-	// go through the JSON patch overrides to replace the built-in variables before json Marshal
-	// as it may contain the built-in variables that cannot be marshaled directly
+	// Go through the JSON patch overrides to replace the built-in variables before json.Marshal,
+	// as the patch values may contain built-in variables that cannot be marshaled directly.
 	for i := range overrides {
 		// Process the JSON string to replace variables
 		jsonStr := string(overrides[i].Value.Raw)
@@ -263,14 +289,14 @@ func replaceClusterLabelKeyVariables(input string, cluster *clusterv1beta1.Membe
 		// extract the key value user wants to replace
 		endIdx := strings.Index(result[startIdx+prefixLen:], "}")
 		if endIdx == -1 {
-			klog.V(2).InfoS("malformed key ${MEMBER-CLUSTER-LABEL-KEY without the closing `}`", "input", input)
+			klog.V(2).InfoS("Malformed key ${MEMBER-CLUSTER-LABEL-KEY without the closing `}`", "input", input)
 			return "", fmt.Errorf("input %s is missing the closing bracket `}`", input)
 		}
 		endIdx += startIdx + prefixLen
 		// extract the key name
 		keyName := result[startIdx+prefixLen : endIdx]
 		// check if the key exists in the cluster labels
-		labelValue, exists := cluster.ObjectMeta.Labels[keyName]
+		labelValue, exists := cluster.Labels[keyName]
 		if !exists {
 			klog.V(2).InfoS("Label key not found on cluster", "key", keyName, "cluster", cluster.Name)
 			return "", fmt.Errorf("label key %s not found on cluster %s", keyName, cluster.Name)

--- a/pkg/controllers/workgenerator/override.go
+++ b/pkg/controllers/workgenerator/override.go
@@ -35,10 +35,9 @@ import (
 	"github.com/kubefleet-dev/kubefleet/pkg/utils/overrider"
 )
 
-// fetchClusterResourceOverrideSnapshots returns the ClusterResourceOverrideSnapshots referenced
-// by the given binding, keyed by the ResourceIdentifier each snapshot's selectors target. The
-// returned map preserves the order in which the binding lists the snapshots, so the caller can
-// apply them in a deterministic sequence.
+// fetchClusterResourceOverrideSnapshots returns the binding's CRO snapshots keyed by the
+// ResourceIdentifier their selectors target. Order matches the binding's snapshot list so
+// callers can apply deterministically.
 //
 // TODO: combine the following two functions into one, as they are very similar.
 func (r *Reconciler) fetchClusterResourceOverrideSnapshots(ctx context.Context, resourceBinding placementv1beta1.BindingObj) (map[placementv1beta1.ResourceIdentifier][]*placementv1beta1.ClusterResourceOverrideSnapshot, error) {
@@ -75,10 +74,9 @@ func (r *Reconciler) fetchClusterResourceOverrideSnapshots(ctx context.Context, 
 	return croMap, nil
 }
 
-// fetchResourceOverrideSnapshots returns the ResourceOverrideSnapshots referenced by the given
-// binding, keyed by the ResourceIdentifier each snapshot's selectors target. The returned map
-// preserves the order in which the binding lists the snapshots, so the caller can apply them in
-// a deterministic sequence.
+// fetchResourceOverrideSnapshots returns the binding's RO snapshots keyed by the
+// ResourceIdentifier their selectors target. Order matches the binding's snapshot list so
+// callers can apply deterministically.
 func (r *Reconciler) fetchResourceOverrideSnapshots(ctx context.Context, resourceBinding placementv1beta1.BindingObj) (map[placementv1beta1.ResourceIdentifier][]*placementv1beta1.ResourceOverrideSnapshot, error) {
 	roMap := make(map[placementv1beta1.ResourceIdentifier][]*placementv1beta1.ResourceOverrideSnapshot)
 
@@ -158,8 +156,8 @@ func (r *Reconciler) applyOverrides(resource *placementv1beta1.ResourceContent, 
 		}
 		if err := applyOverrideRules(resource, cluster, snapshot.Spec.OverrideSpec.Policy.OverrideRules); err != nil {
 			klog.ErrorS(err, "Failed to apply the override rules", "clusterResourceOverrideSnapshot", klog.KObj(snapshot))
-			return false, fmt.Errorf("%w: ClusterResourceOverrideSnapshot %q failed to apply on %s: %s",
-				controller.ErrUserError, snapshot.Name, formatOverrideTarget(&uResource), err.Error())
+			return false, controller.NewUserError(fmt.Errorf("ClusterResourceOverrideSnapshot %q failed to apply on %s: %s",
+				snapshot.Name, formatOverrideTarget(&uResource), err.Error()))
 		}
 	}
 	klog.V(2).InfoS("Applied clusterResourceOverrideSnapshots", "resource", klog.KObj(&uResource), "numberOfOverrides", len(croMap[key]))
@@ -182,8 +180,8 @@ func (r *Reconciler) applyOverrides(resource *placementv1beta1.ResourceContent, 
 			}
 			if err := applyOverrideRules(resource, cluster, snapshot.Spec.OverrideSpec.Policy.OverrideRules); err != nil {
 				klog.ErrorS(err, "Failed to apply the override rules", "resourceOverrideSnapshot", klog.KObj(snapshot))
-				return false, fmt.Errorf("%w: ResourceOverrideSnapshot %q failed to apply on %s: %s",
-					controller.ErrUserError, snapshot.Name, formatOverrideTarget(&uResource), err.Error())
+				return false, controller.NewUserError(fmt.Errorf("ResourceOverrideSnapshot %q failed to apply on %s: %s",
+					snapshot.Name, formatOverrideTarget(&uResource), err.Error()))
 			}
 		}
 		klog.V(2).InfoS("Applied resourceOverrideSnapshots", "resource", klog.KObj(&uResource), "numberOfOverrides", len(roMap[key]))
@@ -191,27 +189,29 @@ func (r *Reconciler) applyOverrides(resource *placementv1beta1.ResourceContent, 
 	return resource.Raw == nil, nil
 }
 
-// formatOverrideTarget returns a human-readable identifier for the resource being overridden,
-// suitable for inclusion in a user-facing error message (e.g. `Deployment "my-app" in namespace "default"`).
+// formatOverrideTarget renders the target as e.g. `Deployment "my-app" in namespace "default"`
+// for inclusion in a user-facing error message.
 func formatOverrideTarget(target *unstructured.Unstructured) string {
+	// Fall back to "Unknown" so a snapshot missing `kind` doesn't render as `"" "name"`.
 	kind := target.GetObjectKind().GroupVersionKind().Kind
+	if kind == "" {
+		kind = "Unknown"
+	}
 	if ns := target.GetNamespace(); ns != "" {
 		return fmt.Sprintf("%s %q in namespace %q", kind, target.GetName(), ns)
 	}
 	return fmt.Sprintf("%s %q", kind, target.GetName())
 }
 
-// applyOverrideRules applies the given override rules to the resource for the cluster. Rules
-// whose cluster selector does not match the cluster are skipped. A DeleteOverrideType rule
-// clears the resource and ends rule application; otherwise the rule's JSON patches are applied
-// in order. The first rule that fails returns its raw error to the caller, which is responsible
-// for tagging the failure as a user error.
+// applyOverrideRules applies matching rules to the resource. A DeleteOverrideType rule clears
+// the resource and stops; otherwise JSON patches apply in order. Errors are returned raw — the
+// caller (applyOverrides) tags them as user errors so we don't double-wrap the sentinel.
 func applyOverrideRules(resource *placementv1beta1.ResourceContent, cluster *clusterv1beta1.MemberCluster, rules []placementv1beta1.OverrideRule) error {
 	for _, rule := range rules {
 		matched, err := overrider.IsClusterMatched(cluster, rule)
 		if err != nil {
-			klog.ErrorS(controller.NewUnexpectedBehaviorError(err), "Found an invalid override rule")
-			return err // should not happen though and should be rejected by the webhook
+			klog.ErrorS(err, "Found an invalid override rule")
+			return err
 		}
 		if !matched {
 			continue

--- a/pkg/controllers/workgenerator/override_test.go
+++ b/pkg/controllers/workgenerator/override_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -428,6 +429,10 @@ func TestFetchResourceOverrideSnapshot(t *testing.T) {
 }
 
 func TestApplyOverrides_clusterScopedResource(t *testing.T) {
+	// FakeManager.IsClusterScopedResources returns (m.APIResources[gvk] == m.IsClusterScopedResource),
+	// so a `false` flag combined with a map of namespace-scoped GVKs makes any GVK NOT in the map
+	// (here: ClusterRole) correctly report as cluster-scoped, while listed GVKs (Deployment) report
+	// as namespace-scoped. Despite the field name, `false` is the right value for these tests.
 	fakeInformer := informer.FakeManager{
 		APIResources: map[schema.GroupVersionKind]bool{
 			{
@@ -450,7 +455,10 @@ func TestApplyOverrides_clusterScopedResource(t *testing.T) {
 		croMap          map[placementv1beta1.ResourceIdentifier][]*placementv1beta1.ClusterResourceOverrideSnapshot
 		wantClusterRole rbacv1.ClusterRole
 		wantErr         error
-		wantDeleted     bool
+		// wantErrSubstr asserts substrings in the returned error message — used to verify
+		// that the per-resource failure identifies the failing override snapshot and target object.
+		wantErrSubstr []string
+		wantDeleted   bool
 	}{
 		{
 			name: "empty overrides",
@@ -844,6 +852,9 @@ func TestApplyOverrides_clusterScopedResource(t *testing.T) {
 					Name:    "clusterrole-name",
 				}: {
 					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "conflicting-rules-cro-snapshot",
+						},
 						Spec: placementv1beta1.ClusterResourceOverrideSnapshotSpec{
 							OverrideSpec: placementv1beta1.ClusterResourceOverrideSpec{
 								Policy: &placementv1beta1.OverridePolicy{
@@ -895,6 +906,10 @@ func TestApplyOverrides_clusterScopedResource(t *testing.T) {
 				},
 			},
 			wantErr: controller.ErrUserError,
+			wantErrSubstr: []string{
+				`ClusterResourceOverrideSnapshot "conflicting-rules-cro-snapshot"`,
+				`ClusterRole "clusterrole-name"`,
+			},
 		},
 		{
 			name: "invalid json patch of clusterResourceOverride",
@@ -921,6 +936,9 @@ func TestApplyOverrides_clusterScopedResource(t *testing.T) {
 					Name:    "clusterrole-name",
 				}: {
 					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-cro-snapshot",
+						},
 						Spec: placementv1beta1.ClusterResourceOverrideSnapshotSpec{
 							OverrideSpec: placementv1beta1.ClusterResourceOverrideSpec{
 								Policy: &placementv1beta1.OverridePolicy{
@@ -953,6 +971,72 @@ func TestApplyOverrides_clusterScopedResource(t *testing.T) {
 				},
 			},
 			wantErr: controller.ErrUserError,
+			wantErrSubstr: []string{
+				`ClusterResourceOverrideSnapshot "test-cro-snapshot"`,
+				`ClusterRole "clusterrole-name"`,
+			},
+		},
+		{
+			// Covers the applyOverrideRules → IsClusterMatched error path. An invalid LabelSelector
+			// Operator causes metav1.LabelSelectorAsSelector to fail; applyOverrideRules returns
+			// the raw error, and applyOverrides wraps it with the snapshot/target identity.
+			name: "invalid cluster label selector in clusterResourceOverride",
+			clusterRole: rbacv1.ClusterRole{
+				TypeMeta: clusterRoleType,
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "clusterrole-name",
+				},
+			},
+			cluster: clusterv1beta1.MemberCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster-1",
+				},
+			},
+			croMap: map[placementv1beta1.ResourceIdentifier][]*placementv1beta1.ClusterResourceOverrideSnapshot{
+				{
+					Group:   "rbac.authorization.k8s.io",
+					Version: "v1",
+					Kind:    "ClusterRole",
+					Name:    "clusterrole-name",
+				}: {
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "bad-selector-cro-snapshot",
+						},
+						Spec: placementv1beta1.ClusterResourceOverrideSnapshotSpec{
+							OverrideSpec: placementv1beta1.ClusterResourceOverrideSpec{
+								Policy: &placementv1beta1.OverridePolicy{
+									OverrideRules: []placementv1beta1.OverrideRule{
+										{
+											ClusterSelector: &placementv1beta1.ClusterSelector{
+												ClusterSelectorTerms: []placementv1beta1.ClusterSelectorTerm{
+													{
+														LabelSelector: &metav1.LabelSelector{
+															MatchExpressions: []metav1.LabelSelectorRequirement{
+																{
+																	Key:      "key1",
+																	Operator: "InvalidOperator",
+																	Values:   []string{"value1"},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: controller.ErrUserError,
+			wantErrSubstr: []string{
+				`ClusterResourceOverrideSnapshot "bad-selector-cro-snapshot"`,
+				`ClusterRole "clusterrole-name"`,
+				`invalid cluster label selector`,
+			},
 		},
 		{
 			name: "delete during the clusterResourceOverride",
@@ -1118,6 +1202,11 @@ func TestApplyOverrides_clusterScopedResource(t *testing.T) {
 				t.Fatalf("applyOverrides() gotDeleted %v, want %v", gotDeleted, tc.wantDeleted)
 			}
 			if tc.wantErr != nil {
+				for _, want := range tc.wantErrSubstr {
+					if !strings.Contains(err.Error(), want) {
+						t.Errorf("applyOverrides() error = %q, want to contain %q", err.Error(), want)
+					}
+				}
 				return
 			}
 			if tc.wantDeleted {
@@ -1126,12 +1215,12 @@ func TestApplyOverrides_clusterScopedResource(t *testing.T) {
 
 			var u unstructured.Unstructured
 			if err := u.UnmarshalJSON(rc.Raw); err != nil {
-				t.Fatalf("Failed to unmarshl the result: %v, want nil", err)
+				t.Fatalf("Failed to unmarshal the result: %v, want nil", err)
 			}
 
 			var clusterRole rbacv1.ClusterRole
 			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &clusterRole); err != nil {
-				t.Fatalf("Failed to convert the result to clusterole: %v, want nil", err)
+				t.Fatalf("Failed to convert the result to clusterRole: %v, want nil", err)
 			}
 
 			if diff := cmp.Diff(tc.wantClusterRole, clusterRole); diff != "" {
@@ -1141,7 +1230,9 @@ func TestApplyOverrides_clusterScopedResource(t *testing.T) {
 	}
 }
 
-func TestApplyOverrides_namespacedScopeResource(t *testing.T) {
+func TestApplyOverrides_namespaceScopedResource(t *testing.T) {
+	// See the same setup in TestApplyOverrides_clusterScopedResource above for the rationale
+	// behind IsClusterScopedResource: false combined with a map of namespace-scoped GVKs.
 	fakeInformer := informer.FakeManager{
 		APIResources: map[schema.GroupVersionKind]bool{
 			{
@@ -1165,7 +1256,10 @@ func TestApplyOverrides_namespacedScopeResource(t *testing.T) {
 		roMap          map[placementv1beta1.ResourceIdentifier][]*placementv1beta1.ResourceOverrideSnapshot
 		wantDeployment appsv1.Deployment
 		wantErr        error
-		wantDelete     bool
+		// wantErrSubstr asserts substrings in the returned error message — used to verify
+		// that the per-resource failure identifies the failing override snapshot and target object.
+		wantErrSubstr []string
+		wantDeleted   bool
 	}{
 		{
 			name: "empty overrides",
@@ -1664,6 +1758,9 @@ func TestApplyOverrides_namespacedScopeResource(t *testing.T) {
 					Name:    "deployment-namespace",
 				}: {
 					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "invalid-patch-cro-snapshot",
+						},
 						Spec: placementv1beta1.ClusterResourceOverrideSnapshotSpec{
 							OverrideSpec: placementv1beta1.ClusterResourceOverrideSpec{
 								Policy: &placementv1beta1.OverridePolicy{
@@ -1697,6 +1794,11 @@ func TestApplyOverrides_namespacedScopeResource(t *testing.T) {
 				},
 			},
 			wantErr: controller.ErrUserError,
+			wantErrSubstr: []string{
+				`ClusterResourceOverrideSnapshot "invalid-patch-cro-snapshot"`,
+				`Deployment "deployment-name"`,
+				`namespace "deployment-namespace"`,
+			},
 		},
 		{
 			name: "invalid json patch of resourceOverride",
@@ -1728,6 +1830,10 @@ func TestApplyOverrides_namespacedScopeResource(t *testing.T) {
 					Namespace: "deployment-namespace",
 				}: {
 					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "invalid-patch-ro-snapshot",
+							Namespace: "deployment-namespace",
+						},
 						Spec: placementv1beta1.ResourceOverrideSnapshotSpec{
 							OverrideSpec: placementv1beta1.ResourceOverrideSpec{
 								Policy: &placementv1beta1.OverridePolicy{
@@ -1751,6 +1857,11 @@ func TestApplyOverrides_namespacedScopeResource(t *testing.T) {
 				},
 			},
 			wantErr: controller.ErrUserError,
+			wantErrSubstr: []string{
+				`ResourceOverrideSnapshot "invalid-patch-ro-snapshot"`,
+				`Deployment "deployment-name"`,
+				`namespace "deployment-namespace"`,
+			},
 		},
 		{
 			name: "delete type of resourceOverride",
@@ -1797,7 +1908,7 @@ func TestApplyOverrides_namespacedScopeResource(t *testing.T) {
 					},
 				},
 			},
-			wantDelete: true,
+			wantDeleted: true,
 		},
 		{
 			name: "resourceOverride delete the cro override",
@@ -1884,7 +1995,7 @@ func TestApplyOverrides_namespacedScopeResource(t *testing.T) {
 					},
 				},
 			},
-			wantDelete: true,
+			wantDeleted: true,
 		},
 		{
 			name: "resourceOverride no-op when the cro delete",
@@ -1970,7 +2081,7 @@ func TestApplyOverrides_namespacedScopeResource(t *testing.T) {
 					},
 				},
 			},
-			wantDelete: true,
+			wantDeleted: true,
 		},
 		{
 			name: "cluster name as value in json patch of resourceOverride",
@@ -2218,6 +2329,10 @@ func TestApplyOverrides_namespacedScopeResource(t *testing.T) {
 					Namespace: "deployment-namespace",
 				}: {
 					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-ro-snapshot",
+							Namespace: "deployment-namespace",
+						},
 						Spec: placementv1beta1.ResourceOverrideSnapshotSpec{
 							OverrideSpec: placementv1beta1.ResourceOverrideSpec{
 								Policy: &placementv1beta1.OverridePolicy{
@@ -2240,6 +2355,11 @@ func TestApplyOverrides_namespacedScopeResource(t *testing.T) {
 				},
 			},
 			wantErr: controller.ErrUserError,
+			wantErrSubstr: []string{
+				`ResourceOverrideSnapshot "test-ro-snapshot"`,
+				`Deployment "deployment-name"`,
+				`namespace "deployment-namespace"`,
+			},
 		},
 	}
 	for _, tc := range tests {
@@ -2252,19 +2372,24 @@ func TestApplyOverrides_namespacedScopeResource(t *testing.T) {
 			if gotErr, wantErr := err != nil, tc.wantErr != nil; gotErr != wantErr || !errors.Is(err, tc.wantErr) {
 				t.Fatalf("applyOverrides() got error %v, want error %v", err, tc.wantErr)
 			}
-			if gotDeleted != tc.wantDelete {
-				t.Fatalf("applyOverrides() gotDeleted %v, want %v", gotDeleted, tc.wantDelete)
+			if gotDeleted != tc.wantDeleted {
+				t.Fatalf("applyOverrides() gotDeleted %v, want %v", gotDeleted, tc.wantDeleted)
 			}
 			if tc.wantErr != nil {
+				for _, want := range tc.wantErrSubstr {
+					if !strings.Contains(err.Error(), want) {
+						t.Errorf("applyOverrides() error = %q, want to contain %q", err.Error(), want)
+					}
+				}
 				return
 			}
-			if tc.wantDelete {
+			if tc.wantDeleted {
 				return
 			}
 
 			var u unstructured.Unstructured
 			if err := u.UnmarshalJSON(rc.Raw); err != nil {
-				t.Fatalf("Failed to unmarshl the result: %v, want nil", err)
+				t.Fatalf("Failed to unmarshal the result: %v, want nil", err)
 			}
 
 			var deployment appsv1.Deployment
@@ -2757,7 +2882,7 @@ func TestApplyJSONPatchOverride(t *testing.T) {
 
 			var u unstructured.Unstructured
 			if err := u.UnmarshalJSON(rc.Raw); err != nil {
-				t.Fatalf("Failed to unmarshl the result: %v, want nil", err)
+				t.Fatalf("Failed to unmarshal the result: %v, want nil", err)
 			}
 
 			var deployment appsv1.Deployment
@@ -2774,10 +2899,10 @@ func TestApplyJSONPatchOverride(t *testing.T) {
 
 func TestReplaceClusterLabelKeyVariables(t *testing.T) {
 	tests := map[string]struct {
-		cluster   *clusterv1beta1.MemberCluster
-		input     string
-		expected  string
-		expectErr bool
+		cluster *clusterv1beta1.MemberCluster
+		input   string
+		want    string
+		wantErr bool
 	}{
 		"No clusterLabelKey variables": {
 			cluster: &clusterv1beta1.MemberCluster{
@@ -2787,8 +2912,8 @@ func TestReplaceClusterLabelKeyVariables(t *testing.T) {
 					},
 				},
 			},
-			input:    "The cluster is in us-west-1",
-			expected: "The cluster is in us-west-1",
+			input: "The cluster is in us-west-1",
+			want:  "The cluster is in us-west-1",
 		},
 		"ClusterLabelKey Variable replaced": {
 			cluster: &clusterv1beta1.MemberCluster{
@@ -2798,8 +2923,8 @@ func TestReplaceClusterLabelKeyVariables(t *testing.T) {
 					},
 				},
 			},
-			input:    "The cluster is in ${MEMBER-CLUSTER-LABEL-KEY-region}",
-			expected: "The cluster is in us-west-1",
+			input: "The cluster is in ${MEMBER-CLUSTER-LABEL-KEY-region}",
+			want:  "The cluster is in us-west-1",
 		},
 		"The clusterLabelKey key is misspelled": {
 			cluster: &clusterv1beta1.MemberCluster{
@@ -2807,8 +2932,8 @@ func TestReplaceClusterLabelKeyVariables(t *testing.T) {
 					Labels: map[string]string{},
 				},
 			},
-			input:    "The cluster is in $MEMBER-CLUSTER-LABEL-KEY-region",
-			expected: "The cluster is in $MEMBER-CLUSTER-LABEL-KEY-region",
+			input: "The cluster is in $MEMBER-CLUSTER-LABEL-KEY-region",
+			want:  "The cluster is in $MEMBER-CLUSTER-LABEL-KEY-region",
 		},
 		"Multiple complex clusterLabelKey variables replaced": {
 			cluster: &clusterv1beta1.MemberCluster{
@@ -2819,8 +2944,8 @@ func TestReplaceClusterLabelKeyVariables(t *testing.T) {
 					},
 				},
 			},
-			input:    "The cluster is in ${MEMBER-CLUSTER-LABEL-KEY-fleet.azure.com/location-region_public} and environment is ${MEMBER-CLUSTER-LABEL-KEY-fleet.azure.com/env}",
-			expected: "The cluster is in us-west-1 and environment is prod",
+			input: "The cluster is in ${MEMBER-CLUSTER-LABEL-KEY-fleet.azure.com/location-region_public} and environment is ${MEMBER-CLUSTER-LABEL-KEY-fleet.azure.com/env}",
+			want:  "The cluster is in us-west-1 and environment is prod",
 		},
 		"The clusterLabelKey key is not found": {
 			cluster: &clusterv1beta1.MemberCluster{
@@ -2828,8 +2953,8 @@ func TestReplaceClusterLabelKeyVariables(t *testing.T) {
 					Labels: map[string]string{},
 				},
 			},
-			input:     "The cluster is in ${MEMBER-CLUSTER-LABEL-KEY-region}",
-			expectErr: true,
+			input:   "The cluster is in ${MEMBER-CLUSTER-LABEL-KEY-region}",
+			wantErr: true,
 		},
 		"ClusterLabelKey Variable key case not match": {
 			cluster: &clusterv1beta1.MemberCluster{
@@ -2839,10 +2964,10 @@ func TestReplaceClusterLabelKeyVariables(t *testing.T) {
 					},
 				},
 			},
-			input:     "The cluster is in ${MEMBER-CLUSTER-LABEL-KEY-REGION}",
-			expectErr: true,
+			input:   "The cluster is in ${MEMBER-CLUSTER-LABEL-KEY-REGION}",
+			wantErr: true,
 		},
-		"Invalid  clusterLabelKey variable format": {
+		"Invalid clusterLabelKey variable format": {
 			cluster: &clusterv1beta1.MemberCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
@@ -2850,8 +2975,8 @@ func TestReplaceClusterLabelKeyVariables(t *testing.T) {
 					},
 				},
 			},
-			input:     "The cluster is in ${MEMBER-CLUSTER-LABEL-KEY-region",
-			expectErr: true,
+			input:   "The cluster is in ${MEMBER-CLUSTER-LABEL-KEY-region",
+			wantErr: true,
 		},
 		"ClusterLabelKey variable key empty": {
 			cluster: &clusterv1beta1.MemberCluster{
@@ -2861,19 +2986,19 @@ func TestReplaceClusterLabelKeyVariables(t *testing.T) {
 					},
 				},
 			},
-			input:     "The cluster is in ${MEMBER-CLUSTER-LABEL-KEY-}",
-			expectErr: true,
+			input:   "The cluster is in ${MEMBER-CLUSTER-LABEL-KEY-}",
+			wantErr: true,
 		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			result, err := replaceClusterLabelKeyVariables(tc.input, tc.cluster)
-			if gotErr := err != nil; gotErr != tc.expectErr {
-				t.Fatalf("applyJSONPatchOverride() = error %v, want %v", err, tc.expectErr)
+			if gotErr := err != nil; gotErr != tc.wantErr {
+				t.Fatalf("replaceClusterLabelKeyVariables() = error %v, want %v", err, tc.wantErr)
 			}
-			if result != tc.expected {
-				t.Errorf("replaceClusterLabelKeyVariables() = %v, want %v", result, tc.expected)
+			if result != tc.want {
+				t.Errorf("replaceClusterLabelKeyVariables() = %v, want %v", result, tc.want)
 			}
 		})
 	}

--- a/pkg/controllers/workgenerator/override_test.go
+++ b/pkg/controllers/workgenerator/override_test.go
@@ -429,10 +429,9 @@ func TestFetchResourceOverrideSnapshot(t *testing.T) {
 }
 
 func TestApplyOverrides_clusterScopedResource(t *testing.T) {
-	// FakeManager.IsClusterScopedResources returns (m.APIResources[gvk] == m.IsClusterScopedResource),
-	// so a `false` flag combined with a map of namespace-scoped GVKs makes any GVK NOT in the map
-	// (here: ClusterRole) correctly report as cluster-scoped, while listed GVKs (Deployment) report
-	// as namespace-scoped. Despite the field name, `false` is the right value for these tests.
+	// FakeManager.IsClusterScopedResources returns (APIResources[gvk] == IsClusterScopedResource).
+	// With the flag set to false and APIResources listing namespace-scoped GVKs, listed GVKs
+	// report as namespace-scoped and unlisted GVKs (ClusterRole) report as cluster-scoped.
 	fakeInformer := informer.FakeManager{
 		APIResources: map[schema.GroupVersionKind]bool{
 			{
@@ -455,8 +454,7 @@ func TestApplyOverrides_clusterScopedResource(t *testing.T) {
 		croMap          map[placementv1beta1.ResourceIdentifier][]*placementv1beta1.ClusterResourceOverrideSnapshot
 		wantClusterRole rbacv1.ClusterRole
 		wantErr         error
-		// wantErrSubstr asserts substrings in the returned error message — used to verify
-		// that the per-resource failure identifies the failing override snapshot and target object.
+		// wantErrSubstr asserts the failure message names the failing snapshot and target.
 		wantErrSubstr []string
 		wantDeleted   bool
 	}{
@@ -977,9 +975,8 @@ func TestApplyOverrides_clusterScopedResource(t *testing.T) {
 			},
 		},
 		{
-			// Covers the applyOverrideRules → IsClusterMatched error path. An invalid LabelSelector
-			// Operator causes metav1.LabelSelectorAsSelector to fail; applyOverrideRules returns
-			// the raw error, and applyOverrides wraps it with the snapshot/target identity.
+			// Invalid LabelSelector Operator makes IsClusterMatched fail — exercises the
+			// applyOverrideRules raw-error return that applyOverrides wraps.
 			name: "invalid cluster label selector in clusterResourceOverride",
 			clusterRole: rbacv1.ClusterRole{
 				TypeMeta: clusterRoleType,
@@ -1231,8 +1228,7 @@ func TestApplyOverrides_clusterScopedResource(t *testing.T) {
 }
 
 func TestApplyOverrides_namespaceScopedResource(t *testing.T) {
-	// See the same setup in TestApplyOverrides_clusterScopedResource above for the rationale
-	// behind IsClusterScopedResource: false combined with a map of namespace-scoped GVKs.
+	// See TestApplyOverrides_clusterScopedResource for the IsClusterScopedResource: false rationale.
 	fakeInformer := informer.FakeManager{
 		APIResources: map[schema.GroupVersionKind]bool{
 			{
@@ -1256,8 +1252,7 @@ func TestApplyOverrides_namespaceScopedResource(t *testing.T) {
 		roMap          map[placementv1beta1.ResourceIdentifier][]*placementv1beta1.ResourceOverrideSnapshot
 		wantDeployment appsv1.Deployment
 		wantErr        error
-		// wantErrSubstr asserts substrings in the returned error message — used to verify
-		// that the per-resource failure identifies the failing override snapshot and target object.
+		// wantErrSubstr asserts the failure message names the failing snapshot and target.
 		wantErrSubstr []string
 		wantDeleted   bool
 	}{
@@ -2999,6 +2994,48 @@ func TestReplaceClusterLabelKeyVariables(t *testing.T) {
 			}
 			if result != tc.want {
 				t.Errorf("replaceClusterLabelKeyVariables() = %v, want %v", result, tc.want)
+			}
+		})
+	}
+}
+
+func TestFormatOverrideTarget(t *testing.T) {
+	tests := map[string]struct {
+		kind      string
+		name      string
+		namespace string
+		want      string
+	}{
+		"namespaced resource": {
+			kind:      "Deployment",
+			name:      "my-app",
+			namespace: "default",
+			want:      `Deployment "my-app" in namespace "default"`,
+		},
+		"cluster-scoped resource": {
+			kind: "Namespace",
+			name: "app",
+			want: `Namespace "app"`,
+		},
+		"empty kind falls back to Unknown": {
+			name:      "my-app",
+			namespace: "default",
+			want:      `Unknown "my-app" in namespace "default"`,
+		},
+		"empty kind, cluster-scoped": {
+			name: "app",
+			want: `Unknown "app"`,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			target := &unstructured.Unstructured{}
+			target.SetGroupVersionKind(schema.GroupVersionKind{Kind: tc.kind})
+			target.SetName(tc.name)
+			target.SetNamespace(tc.namespace)
+			if got := formatOverrideTarget(target); got != tc.want {
+				t.Errorf("formatOverrideTarget() = %q, want %q", got, tc.want)
 			}
 		})
 	}

--- a/pkg/controllers/workgenerator/suite_test.go
+++ b/pkg/controllers/workgenerator/suite_test.go
@@ -301,6 +301,47 @@ func createOverrides() {
 	}
 	Expect(k8sClient.Create(ctx, &invalidClusterResourceOverrideSnapshot)).Should(Succeed(), "Failed to create the cro-2")
 	By(fmt.Sprintf("Invalid cluster resource override snapshot %s created", invalidClusterResourceOverrideSnapshotName))
+
+	invalidResourceOverrideSnapshot = placementv1beta1.ResourceOverrideSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      invalidResourceOverrideSnapshotName,
+			Namespace: appNamespaceName,
+			Labels: map[string]string{
+				placementv1beta1.IsLatestSnapshotLabel: "true",
+			},
+		},
+		Spec: placementv1beta1.ResourceOverrideSnapshotSpec{
+			OverrideSpec: placementv1beta1.ResourceOverrideSpec{
+				ResourceSelectors: []placementv1beta1.ResourceSelector{
+					{
+						Group:   "test.kubernetes-fleet.io",
+						Version: "v1alpha1",
+						Kind:    "TestResource",
+						Name:    "random-test-resource",
+					},
+				},
+				Policy: &placementv1beta1.OverridePolicy{
+					OverrideRules: []placementv1beta1.OverrideRule{
+						{
+							ClusterSelector: &placementv1beta1.ClusterSelector{
+								ClusterSelectorTerms: []placementv1beta1.ClusterSelectorTerm{}, // select all members
+							},
+							JSONPatchOverrides: []placementv1beta1.JSONPatchOverride{
+								{
+									Operator: placementv1beta1.JSONPatchOverrideOpAdd,
+									Path:     "/invalid/path",
+									Value:    apiextensionsv1.JSON{Raw: []byte(`"new-value"`)},
+								},
+							},
+						},
+					},
+				},
+			},
+			OverrideHash: []byte("123"),
+		},
+	}
+	Expect(k8sClient.Create(ctx, &invalidResourceOverrideSnapshot)).Should(Succeed(), "Failed to create the ro-2")
+	By(fmt.Sprintf("Invalid resource override snapshot %s created", invalidResourceOverrideSnapshotName))
 }
 
 var _ = AfterSuite(func() {
@@ -309,6 +350,7 @@ var _ = AfterSuite(func() {
 	Expect(k8sClient.Delete(ctx, &validClusterResourceOverrideSnapshot)).Should(Succeed(), "Failed to delete the cro-1")
 	Expect(k8sClient.Delete(ctx, &validResourceOverrideSnapshot)).Should(Succeed(), "Failed to delete the ro-1")
 	Expect(k8sClient.Delete(ctx, &invalidClusterResourceOverrideSnapshot)).Should(Succeed(), "Failed to delete the cro-2")
+	Expect(k8sClient.Delete(ctx, &invalidResourceOverrideSnapshot)).Should(Succeed(), "Failed to delete the ro-2")
 	Expect(k8sClient.Delete(ctx, &appNamespace)).Should(Succeed(), "Failed to delete app namespace")
 
 	cancel()


### PR DESCRIPTION
### Description of your changes

When an override snapshot fails to apply on a selected resource, the binding's `Overridden=False` condition message now identifies **which** override snapshot and **which** target object failed, instead of surfacing only the underlying patch error.

Before:
> `Failed to apply the override rules on the resources: failed to process the request due to a client error: add operation does not apply: doc is missing key: /invalid`

After:
> `Failed to apply the override rules on the resources: ClusterResourceOverrideSnapshot "cro-2" failed to apply on Namespace "app": add operation does not apply: doc is missing key: /invalid`

**Implementation:** the wrap is done once at the outer `applyOverrides` call site so the existing controller-level message trim at `controller.go:188-194` works correctly without doubled sentinel prefixes. `applyOverrideRules` and `applyJSONPatchOverride` no longer call `controller.NewUserError` themselves — they return raw errors, and `applyOverrides` does the sentinel-tagging once with the snapshot + target context. `errors.Is(err, controller.ErrUserError)` still holds end-to-end.

Boy Scout cleanups limited to the files touched by this fix:
- `override.go` — `isClusterScopeResource` → `isClusterScopedResource`; capitalised log messages; `cluster.ObjectMeta.Labels` → `cluster.Labels`; doc comments on three unexported functions; redundant `// do nothing` dropped.
- `override_test.go` — `unmarshl` → `unmarshal` (3 sites); `clusterole` → `clusterRole`; corrected the wrong function name in a test failure diagnostic (`TestReplaceClusterLabelKeyVariables` was logging `applyJSONPatchOverride()`); `expected/expectErr` → `want/wantErr` per project style; test renamed `TestApplyOverrides_namespacedScopeResource` → `_namespaceScopedResource`; explanatory comment added for the inverted-looking `IsClusterScopedResource: false` `FakeManager` flag.
- `controller_integration_test.go` — double-space typos in `By(...)` strings.

I have:

- [ ] Associated this change with a known KubeFleet Issue (Bug, Feature, etc).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- `make test` passes (`pkg/controllers/workgenerator` runs 86 Ginkgo specs plus unit tests; `pkg/utils/condition` and `pkg/controllers/placement` unaffected and green).
- **Unit coverage:**
  - `TestApplyOverrides_clusterScopedResource` and `TestApplyOverrides_namespaceScopedResource` gained a `wantErrSubstr` field. Four failure cases now assert on the new message format (snapshot identity + target identity), including two cases that previously had no `wantErrSubstr` and would have surfaced an empty snapshot name post-change.
  - New case for the `IsClusterMatched` error path through `applyOverrideRules` (an invalid `MatchExpressions` `Operator` makes `metav1.LabelSelectorAsSelector` fail). This path was previously unexercised in `override_test.go`.
- **Integration coverage:**
  - The existing `Bound ClusterResourceBinding … invalid override` context now asserts via `MatchRegexp` on the new message structure.
  - New sibling context `Bound ClusterResourceBinding … invalid resource override` mirrors the CRO failure path for `ResourceOverrideSnapshot`. New fixture `invalidResourceOverrideSnapshot` (`ro-2`) added in `suite_test.go`.

### Special notes for your reviewer

- **Single-call wrap is intentional.** `applyOverrideRules` and `applyJSONPatchOverride` no longer call `controller.NewUserError`. Re-wrapping an already-tagged error created a doubled `"failed to process the request due to a client error: "` prefix that the trim at `controller.go:188-194` couldn't strip cleanly. Doing the wrap once at `applyOverrides` keeps the `%w: <suffix>` shape the trim expects.
- **Trim untouched.** The pre-existing trim at `controller.go:188-194` and its `//TODO: check if it's user error and set a different failed reason` are unchanged; cleaning that up is a separate refactor.
- **Scope discipline.** Two follow-on improvements were considered and explicitly deferred to keep this PR focused:
  - Firing a Kubernetes `Event` on `Overridden=False` so `kubectl describe binding` shows the same enriched message.
  - Enriching the CRP/RP `Overridden=False` rollup condition message with the failing cluster names instead of just a count.
