### PR TITLE
fix: close override snapshot transition race on update

### DIFF
--- a/cmd/hubagent/workload/setup.go
+++ b/cmd/hubagent/workload/setup.go
@@ -455,7 +455,8 @@ func SetupControllers(ctx context.Context, wg *sync.WaitGroup, mgr ctrl.Manager,
 		klog.Info("Setting up the clusterResourceOverride controller")
 		if err := (&overrider.ClusterResourceReconciler{
 			Reconciler: overrider.Reconciler{
-				Client: mgr.GetClient(),
+				Client:         mgr.GetClient(),
+				UncachedReader: mgr.GetAPIReader(),
 			},
 		}).SetupWithManager(mgr); err != nil {
 			klog.ErrorS(err, "Unable to set up clusterResourceOverride controller")
@@ -465,7 +466,8 @@ func SetupControllers(ctx context.Context, wg *sync.WaitGroup, mgr ctrl.Manager,
 		klog.Info("Setting up the resourceOverride controller")
 		if err := (&overrider.ResourceReconciler{
 			Reconciler: overrider.Reconciler{
-				Client: mgr.GetClient(),
+				Client:         mgr.GetClient(),
+				UncachedReader: mgr.GetAPIReader(),
 			},
 		}).SetupWithManager(mgr); err != nil {
 			klog.ErrorS(err, "Unable to set up resourceOverride controller")

--- a/pkg/controllers/overrider/clusterresource_controller.go
+++ b/pkg/controllers/overrider/clusterresource_controller.go
@@ -23,9 +23,11 @@ import (
 	"strconv"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -42,7 +44,7 @@ type ClusterResourceReconciler struct {
 	Reconciler
 }
 
-// Reconcile triggers a single  reconcile round when scheduling policy has changed.
+// Reconcile triggers a single reconcile round when the override has changed.
 func (r *ClusterResourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	name := req.NamespacedName
 	clusterOverride := placementv1beta1.ClusterResourceOverride{}
@@ -99,29 +101,24 @@ func (r *ClusterResourceReconciler) ensureClusterResourceOverrideSnapshot(ctx co
 		return err
 	}
 
-	latestSnapshotIndex := -1 //so index start at 0
+	latestSnapshotIndex := -1 // so index starts at 0
+	var latestSnapshot *placementv1beta1.ClusterResourceOverrideSnapshot
 	if len(snapshotList.Items) != 0 {
-		// convert the last unstructured snapshot to the typed object
-		latestSnapshot := &placementv1beta1.ClusterResourceOverrideSnapshot{}
+		// Convert the last (highest-index) unstructured snapshot to the typed object.
+		latestSnapshot = &placementv1beta1.ClusterResourceOverrideSnapshot{}
 		if err = runtime.DefaultUnstructuredConverter.FromUnstructured(snapshotList.Items[len(snapshotList.Items)-1].Object, latestSnapshot); err != nil {
 			klog.ErrorS(err, "Invalid overrideSnapshot", "clusterResourceOverride", croKObj, "overrideSnapshot", klog.KObj(&snapshotList.Items[len(snapshotList.Items)-1]))
 			return controller.NewUnexpectedBehaviorError(err)
 		}
 		if string(latestSnapshot.Spec.OverrideHash) == overrideSpecHash {
-			// the content has not changed, so we don't need to create a new snapshot.
-			return r.ensureSnapshotLatest(ctx, latestSnapshot)
-		}
-		// mark the last policy snapshot as inactive if it is different from what we have now.
-		if latestSnapshot.Labels[placementv1beta1.IsLatestSnapshotLabel] == strconv.FormatBool(true) {
-			// set the latest label to false first to make sure there is only one or none active policy snapshot
-			latestSnapshot.Labels[placementv1beta1.IsLatestSnapshotLabel] = strconv.FormatBool(false)
-			if err := r.Client.Update(ctx, latestSnapshot); err != nil {
-				klog.ErrorS(err, "Failed to set the isLatestSnapshot label to false", "clusterResourceOverride", croKObj, "overrideSnapshot", klog.KObj(latestSnapshot))
-				return controller.NewUpdateIgnoreConflictError(err)
+			// The content has not changed; no new snapshot is needed.
+			// Ensure the highest-index snapshot is marked latest, then audit siblings to clean
+			// up any duplicate latest=true left by a prior partial run.
+			if err := r.ensureSnapshotLatest(ctx, latestSnapshot); err != nil {
+				return err
 			}
-			klog.V(2).InfoS("Marked the latest overrideSnapshot as inactive", "clusterResourceOverride", croKObj, "overrideSnapshot", klog.KObj(latestSnapshot))
+			return r.cleanupStaleLatestSiblings(ctx, snapshotList)
 		}
-		// we need to figure out the last snapshot index.
 		latestSnapshotIndex, err = labels.ExtractIndex(latestSnapshot, placementv1beta1.OverrideIndexLabel)
 		if err != nil {
 			klog.ErrorS(err, "Failed to parse the override index label", "clusterResourceOverride", croKObj, "overrideSnapshot", klog.KObj(latestSnapshot))
@@ -129,7 +126,10 @@ func (r *ClusterResourceReconciler) ensureClusterResourceOverrideSnapshot(ctx co
 		}
 	}
 
-	// Need to create new snapshot when 1) there is no snapshots or 2) the latest snapshot hash != current one.
+	// Create the new snapshot (latest=true) BEFORE flipping the old one to false. This avoids a
+	// zero-latest window: if we crash between operations, at worst we leave two snapshots with
+	// latest=true, which is resolved by read-time dedup and cleaned up by cleanupStaleLatestSiblings
+	// on the next reconcile that hits the hash-match path above.
 	latestSnapshotIndex++
 	newSnapshot := &placementv1beta1.ClusterResourceOverrideSnapshot{
 		ObjectMeta: metav1.ObjectMeta{
@@ -149,15 +149,70 @@ func (r *ClusterResourceReconciler) ensureClusterResourceOverrideSnapshot(ctx co
 		},
 	}
 	if err := r.Client.Create(ctx, newSnapshot); err != nil {
-		klog.ErrorS(err, "Failed to create new overrideSnapshot", "newOverrideSnapshot", klog.KObj(newSnapshot))
-		return controller.NewAPIServerError(false, err)
+		if !errors.IsAlreadyExists(err) {
+			klog.ErrorS(err, "Failed to create new overrideSnapshot", "newOverrideSnapshot", klog.KObj(newSnapshot))
+			return controller.NewAPIServerError(false, err)
+		}
+		// AlreadyExists here normally means a prior reconcile succeeded the Create but failed to
+		// flip the old snapshot. The deterministic name {ParentName}-{index} plus the hash check
+		// above mean the existing object should have identical content. Verify before proceeding,
+		// because etcd restore from backup, manual edits, or a future hash-function change could
+		// leave an existing object whose hash no longer matches the current spec.
+		//
+		// Read through the uncached client: the cached read can lag the server's write to the
+		// just-Created object and return NotFound, forcing a needless requeue.
+		existing := &placementv1beta1.ClusterResourceOverrideSnapshot{}
+		if getErr := r.UncachedReader.Get(ctx, types.NamespacedName{Name: newSnapshot.Name}, existing); getErr != nil {
+			klog.ErrorS(getErr, "Failed to get existing overrideSnapshot for hash verification", "clusterResourceOverride", croKObj, "newOverrideSnapshot", klog.KObj(newSnapshot))
+			return controller.NewAPIServerError(false, getErr)
+		}
+		if string(existing.Spec.OverrideHash) != overrideSpecHash {
+			mismatchErr := fmt.Errorf("existing overrideSnapshot %s has hash %q, want %q", newSnapshot.Name, string(existing.Spec.OverrideHash), overrideSpecHash)
+			klog.ErrorS(mismatchErr, "Existing overrideSnapshot has different content than expected; will requeue and retry", "clusterResourceOverride", croKObj)
+			// Surface to the operator via an Event on the parent CRO so it shows up in
+			// `kubectl describe`. Without this, a permanent mismatch (manual edit, hash-fn break)
+			// would requeue forever with only log noise to indicate the problem.
+			if r.recorder != nil {
+				r.recorder.Eventf(cro, corev1.EventTypeWarning, "OverrideSnapshotHashMismatch",
+					"existing snapshot %s has a different hash than the current spec; retrying. If this persists, the snapshot needs operator inspection (etcd restore from backup, manual edit, or hash-function change).", newSnapshot.Name)
+			}
+			// Treat as expected-behavior: the most likely real-world trigger is etcd restore from
+			// backup, where retry resolves once the parent CRO converges. A truly unrecoverable
+			// state (manual edit, hash-fn break) will keep producing this log on every retry,
+			// which is enough for operators to notice without flooding stack traces.
+			return controller.NewExpectedBehaviorError(mismatchErr)
+		}
+		klog.V(2).InfoS("Snapshot already exists with matching content; recovering from prior partial reconcile", "clusterResourceOverride", croKObj, "newOverrideSnapshot", klog.KObj(newSnapshot))
+	} else {
+		klog.V(2).InfoS("Created new overrideSnapshot", "clusterResourceOverride", croKObj, "newOverrideSnapshot", klog.KObj(newSnapshot))
 	}
-	klog.V(2).InfoS("Created new overrideSnapshot", "clusterResourceOverride", croKObj, "newOverrideSnapshot", klog.KObj(newSnapshot))
-	return nil
+
+	// Demote the previous latest snapshot. Tolerate IsNotFound from a concurrent prune or parent
+	// deletion: in that case there is nothing to demote, but we still want to run the sibling
+	// audit below to clean up any stale latest=true left by earlier crashes.
+	if latestSnapshot != nil && latestSnapshot.Labels[placementv1beta1.IsLatestSnapshotLabel] == strconv.FormatBool(true) {
+		latestSnapshot.Labels[placementv1beta1.IsLatestSnapshotLabel] = strconv.FormatBool(false)
+		if err := r.Client.Update(ctx, latestSnapshot); err != nil {
+			if errors.IsNotFound(err) {
+				klog.V(2).InfoS("Old overrideSnapshot already gone; skipping demotion", "clusterResourceOverride", croKObj, "overrideSnapshot", klog.KObj(latestSnapshot))
+			} else {
+				klog.ErrorS(err, "Failed to set the isLatestSnapshot label to false on previous snapshot", "clusterResourceOverride", croKObj, "overrideSnapshot", klog.KObj(latestSnapshot))
+				return controller.NewUpdateIgnoreConflictError(err)
+			}
+		} else {
+			klog.V(2).InfoS("Marked previous overrideSnapshot as inactive", "clusterResourceOverride", croKObj, "overrideSnapshot", klog.KObj(latestSnapshot))
+		}
+	}
+
+	// Audit older siblings for stale latest=true left by prior crashes. cleanupStaleLatestSiblings
+	// preserves the highest-index item in snapshotList (the previous latest, which we just demoted
+	// in-memory and on the server) and flips any older sibling still carrying latest=true.
+	return r.cleanupStaleLatestSiblings(ctx, snapshotList)
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ClusterResourceReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	r.recorder = mgr.GetEventRecorderFor("clusterresourceoverride-controller")
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("clusterresourceoverride-controller").
 		For(&placementv1beta1.ClusterResourceOverride{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).

--- a/pkg/controllers/overrider/clusterresource_controller.go
+++ b/pkg/controllers/overrider/clusterresource_controller.go
@@ -101,19 +101,16 @@ func (r *ClusterResourceReconciler) ensureClusterResourceOverrideSnapshot(ctx co
 		return err
 	}
 
-	latestSnapshotIndex := -1 // so index starts at 0
+	latestSnapshotIndex := -1 // index starts at 0
 	var latestSnapshot *placementv1beta1.ClusterResourceOverrideSnapshot
 	if len(snapshotList.Items) != 0 {
-		// Convert the last (highest-index) unstructured snapshot to the typed object.
 		latestSnapshot = &placementv1beta1.ClusterResourceOverrideSnapshot{}
 		if err = runtime.DefaultUnstructuredConverter.FromUnstructured(snapshotList.Items[len(snapshotList.Items)-1].Object, latestSnapshot); err != nil {
 			klog.ErrorS(err, "Invalid overrideSnapshot", "clusterResourceOverride", croKObj, "overrideSnapshot", klog.KObj(&snapshotList.Items[len(snapshotList.Items)-1]))
 			return controller.NewUnexpectedBehaviorError(err)
 		}
 		if string(latestSnapshot.Spec.OverrideHash) == overrideSpecHash {
-			// The content has not changed; no new snapshot is needed.
-			// Ensure the highest-index snapshot is marked latest, then audit siblings to clean
-			// up any duplicate latest=true left by a prior partial run.
+			// Hash matches: re-mark this snapshot latest (idempotent) and audit siblings.
 			if err := r.ensureSnapshotLatest(ctx, latestSnapshot); err != nil {
 				return err
 			}
@@ -126,10 +123,8 @@ func (r *ClusterResourceReconciler) ensureClusterResourceOverrideSnapshot(ctx co
 		}
 	}
 
-	// Create the new snapshot (latest=true) BEFORE flipping the old one to false. This avoids a
-	// zero-latest window: if we crash between operations, at worst we leave two snapshots with
-	// latest=true, which is resolved by read-time dedup and cleaned up by cleanupStaleLatestSiblings
-	// on the next reconcile that hits the hash-match path above.
+	// Create-then-demote: avoids a zero-latest window across crashes. Any transient duplicate
+	// is resolved by read-time dedup and the sibling audit on the next reconcile.
 	latestSnapshotIndex++
 	newSnapshot := &placementv1beta1.ClusterResourceOverrideSnapshot{
 		ObjectMeta: metav1.ObjectMeta{
@@ -153,33 +148,32 @@ func (r *ClusterResourceReconciler) ensureClusterResourceOverrideSnapshot(ctx co
 			klog.ErrorS(err, "Failed to create new overrideSnapshot", "newOverrideSnapshot", klog.KObj(newSnapshot))
 			return controller.NewAPIServerError(false, err)
 		}
-		// AlreadyExists here normally means a prior reconcile succeeded the Create but failed to
-		// flip the old snapshot. The deterministic name {ParentName}-{index} plus the hash check
-		// above mean the existing object should have identical content. Verify before proceeding,
-		// because etcd restore from backup, manual edits, or a future hash-function change could
-		// leave an existing object whose hash no longer matches the current spec.
-		//
-		// Read through the uncached client: the cached read can lag the server's write to the
-		// just-Created object and return NotFound, forcing a needless requeue.
+		// AlreadyExists usually means a prior reconcile created this snapshot but didn't flip
+		// the old one. Verify content matches before proceeding; the realistic drift sources
+		// are manual edits or a hash-function change between controller versions. Use the
+		// uncached reader — the cache can lag the just-Created object.
 		existing := &placementv1beta1.ClusterResourceOverrideSnapshot{}
 		if getErr := r.UncachedReader.Get(ctx, types.NamespacedName{Name: newSnapshot.Name}, existing); getErr != nil {
 			klog.ErrorS(getErr, "Failed to get existing overrideSnapshot for hash verification", "clusterResourceOverride", croKObj, "newOverrideSnapshot", klog.KObj(newSnapshot))
 			return controller.NewAPIServerError(false, getErr)
 		}
+		// Compare stored OverrideHash, not a re-hash of existing.Spec.OverrideSpec: API-server
+		// defaulting on Create (selectionScope, scope, overrideType) makes the read-back spec
+		// differ from the input, so a recompute would never match.
 		if string(existing.Spec.OverrideHash) != overrideSpecHash {
-			mismatchErr := fmt.Errorf("existing overrideSnapshot %s has hash %q, want %q", newSnapshot.Name, string(existing.Spec.OverrideHash), overrideSpecHash)
-			klog.ErrorS(mismatchErr, "Existing overrideSnapshot has different content than expected; will requeue and retry", "clusterResourceOverride", croKObj)
-			// Surface to the operator via an Event on the parent CRO so it shows up in
-			// `kubectl describe`. Without this, a permanent mismatch (manual edit, hash-fn break)
-			// would requeue forever with only log noise to indicate the problem.
+			mismatchErr := fmt.Errorf("existing overrideSnapshot %s has stored hash %q, want %q", newSnapshot.Name, string(existing.Spec.OverrideHash), overrideSpecHash)
+			klog.ErrorS(mismatchErr, "Existing overrideSnapshot has different content than the current spec; deleting it so the next reconcile can recreate with correct content", "clusterResourceOverride", croKObj)
+			// Event surfaces the recovery in `kubectl describe`.
 			if r.recorder != nil {
 				r.recorder.Eventf(cro, corev1.EventTypeWarning, "OverrideSnapshotHashMismatch",
-					"existing snapshot %s has a different hash than the current spec; retrying. If this persists, the snapshot needs operator inspection (etcd restore from backup, manual edit, or hash-function change).", newSnapshot.Name)
+					"existing snapshot %s has different content than the current spec; deleting it for the next reconcile to recreate. If this persists, investigate the snapshot for manual edits or a hash-function change between controller versions.", newSnapshot.Name)
 			}
-			// Treat as expected-behavior: the most likely real-world trigger is etcd restore from
-			// backup, where retry resolves once the parent CRO converges. A truly unrecoverable
-			// state (manual edit, hash-fn break) will keep producing this log on every retry,
-			// which is enough for operators to notice without flooding stack traces.
+			// Drive observed → desired: delete the mismatched snapshot so the next reconcile
+			// recreates it with the correct content.
+			if delErr := r.Client.Delete(ctx, existing); delErr != nil && !errors.IsNotFound(delErr) {
+				klog.ErrorS(delErr, "Failed to delete mismatched overrideSnapshot", "clusterResourceOverride", croKObj, "overrideSnapshot", klog.KObj(existing))
+				return controller.NewAPIServerError(false, delErr)
+			}
 			return controller.NewExpectedBehaviorError(mismatchErr)
 		}
 		klog.V(2).InfoS("Snapshot already exists with matching content; recovering from prior partial reconcile", "clusterResourceOverride", croKObj, "newOverrideSnapshot", klog.KObj(newSnapshot))
@@ -187,9 +181,8 @@ func (r *ClusterResourceReconciler) ensureClusterResourceOverrideSnapshot(ctx co
 		klog.V(2).InfoS("Created new overrideSnapshot", "clusterResourceOverride", croKObj, "newOverrideSnapshot", klog.KObj(newSnapshot))
 	}
 
-	// Demote the previous latest snapshot. Tolerate IsNotFound from a concurrent prune or parent
-	// deletion: in that case there is nothing to demote, but we still want to run the sibling
-	// audit below to clean up any stale latest=true left by earlier crashes.
+	// Demote the previous latest. IsNotFound is fine — there's nothing to demote, but we still
+	// want to run the sibling audit below.
 	if latestSnapshot != nil && latestSnapshot.Labels[placementv1beta1.IsLatestSnapshotLabel] == strconv.FormatBool(true) {
 		latestSnapshot.Labels[placementv1beta1.IsLatestSnapshotLabel] = strconv.FormatBool(false)
 		if err := r.Client.Update(ctx, latestSnapshot); err != nil {
@@ -204,9 +197,7 @@ func (r *ClusterResourceReconciler) ensureClusterResourceOverrideSnapshot(ctx co
 		}
 	}
 
-	// Audit older siblings for stale latest=true left by prior crashes. cleanupStaleLatestSiblings
-	// preserves the highest-index item in snapshotList (the previous latest, which we just demoted
-	// in-memory and on the server) and flips any older sibling still carrying latest=true.
+	// Audit older siblings; cleanupStaleLatestSiblings preserves the last (just-demoted) item.
 	return r.cleanupStaleLatestSiblings(ctx, snapshotList)
 }
 

--- a/pkg/controllers/overrider/clusterresource_controller.go
+++ b/pkg/controllers/overrider/clusterresource_controller.go
@@ -164,10 +164,8 @@ func (r *ClusterResourceReconciler) ensureClusterResourceOverrideSnapshot(ctx co
 			mismatchErr := fmt.Errorf("existing overrideSnapshot %s has stored hash %q, want %q", newSnapshot.Name, string(existing.Spec.OverrideHash), overrideSpecHash)
 			klog.ErrorS(mismatchErr, "Existing overrideSnapshot has different content than the current spec; deleting it so the next reconcile can recreate with correct content", "clusterResourceOverride", croKObj)
 			// Event surfaces the recovery in `kubectl describe`.
-			if r.recorder != nil {
-				r.recorder.Eventf(cro, corev1.EventTypeWarning, "OverrideSnapshotHashMismatch",
-					"existing snapshot %s has different content than the current spec; deleting it for the next reconcile to recreate. If this persists, investigate the snapshot for manual edits or a hash-function change between controller versions.", newSnapshot.Name)
-			}
+			r.recorder.Eventf(cro, corev1.EventTypeWarning, "OverrideSnapshotHashMismatch",
+				"existing snapshot %s has different content than the current spec; deleting it for the next reconcile to recreate. If this persists, investigate the snapshot for manual edits or a hash-function change between controller versions.", newSnapshot.Name)
 			// Drive observed → desired: delete the mismatched snapshot so the next reconcile
 			// recreates it with the correct content.
 			if delErr := r.Client.Delete(ctx, existing); delErr != nil && !errors.IsNotFound(delErr) {

--- a/pkg/controllers/overrider/clusterresource_controller_test.go
+++ b/pkg/controllers/overrider/clusterresource_controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KubeFleet Authors.
+Copyright 2026 The KubeFleet Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -25,8 +25,8 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -45,7 +45,8 @@ import (
 // (no tracking label, divergent hash) so the controller hits the AlreadyExists path on Create
 // and then the hash-mismatch branch on the subsequent Get.
 func TestEnsureClusterResourceOverrideSnapshotAlreadyExistsDelete(t *testing.T) {
-	if err := placementv1beta1.AddToScheme(scheme.Scheme); err != nil {
+	s := runtime.NewScheme()
+	if err := placementv1beta1.AddToScheme(s); err != nil {
 		t.Fatalf("scheme: %v", err)
 	}
 
@@ -136,7 +137,7 @@ func TestEnsureClusterResourceOverrideSnapshotAlreadyExistsDelete(t *testing.T) 
 			}
 
 			fakeClient := fake.NewClientBuilder().
-				WithScheme(scheme.Scheme).
+				WithScheme(s).
 				WithObjects(snap0, snap1).
 				WithInterceptorFuncs(interceptors).
 				Build()

--- a/pkg/controllers/overrider/clusterresource_controller_test.go
+++ b/pkg/controllers/overrider/clusterresource_controller_test.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2025 The KubeFleet Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package overrider
+
+import (
+	"context"
+	stderrors "errors"
+	"fmt"
+	"strconv"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	placementv1beta1 "github.com/kubefleet-dev/kubefleet/apis/placement/v1beta1"
+	"github.com/kubefleet-dev/kubefleet/pkg/utils/controller"
+)
+
+// TestEnsureClusterResourceOverrideSnapshotAlreadyExistsDelete uses a fake client with Delete
+// interceptors to exercise the three Delete branches inside the AlreadyExists hash-mismatch
+// recovery path, which envtest can't reach reliably (real Delete almost always succeeds, so the
+// non-NotFound error branch is unreachable there).
+//
+// The flow: pre-create snapshot 0 (current "latest" with a stale hash) and a hidden snapshot 1
+// (no tracking label, divergent hash) so the controller hits the AlreadyExists path on Create
+// and then the hash-mismatch branch on the subsequent Get.
+func TestEnsureClusterResourceOverrideSnapshotAlreadyExistsDelete(t *testing.T) {
+	if err := placementv1beta1.AddToScheme(scheme.Scheme); err != nil {
+		t.Fatalf("scheme: %v", err)
+	}
+
+	tests := []struct {
+		name           string
+		deleteErr      error
+		wantSentinel   error
+		wantSnapDelete bool // whether the fake client recorded a Delete call
+	}{
+		{
+			name:           "delete succeeds returns expected-behavior error",
+			deleteErr:      nil,
+			wantSentinel:   controller.ErrExpectedBehavior,
+			wantSnapDelete: true,
+		},
+		{
+			name: "delete returning IsNotFound is swallowed and still returns expected-behavior error",
+			deleteErr: apierrors.NewNotFound(
+				schema.GroupResource{Group: placementv1beta1.GroupVersion.Group, Resource: "clusterresourceoverridesnapshots"},
+				"already-gone"),
+			wantSentinel:   controller.ErrExpectedBehavior,
+			wantSnapDelete: true,
+		},
+		{
+			name:         "delete returning non-NotFound error returns API server error",
+			deleteErr:    apierrors.NewInternalError(fmt.Errorf("simulated transient")),
+			wantSentinel: controller.ErrAPIServerError,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cro := &placementv1beta1.ClusterResourceOverride{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: placementv1beta1.GroupVersion.String(),
+					Kind:       placementv1beta1.ClusterResourceOverrideKind,
+				},
+				ObjectMeta: metav1.ObjectMeta{Name: "ae-cro", UID: "fake-uid"},
+				Spec: placementv1beta1.ClusterResourceOverrideSpec{
+					ClusterResourceSelectors: []placementv1beta1.ResourceSelectorTerm{
+						{Group: "", Version: "v1", Kind: "Namespace", Name: "ae-ns"},
+					},
+				},
+			}
+
+			// Pre-existing snapshot 0 with an old hash and the tracking label so list returns it.
+			snap0 := &placementv1beta1.ClusterResourceOverrideSnapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: fmt.Sprintf(placementv1beta1.OverrideSnapshotNameFmt, cro.Name, 0),
+					Labels: map[string]string{
+						placementv1beta1.OverrideTrackingLabel: cro.Name,
+						placementv1beta1.IsLatestSnapshotLabel: strconv.FormatBool(true),
+						placementv1beta1.OverrideIndexLabel:    "0",
+					},
+				},
+				Spec: placementv1beta1.ClusterResourceOverrideSnapshotSpec{
+					OverrideSpec: cro.Spec,
+					OverrideHash: []byte("stale-hash-not-matching-current-spec"),
+				},
+			}
+			// Pre-existing snapshot 1 invisible to listSortedOverrideSnapshots (no tracking label),
+			// with a hash that does NOT match the current spec — triggers the mismatch branch.
+			snap1 := &placementv1beta1.ClusterResourceOverrideSnapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: fmt.Sprintf(placementv1beta1.OverrideSnapshotNameFmt, cro.Name, 1),
+					Labels: map[string]string{
+						placementv1beta1.IsLatestSnapshotLabel: strconv.FormatBool(true),
+						placementv1beta1.OverrideIndexLabel:    "1",
+						// OverrideTrackingLabel deliberately omitted
+					},
+				},
+				Spec: placementv1beta1.ClusterResourceOverrideSnapshotSpec{
+					OverrideHash: []byte("different-hash-from-current-spec"),
+				},
+			}
+
+			deleteCalls := 0
+			interceptors := interceptor.Funcs{
+				Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+					if _, ok := obj.(*placementv1beta1.ClusterResourceOverrideSnapshot); ok && obj.GetName() == snap1.Name {
+						deleteCalls++
+						if tc.deleteErr != nil {
+							return tc.deleteErr
+						}
+					}
+					return c.Delete(ctx, obj, opts...)
+				},
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				WithObjects(snap0, snap1).
+				WithInterceptorFuncs(interceptors).
+				Build()
+
+			r := &ClusterResourceReconciler{
+				Reconciler: Reconciler{
+					Client:         fakeClient,
+					UncachedReader: fakeClient,
+					recorder:       record.NewFakeRecorder(10),
+				},
+			}
+
+			err := r.ensureClusterResourceOverrideSnapshot(context.Background(), cro, 10)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !stderrors.Is(err, tc.wantSentinel) {
+				t.Errorf("error = %v, want sentinel %v", err, tc.wantSentinel)
+			}
+			if tc.wantSnapDelete && deleteCalls == 0 {
+				t.Errorf("expected the controller to attempt deletion of the mismatched snapshot, but it didn't")
+			}
+		})
+	}
+}

--- a/pkg/controllers/overrider/clusterresource_controller_test.go
+++ b/pkg/controllers/overrider/clusterresource_controller_test.go
@@ -45,6 +45,7 @@ import (
 // (no tracking label, divergent hash) so the controller hits the AlreadyExists path on Create
 // and then the hash-mismatch branch on the subsequent Get.
 func TestEnsureClusterResourceOverrideSnapshotAlreadyExistsDelete(t *testing.T) {
+	t.Parallel()
 	s := runtime.NewScheme()
 	if err := placementv1beta1.AddToScheme(s); err != nil {
 		t.Fatalf("scheme: %v", err)
@@ -71,14 +72,16 @@ func TestEnsureClusterResourceOverrideSnapshotAlreadyExistsDelete(t *testing.T) 
 			wantSnapDelete: true,
 		},
 		{
-			name:         "delete returning non-NotFound error returns API server error",
-			deleteErr:    apierrors.NewInternalError(fmt.Errorf("simulated transient")),
-			wantSentinel: controller.ErrAPIServerError,
+			name:           "delete returning non-NotFound error returns API server error",
+			deleteErr:      apierrors.NewInternalError(fmt.Errorf("simulated transient")),
+			wantSentinel:   controller.ErrAPIServerError,
+			wantSnapDelete: true,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			cro := &placementv1beta1.ClusterResourceOverride{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: placementv1beta1.GroupVersion.String(),

--- a/pkg/controllers/overrider/common.go
+++ b/pkg/controllers/overrider/common.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -38,8 +39,16 @@ import (
 
 // Reconciler reconciles a clusterResourceOverride object.
 type Reconciler struct {
-	// Client is used to update objects which goes to the api server directly.
+	// Client is the cached controller-runtime client used for routine reads/writes.
 	client.Client
+	// UncachedReader bypasses the informer cache. Use it for read-after-write verification
+	// (e.g. post-Create hash checks on the AlreadyExists path) where a cached read could see
+	// stale state and force unnecessary requeues.
+	UncachedReader client.Reader
+	// recorder emits events on the parent override (CRO/RO) when the controller hits a state
+	// that requires operator visibility — e.g. an existing snapshot whose hash doesn't match
+	// the current spec, which silently retries forever otherwise. Set by SetupWithManager.
+	recorder record.EventRecorder
 }
 
 // handleOverrideDeleting handles the delete event of an override object. We need to delete all the related override Snapshot.
@@ -111,16 +120,28 @@ func (r *Reconciler) listSortedOverrideSnapshots(ctx context.Context, parentOver
 	return snapshotList, nil
 }
 
+// removeExtraSnapshot deletes oldest snapshots from sortedSnapshotList until the in-memory slice
+// length is at most limit-1, mirroring the API-server state. The slice is trimmed in place so any
+// downstream caller that consults sortedSnapshotList (e.g. cleanupStaleLatestSiblings) sees only
+// snapshots that should still exist on the server. On error the list is still trimmed by the
+// number of items we successfully accounted for, so a caller that retries doesn't double-process.
 func (r *Reconciler) removeExtraSnapshot(ctx context.Context, sortedSnapshotList *unstructured.UnstructuredList, limit int) error {
 	// the list is sorted by the override index, so we can just remove from the beginning
+	deleted := 0
+	defer func() {
+		sortedSnapshotList.Items = sortedSnapshotList.Items[deleted:]
+	}()
 	for i := 0; i <= len(sortedSnapshotList.Items)-limit; i++ {
 		if err := r.Client.Delete(ctx, &sortedSnapshotList.Items[i]); err != nil {
 			if !apierrors.IsNotFound(err) {
 				klog.ErrorS(err, "Failed to delete the extra override snapshot", "overrideSnapshot", klog.KObj(&sortedSnapshotList.Items[i]))
 				return controller.NewAPIServerError(false, err)
 			}
+			klog.V(2).InfoS("Extra override snapshot already gone", "overrideSnapshot", klog.KObj(&sortedSnapshotList.Items[i]))
+		} else {
+			klog.V(2).InfoS("Deleted the extra override snapshot", "overrideSnapshot", klog.KObj(&sortedSnapshotList.Items[i]))
 		}
-		klog.V(2).InfoS("Deleted the extra override snapshot", "overrideSnapshot", klog.KObj(&sortedSnapshotList.Items[i]))
+		deleted++
 	}
 	return nil
 }
@@ -130,13 +151,51 @@ func (r *Reconciler) ensureSnapshotLatest(ctx context.Context, latestSnapshot cl
 		klog.V(2).InfoS("Policy has not changed", "overrideSnapshot", klog.KObj(latestSnapshot))
 		return nil
 	}
-	// set the latest label to be true first to make sure there is only one or none active policy snapshot.
 	labels := latestSnapshot.GetLabels()
 	labels[placementv1beta1.IsLatestSnapshotLabel] = strconv.FormatBool(true)
 	latestSnapshot.SetLabels(labels)
 	if err := r.Client.Update(ctx, latestSnapshot); err != nil {
-		klog.ErrorS(err, "Failed to set the isLatestSnapshot label to false", "overrideSnapshot", klog.KObj(latestSnapshot))
+		klog.ErrorS(err, "Failed to set the isLatestSnapshot label to true", "overrideSnapshot", klog.KObj(latestSnapshot))
 		return controller.NewUpdateIgnoreConflictError(err)
+	}
+	return nil
+}
+
+// cleanupStaleLatestSiblings flips the IsLatestSnapshotLabel to false on any snapshot in
+// sortedSnapshotList other than the highest-index one. The list is assumed to be sorted in
+// ascending order of OverrideIndexLabel; the last item is the authoritative latest snapshot.
+//
+// This handles two scenarios:
+//   - A prior reconcile crashed between Create(new) and Update(old, latest=false), leaving
+//     duplicate latest=true labels.
+//   - Any other source of inconsistency (manual edit, partial-state recovery) that leaves
+//     stale latest=true labels on older snapshots.
+//
+// IsNotFound on the per-snapshot Update is treated as success: a concurrent prune or parent
+// deletion may have removed the snapshot already, which is the desired end state.
+func (r *Reconciler) cleanupStaleLatestSiblings(ctx context.Context, sortedSnapshotList *unstructured.UnstructuredList) error {
+	if sortedSnapshotList == nil || len(sortedSnapshotList.Items) <= 1 {
+		return nil
+	}
+	// Iterate every snapshot except the last (highest-index) one.
+	siblings := sortedSnapshotList.Items[:len(sortedSnapshotList.Items)-1]
+	for i := range siblings {
+		snapshot := &siblings[i]
+		if snapshot.GetLabels()[placementv1beta1.IsLatestSnapshotLabel] != strconv.FormatBool(true) {
+			continue
+		}
+		labels := snapshot.GetLabels()
+		labels[placementv1beta1.IsLatestSnapshotLabel] = strconv.FormatBool(false)
+		snapshot.SetLabels(labels)
+		if err := r.Client.Update(ctx, snapshot); err != nil {
+			if apierrors.IsNotFound(err) {
+				klog.V(2).InfoS("Stale latest sibling already gone; skipping", "overrideSnapshot", klog.KObj(snapshot))
+				continue
+			}
+			klog.ErrorS(err, "Failed to flip stale latest sibling to false", "overrideSnapshot", klog.KObj(snapshot))
+			return controller.NewUpdateIgnoreConflictError(err)
+		}
+		klog.V(2).InfoS("Flipped stale latest sibling to false", "overrideSnapshot", klog.KObj(snapshot))
 	}
 	return nil
 }

--- a/pkg/controllers/overrider/common.go
+++ b/pkg/controllers/overrider/common.go
@@ -39,15 +39,10 @@ import (
 
 // Reconciler reconciles a clusterResourceOverride object.
 type Reconciler struct {
-	// Client is the cached controller-runtime client used for routine reads/writes.
 	client.Client
-	// UncachedReader bypasses the informer cache. Use it for read-after-write verification
-	// (e.g. post-Create hash checks on the AlreadyExists path) where a cached read could see
-	// stale state and force unnecessary requeues.
+	// UncachedReader bypasses the informer cache for read-after-write verification.
 	UncachedReader client.Reader
-	// recorder emits events on the parent override (CRO/RO) when the controller hits a state
-	// that requires operator visibility — e.g. an existing snapshot whose hash doesn't match
-	// the current spec, which silently retries forever otherwise. Set by SetupWithManager.
+	// recorder is set by SetupWithManager; used for operator-visible warnings.
 	recorder record.EventRecorder
 }
 
@@ -120,11 +115,9 @@ func (r *Reconciler) listSortedOverrideSnapshots(ctx context.Context, parentOver
 	return snapshotList, nil
 }
 
-// removeExtraSnapshot deletes oldest snapshots from sortedSnapshotList until the in-memory slice
-// length is at most limit-1, mirroring the API-server state. The slice is trimmed in place so any
-// downstream caller that consults sortedSnapshotList (e.g. cleanupStaleLatestSiblings) sees only
-// snapshots that should still exist on the server. On error the list is still trimmed by the
-// number of items we successfully accounted for, so a caller that retries doesn't double-process.
+// removeExtraSnapshot deletes the oldest snapshots beyond limit-1 and trims the in-memory slice
+// in place so downstream callers (e.g. cleanupStaleLatestSiblings) don't re-process deleted items.
+// The trim is deferred so it still runs on the error path.
 func (r *Reconciler) removeExtraSnapshot(ctx context.Context, sortedSnapshotList *unstructured.UnstructuredList, limit int) error {
 	// the list is sorted by the override index, so we can just remove from the beginning
 	deleted := 0
@@ -161,23 +154,14 @@ func (r *Reconciler) ensureSnapshotLatest(ctx context.Context, latestSnapshot cl
 	return nil
 }
 
-// cleanupStaleLatestSiblings flips the IsLatestSnapshotLabel to false on any snapshot in
-// sortedSnapshotList other than the highest-index one. The list is assumed to be sorted in
-// ascending order of OverrideIndexLabel; the last item is the authoritative latest snapshot.
-//
-// This handles two scenarios:
-//   - A prior reconcile crashed between Create(new) and Update(old, latest=false), leaving
-//     duplicate latest=true labels.
-//   - Any other source of inconsistency (manual edit, partial-state recovery) that leaves
-//     stale latest=true labels on older snapshots.
-//
-// IsNotFound on the per-snapshot Update is treated as success: a concurrent prune or parent
-// deletion may have removed the snapshot already, which is the desired end state.
+// cleanupStaleLatestSiblings flips IsLatestSnapshotLabel to false on every snapshot in the
+// (ascending-by-index) list except the highest. Cleans up duplicate latest=true left by a
+// crashed Create-then-demote sequence or any out-of-band edit. IsNotFound on the Update is
+// treated as success.
 func (r *Reconciler) cleanupStaleLatestSiblings(ctx context.Context, sortedSnapshotList *unstructured.UnstructuredList) error {
 	if sortedSnapshotList == nil || len(sortedSnapshotList.Items) <= 1 {
 		return nil
 	}
-	// Iterate every snapshot except the last (highest-index) one.
 	siblings := sortedSnapshotList.Items[:len(sortedSnapshotList.Items)-1]
 	for i := range siblings {
 		snapshot := &siblings[i]

--- a/pkg/controllers/overrider/common_test.go
+++ b/pkg/controllers/overrider/common_test.go
@@ -383,6 +383,34 @@ var _ = Describe("Test ClusterResourceOverride common logic", func() {
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: snapshot0.Name}, final0)).Should(Succeed())
 			Expect(final0.Labels[placementv1beta1.IsLatestSnapshotLabel]).Should(Equal("true"))
 		})
+
+		It("Should take the hash-match path and audit siblings when the latest snapshot's hash equals the CRO spec", func() {
+			// Pre-create snapshot 0 with a hash that matches the CRO's current spec. When the
+			// controller lists snapshots and inspects the highest-index one (this snapshot), the
+			// hash check at the top of ensureClusterResourceOverrideSnapshot will short-circuit:
+			// no new snapshot is created and ensureSnapshotLatest + cleanupStaleLatestSiblings run.
+			intendedHash, err := resource.HashOf(aeCRO.Spec)
+			Expect(err).Should(Succeed())
+			snapshot0 := getClusterResourceOverrideSnapshot(aeCROName, 0)
+			snapshot0.Spec.OverrideHash = []byte(intendedHash)
+			snapshot0.Spec.OverrideSpec = aeCRO.Spec
+			// ensureSnapshotLatest should flip this back to true on the hash-match path.
+			snapshot0.Labels[placementv1beta1.IsLatestSnapshotLabel] = strconv.FormatBool(false)
+			Expect(k8sClient.Create(ctx, snapshot0)).Should(Succeed())
+
+			Expect(aeReconciler.ensureClusterResourceOverrideSnapshot(ctx, aeCRO, 10)).Should(Succeed())
+
+			By("Verifying ensureSnapshotLatest flipped snapshot 0 back to latest=true")
+			final0 := &placementv1beta1.ClusterResourceOverrideSnapshot{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: snapshot0.Name}, final0)).Should(Succeed())
+			Expect(final0.Labels[placementv1beta1.IsLatestSnapshotLabel]).Should(Equal("true"))
+
+			By("Verifying no new snapshot at index 1 was created")
+			snapshot1 := getClusterResourceOverrideSnapshot(aeCROName, 1)
+			Expect(apierrors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{Name: snapshot1.Name}, snapshot1))).Should(BeTrue(),
+				"hash-match path must not create a new snapshot")
+		})
+
 	})
 })
 
@@ -683,6 +711,29 @@ var _ = Describe("Test ResourceOverride common logic", func() {
 			final0 := &placementv1beta1.ResourceOverrideSnapshot{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: snapshot0.Name, Namespace: snapshot0.Namespace}, final0)).Should(Succeed())
 			Expect(final0.Labels[placementv1beta1.IsLatestSnapshotLabel]).Should(Equal("true"))
+		})
+
+		It("Should take the hash-match path and audit siblings when the latest snapshot's hash equals the RO spec", func() {
+			// Mirror of the CRO hash-match test for the namespaced controller.
+			intendedHash, err := resource.HashOf(aeRO.Spec)
+			Expect(err).Should(Succeed())
+			snapshot0 := getResourceOverrideSnapshot(aeROName, namespaceName, 0)
+			snapshot0.Spec.OverrideHash = []byte(intendedHash)
+			snapshot0.Spec.OverrideSpec = aeRO.Spec
+			snapshot0.Labels[placementv1beta1.IsLatestSnapshotLabel] = strconv.FormatBool(false)
+			Expect(k8sClient.Create(ctx, snapshot0)).Should(Succeed())
+
+			Expect(aeReconciler.ensureResourceOverrideSnapshot(ctx, aeRO, 10)).Should(Succeed())
+
+			By("Verifying ensureSnapshotLatest flipped snapshot 0 back to latest=true")
+			final0 := &placementv1beta1.ResourceOverrideSnapshot{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: snapshot0.Name, Namespace: snapshot0.Namespace}, final0)).Should(Succeed())
+			Expect(final0.Labels[placementv1beta1.IsLatestSnapshotLabel]).Should(Equal("true"))
+
+			By("Verifying no new snapshot at index 1 was created")
+			snapshot1 := getResourceOverrideSnapshot(aeROName, namespaceName, 1)
+			Expect(apierrors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{Name: snapshot1.Name, Namespace: snapshot1.Namespace}, snapshot1))).Should(BeTrue(),
+				"hash-match path must not create a new snapshot")
 		})
 	})
 })

--- a/pkg/controllers/overrider/common_test.go
+++ b/pkg/controllers/overrider/common_test.go
@@ -31,6 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	placementv1beta1 "github.com/kubefleet-dev/kubefleet/apis/placement/v1beta1"
@@ -341,7 +342,13 @@ var _ = Describe("Test ClusterResourceOverride common logic", func() {
 			Expect(final0.Labels[placementv1beta1.IsLatestSnapshotLabel]).Should(Equal("false"))
 		})
 
-		It("Should return ExpectedBehaviorError when AlreadyExists target has a mismatched hash", func() {
+		It("Should return ExpectedBehaviorError and emit a Warning event when AlreadyExists target has a mismatched hash", func() {
+			// Wire a fake recorder so we can assert the Warning event is actually emitted —
+			// production controllers set this in SetupWithManager, but this test constructs the
+			// reconciler manually.
+			fakeRecorder := record.NewFakeRecorder(10)
+			aeReconciler.recorder = fakeRecorder
+
 			snapshot0 := getClusterResourceOverrideSnapshot(aeCROName, 0)
 			snapshot0.Spec.OverrideHash = []byte("old-hash")
 			Expect(k8sClient.Create(ctx, snapshot0)).Should(Succeed())
@@ -359,6 +366,17 @@ var _ = Describe("Test ClusterResourceOverride common logic", func() {
 			Expect(err).Should(HaveOccurred(), "mismatched hash should not silently succeed")
 			Expect(errors.Is(err, controller.ErrExpectedBehavior)).Should(BeTrue(),
 				"error should wrap ErrExpectedBehavior so retry runs without stack-trace floods, got %v", err)
+
+			By("Verifying a Warning event with reason OverrideSnapshotHashMismatch was emitted on the parent CRO")
+			select {
+			case ev := <-fakeRecorder.Events:
+				Expect(ev).Should(ContainSubstring("OverrideSnapshotHashMismatch"),
+					"event = %q, want reason OverrideSnapshotHashMismatch", ev)
+				Expect(ev).Should(ContainSubstring("Warning"),
+					"event should be a Warning, got %q", ev)
+			default:
+				Fail("expected a Warning event with reason OverrideSnapshotHashMismatch, got none")
+			}
 
 			By("Verifying snapshot 0 was NOT demoted (we abort before the demote step)")
 			final0 := &placementv1beta1.ClusterResourceOverrideSnapshot{}
@@ -580,6 +598,91 @@ var _ = Describe("Test ResourceOverride common logic", func() {
 				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: snapshot.GetName(), Namespace: snapshot.Namespace}, snapshot)).Should(Succeed())
 				Expect(snapshot.GetLabels()[placementv1beta1.IsLatestSnapshotLabel]).Should(Equal("false"))
 			}
+		})
+	})
+
+	Context("Test ensureResourceOverrideSnapshot AlreadyExists recovery", func() {
+		var aeReconciler *ResourceReconciler
+		var aeROName string
+		var aeRO *placementv1beta1.ResourceOverride
+
+		BeforeEach(func() {
+			// Use a dedicated RO so this Context's snapshots don't collide with the parent
+			// BeforeEach's snapshots (testROName at indices 0..totalSnapshots-1).
+			aeROName = fmt.Sprintf("test-ro-already-exists-%s", utils.RandStr())
+			aeRO = getResourceOverride(aeROName, namespaceName)
+			// Snapshot Create adds an OwnerReference whose UID must be non-empty for API-server
+			// validation; we don't apply the RO to the cluster (would trigger the real reconcile
+			// loop), so we synthesize a UID.
+			aeRO.UID = "fake-uid-for-owner-ref"
+			aeReconciler = &ResourceReconciler{Reconciler: commonReconciler}
+		})
+
+		AfterEach(func() {
+			for i := 0; i < 2; i++ {
+				snap := getResourceOverrideSnapshot(aeROName, namespaceName, i)
+				Expect(k8sClient.Delete(ctx, snap)).Should(SatisfyAny(Succeed(), &utils.NotFoundMatcher{}))
+			}
+		})
+
+		It("Should treat AlreadyExists with matching hash as success and demote the previous snapshot", func() {
+			snapshot0 := getResourceOverrideSnapshot(aeROName, namespaceName, 0)
+			snapshot0.Spec.OverrideHash = []byte("old-hash")
+			Expect(k8sClient.Create(ctx, snapshot0)).Should(Succeed())
+
+			// Pre-create snapshot 1 invisibly: stripping OverrideTrackingLabel hides it from
+			// listSortedOverrideSnapshots so the controller computes newIndex=1 and Create races
+			// into AlreadyExists. See the CRO test for the etcd-restore production rationale.
+			intendedHash, err := resource.HashOf(aeRO.Spec)
+			Expect(err).Should(Succeed())
+			invisibleSnapshot1 := getResourceOverrideSnapshot(aeROName, namespaceName, 1)
+			delete(invisibleSnapshot1.Labels, placementv1beta1.OverrideTrackingLabel)
+			invisibleSnapshot1.Spec.OverrideHash = []byte(intendedHash)
+			invisibleSnapshot1.Spec.OverrideSpec = aeRO.Spec
+			Expect(k8sClient.Create(ctx, invisibleSnapshot1)).Should(Succeed())
+
+			Expect(aeReconciler.ensureResourceOverrideSnapshot(ctx, aeRO, 10)).Should(Succeed(),
+				"AlreadyExists with matching hash should be treated as success")
+
+			By("Verifying snapshot 0 was demoted to latest=false")
+			final0 := &placementv1beta1.ResourceOverrideSnapshot{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: snapshot0.Name, Namespace: snapshot0.Namespace}, final0)).Should(Succeed())
+			Expect(final0.Labels[placementv1beta1.IsLatestSnapshotLabel]).Should(Equal("false"))
+		})
+
+		It("Should return ExpectedBehaviorError and emit a Warning event when AlreadyExists target has a mismatched hash", func() {
+			fakeRecorder := record.NewFakeRecorder(10)
+			aeReconciler.recorder = fakeRecorder
+
+			snapshot0 := getResourceOverrideSnapshot(aeROName, namespaceName, 0)
+			snapshot0.Spec.OverrideHash = []byte("old-hash")
+			Expect(k8sClient.Create(ctx, snapshot0)).Should(Succeed())
+
+			invisibleSnapshot1 := getResourceOverrideSnapshot(aeROName, namespaceName, 1)
+			delete(invisibleSnapshot1.Labels, placementv1beta1.OverrideTrackingLabel)
+			invisibleSnapshot1.Spec.OverrideHash = []byte("stale-hash-from-backup")
+			Expect(k8sClient.Create(ctx, invisibleSnapshot1)).Should(Succeed())
+
+			err := aeReconciler.ensureResourceOverrideSnapshot(ctx, aeRO, 10)
+			Expect(err).Should(HaveOccurred(), "mismatched hash should not silently succeed")
+			Expect(errors.Is(err, controller.ErrExpectedBehavior)).Should(BeTrue(),
+				"error should wrap ErrExpectedBehavior, got %v", err)
+
+			By("Verifying a Warning event with reason OverrideSnapshotHashMismatch was emitted on the parent RO")
+			select {
+			case ev := <-fakeRecorder.Events:
+				Expect(ev).Should(ContainSubstring("OverrideSnapshotHashMismatch"),
+					"event = %q, want reason OverrideSnapshotHashMismatch", ev)
+				Expect(ev).Should(ContainSubstring("Warning"),
+					"event should be a Warning, got %q", ev)
+			default:
+				Fail("expected a Warning event with reason OverrideSnapshotHashMismatch, got none")
+			}
+
+			By("Verifying snapshot 0 was NOT demoted (we abort before the demote step)")
+			final0 := &placementv1beta1.ResourceOverrideSnapshot{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: snapshot0.Name, Namespace: snapshot0.Namespace}, final0)).Should(Succeed())
+			Expect(final0.Labels[placementv1beta1.IsLatestSnapshotLabel]).Should(Equal("true"))
 		})
 	})
 })

--- a/pkg/controllers/overrider/common_test.go
+++ b/pkg/controllers/overrider/common_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/kubefleet-dev/kubefleet/pkg/utils"
 	"github.com/kubefleet-dev/kubefleet/pkg/utils/controller"
 	"github.com/kubefleet-dev/kubefleet/pkg/utils/labels"
+	"github.com/kubefleet-dev/kubefleet/pkg/utils/resource"
 )
 
 const (
@@ -126,7 +127,7 @@ var _ = Describe("Test ClusterResourceOverride common logic", func() {
 	})
 
 	Context("Test remove extra cluster override snapshots", func() {
-		It("Should not remove any snapshots if we no snapshot", func() {
+		It("Should not remove any snapshots if we have no snapshots", func() {
 			snapshotList := &unstructured.UnstructuredList{
 				Items: []unstructured.Unstructured{},
 			}
@@ -150,7 +151,7 @@ var _ = Describe("Test ClusterResourceOverride common logic", func() {
 			}
 		})
 
-		It("Should remove 1 extra snapshots if we just reach the limit", func() {
+		It("Should remove 1 extra snapshot if we just reach the limit", func() {
 			snapshotList, err := commonReconciler.listSortedOverrideSnapshots(ctx, cro)
 			Expect(err).Should(Succeed())
 			// we have 5 snapshots, and the limit is 5, so we should remove one. This is the base case.
@@ -191,7 +192,7 @@ var _ = Describe("Test ClusterResourceOverride common logic", func() {
 		})
 	})
 
-	Context("Test remove extra override snapshots", func() {
+	Context("Test ensureSnapshotLatest", func() {
 		It("Should keep the latest label as true if it's already true", func() {
 			snapshot := getClusterResourceOverrideSnapshot(testCROName, 0)
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: snapshot.GetName()}, snapshot)).Should(Succeed())
@@ -223,6 +224,146 @@ var _ = Describe("Test ClusterResourceOverride common logic", func() {
 				placementv1beta1.OverrideTrackingLabel: testCROName,
 			}, snapshot.GetLabels())
 			Expect(diff).Should(BeEmpty(), diff)
+		})
+	})
+
+	Context("Test cleanupStaleLatestSiblings on CRO snapshots", func() {
+		It("Should be a no-op when only one snapshot is latest=true", func() {
+			By("flipping all but the highest-index snapshot to latest=false")
+			for i := range 4 {
+				snapshot := getClusterResourceOverrideSnapshot(testCROName, i)
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: snapshot.GetName()}, snapshot)).Should(Succeed())
+				labels := snapshot.GetLabels()
+				labels[placementv1beta1.IsLatestSnapshotLabel] = "false"
+				snapshot.SetLabels(labels)
+				Expect(k8sClient.Update(ctx, snapshot)).Should(Succeed())
+			}
+
+			By("calling the audit on the freshly listed snapshots")
+			snapshotList, err := commonReconciler.listSortedOverrideSnapshots(ctx, cro)
+			Expect(err).Should(Succeed())
+			Expect(commonReconciler.cleanupStaleLatestSiblings(ctx, snapshotList)).Should(Succeed())
+
+			By("verifying that the highest-index snapshot is still latest=true")
+			highest := getClusterResourceOverrideSnapshot(testCROName, 4)
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: highest.GetName()}, highest)).Should(Succeed())
+			Expect(highest.GetLabels()[placementv1beta1.IsLatestSnapshotLabel]).Should(Equal("true"))
+
+			By("verifying that the older snapshots remain latest=false")
+			for i := range 4 {
+				snapshot := getClusterResourceOverrideSnapshot(testCROName, i)
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: snapshot.GetName()}, snapshot)).Should(Succeed())
+				Expect(snapshot.GetLabels()[placementv1beta1.IsLatestSnapshotLabel]).Should(Equal("false"))
+			}
+		})
+
+		It("Should flip every stale latest=true sibling to false", func() {
+			// BeforeEach creates 5 snapshots all with latest=true, simulating the post-crash
+			// state where Create-first succeeded several times but the demote step failed.
+			By("calling the audit on the freshly listed snapshots")
+			snapshotList, err := commonReconciler.listSortedOverrideSnapshots(ctx, cro)
+			Expect(err).Should(Succeed())
+			Expect(commonReconciler.cleanupStaleLatestSiblings(ctx, snapshotList)).Should(Succeed())
+
+			By("verifying that the highest-index snapshot keeps latest=true")
+			highest := getClusterResourceOverrideSnapshot(testCROName, 4)
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: highest.GetName()}, highest)).Should(Succeed())
+			Expect(highest.GetLabels()[placementv1beta1.IsLatestSnapshotLabel]).Should(Equal("true"))
+
+			By("verifying that the older snapshots are flipped to latest=false")
+			for i := range 4 {
+				snapshot := getClusterResourceOverrideSnapshot(testCROName, i)
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: snapshot.GetName()}, snapshot)).Should(Succeed())
+				Expect(snapshot.GetLabels()[placementv1beta1.IsLatestSnapshotLabel]).Should(Equal("false"))
+			}
+		})
+
+		It("Should be a no-op for empty or single-item lists", func() {
+			Expect(commonReconciler.cleanupStaleLatestSiblings(ctx, nil)).Should(Succeed())
+			Expect(commonReconciler.cleanupStaleLatestSiblings(ctx, &unstructured.UnstructuredList{})).Should(Succeed())
+		})
+	})
+
+	Context("Test ensureClusterResourceOverrideSnapshot AlreadyExists recovery", func() {
+		var aeReconciler *ClusterResourceReconciler
+		var aeCROName string
+		var aeCRO *placementv1beta1.ClusterResourceOverride
+
+		BeforeEach(func() {
+			// Use a dedicated CRO name so this Context's snapshots don't collide with the parent
+			// BeforeEach's snapshots (which all share testCROName at indices 0-4).
+			aeCROName = fmt.Sprintf("test-cro-already-exists-%s", utils.RandStr())
+			aeCRO = getClusterResourceOverride(aeCROName)
+			// We don't apply the CRO to the cluster (would trigger the real reconcile loop), but
+			// the snapshot Create inside ensureClusterResourceOverrideSnapshot adds an OwnerReference
+			// whose UID must be non-empty for API-server validation.
+			aeCRO.UID = "fake-uid-for-owner-ref"
+			aeReconciler = &ClusterResourceReconciler{Reconciler: commonReconciler}
+		})
+
+		AfterEach(func() {
+			// Clean up snapshots created in this Context. Both indices may or may not exist.
+			for i := 0; i < 2; i++ {
+				snap := getClusterResourceOverrideSnapshot(aeCROName, i)
+				Expect(k8sClient.Delete(ctx, snap)).Should(SatisfyAny(Succeed(), &utils.NotFoundMatcher{}))
+			}
+		})
+
+		It("Should treat AlreadyExists with matching hash as success and demote the previous snapshot", func() {
+			// Pre-create snapshot 0 fully tracked: this is the "previous latest" the controller
+			// will see via listSortedOverrideSnapshots.
+			snapshot0 := getClusterResourceOverrideSnapshot(aeCROName, 0)
+			snapshot0.Spec.OverrideHash = []byte("old-hash")
+			Expect(k8sClient.Create(ctx, snapshot0)).Should(Succeed())
+
+			// Pre-create snapshot 1 WITHOUT the OverrideTrackingLabel so listSortedOverrideSnapshots
+			// (which filters by tracking label) does not see it. The controller will compute a new
+			// snapshot at index 1 and hit AlreadyExists when it tries to Create.
+			//
+			// In production the real trigger for this branch is etcd restore from backup (a
+			// snapshot that exists in etcd but is invisible to the controller's listing pass),
+			// which envtest cannot simulate directly. Stripping the tracking label is the most
+			// faithful approximation available in an integration test.
+			intendedHash, err := resource.HashOf(aeCRO.Spec)
+			Expect(err).Should(Succeed())
+			invisibleSnapshot1 := getClusterResourceOverrideSnapshot(aeCROName, 1)
+			delete(invisibleSnapshot1.Labels, placementv1beta1.OverrideTrackingLabel)
+			invisibleSnapshot1.Spec.OverrideHash = []byte(intendedHash)
+			invisibleSnapshot1.Spec.OverrideSpec = aeCRO.Spec
+			Expect(k8sClient.Create(ctx, invisibleSnapshot1)).Should(Succeed())
+
+			Expect(aeReconciler.ensureClusterResourceOverrideSnapshot(ctx, aeCRO, 10)).Should(Succeed(),
+				"AlreadyExists with matching hash should be treated as success")
+
+			By("Verifying snapshot 0 was demoted to latest=false")
+			final0 := &placementv1beta1.ClusterResourceOverrideSnapshot{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: snapshot0.Name}, final0)).Should(Succeed())
+			Expect(final0.Labels[placementv1beta1.IsLatestSnapshotLabel]).Should(Equal("false"))
+		})
+
+		It("Should return ExpectedBehaviorError when AlreadyExists target has a mismatched hash", func() {
+			snapshot0 := getClusterResourceOverrideSnapshot(aeCROName, 0)
+			snapshot0.Spec.OverrideHash = []byte("old-hash")
+			Expect(k8sClient.Create(ctx, snapshot0)).Should(Succeed())
+
+			// Pre-create snapshot 1 invisibly with a hash that does NOT match the CRO's spec —
+			// simulating etcd restore from backup or a future hash-function change. The most
+			// likely real-world trigger is an etcd restore where retry will eventually converge,
+			// so the controller surfaces an expected-behavior error rather than a hard failure.
+			invisibleSnapshot1 := getClusterResourceOverrideSnapshot(aeCROName, 1)
+			delete(invisibleSnapshot1.Labels, placementv1beta1.OverrideTrackingLabel)
+			invisibleSnapshot1.Spec.OverrideHash = []byte("stale-hash-from-backup")
+			Expect(k8sClient.Create(ctx, invisibleSnapshot1)).Should(Succeed())
+
+			err := aeReconciler.ensureClusterResourceOverrideSnapshot(ctx, aeCRO, 10)
+			Expect(err).Should(HaveOccurred(), "mismatched hash should not silently succeed")
+			Expect(errors.Is(err, controller.ErrExpectedBehavior)).Should(BeTrue(),
+				"error should wrap ErrExpectedBehavior so retry runs without stack-trace floods, got %v", err)
+
+			By("Verifying snapshot 0 was NOT demoted (we abort before the demote step)")
+			final0 := &placementv1beta1.ClusterResourceOverrideSnapshot{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: snapshot0.Name}, final0)).Should(Succeed())
+			Expect(final0.Labels[placementv1beta1.IsLatestSnapshotLabel]).Should(Equal("true"))
 		})
 	})
 })
@@ -320,7 +461,7 @@ var _ = Describe("Test ResourceOverride common logic", func() {
 	})
 
 	Context("Test remove extra cluster override snapshots", func() {
-		It("Should not remove any snapshots if we no snapshot", func() {
+		It("Should not remove any snapshots if we have no snapshots", func() {
 			snapshotList := &unstructured.UnstructuredList{
 				Items: []unstructured.Unstructured{},
 			}
@@ -344,14 +485,14 @@ var _ = Describe("Test ResourceOverride common logic", func() {
 			}
 		})
 
-		It("Should remove 1 extra snapshots if we just reach the limit", func() {
+		It("Should remove 1 extra snapshot if we just reach the limit", func() {
 			snapshotList, err := commonReconciler.listSortedOverrideSnapshots(ctx, ro)
 			Expect(err).Should(Succeed())
 			// we have 7 snapshots, and the limit is 7, so we should remove one. This is the base case.
 			err = commonReconciler.removeExtraSnapshot(ctx, snapshotList, totalSnapshots)
 			Expect(err).Should(Succeed())
 			By("verifying that the oldest snapshot is removed")
-			snapshot := getClusterResourceOverrideSnapshot(testROName, 0)
+			snapshot := getResourceOverrideSnapshot(testROName, ro.Namespace, 0)
 			Eventually(func() bool {
 				return apierrors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{Name: snapshot.Name, Namespace: snapshot.Namespace}, snapshot))
 			}, eventuallyTimeout, interval).Should(BeTrue(), "snapshot should be deleted")
@@ -385,7 +526,7 @@ var _ = Describe("Test ResourceOverride common logic", func() {
 		})
 	})
 
-	Context("Test remove extra override snapshots", func() {
+	Context("Test ensureSnapshotLatest", func() {
 		It("Should keep the latest label as true if it's already true", func() {
 			snapshot := getResourceOverrideSnapshot(testROName, ro.Namespace, 0)
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: snapshot.GetName(), Namespace: snapshot.Namespace}, snapshot)).Should(Succeed())
@@ -417,6 +558,28 @@ var _ = Describe("Test ResourceOverride common logic", func() {
 				placementv1beta1.OverrideTrackingLabel: testROName,
 			}, snapshot.GetLabels())
 			Expect(diff).Should(BeEmpty(), diff)
+		})
+	})
+
+	Context("Test cleanupStaleLatestSiblings on RO snapshots", func() {
+		It("Should flip every stale latest=true sibling to false (post-crash recovery)", func() {
+			// BeforeEach creates 7 snapshots all with latest=true, simulating the post-crash state.
+			By("calling the audit on the freshly listed snapshots")
+			snapshotList, err := commonReconciler.listSortedOverrideSnapshots(ctx, ro)
+			Expect(err).Should(Succeed())
+			Expect(commonReconciler.cleanupStaleLatestSiblings(ctx, snapshotList)).Should(Succeed())
+
+			By("verifying that the highest-index snapshot keeps latest=true")
+			highest := getResourceOverrideSnapshot(testROName, ro.Namespace, totalSnapshots-1)
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: highest.GetName(), Namespace: highest.Namespace}, highest)).Should(Succeed())
+			Expect(highest.GetLabels()[placementv1beta1.IsLatestSnapshotLabel]).Should(Equal("true"))
+
+			By("verifying that the older snapshots are flipped to latest=false")
+			for i := 0; i < totalSnapshots-1; i++ {
+				snapshot := getResourceOverrideSnapshot(testROName, ro.Namespace, i)
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: snapshot.GetName(), Namespace: snapshot.Namespace}, snapshot)).Should(Succeed())
+				Expect(snapshot.GetLabels()[placementv1beta1.IsLatestSnapshotLabel]).Should(Equal("false"))
+			}
 		})
 	})
 })

--- a/pkg/controllers/overrider/common_test.go
+++ b/pkg/controllers/overrider/common_test.go
@@ -342,7 +342,7 @@ var _ = Describe("Test ClusterResourceOverride common logic", func() {
 			Expect(final0.Labels[placementv1beta1.IsLatestSnapshotLabel]).Should(Equal("false"))
 		})
 
-		It("Should return ExpectedBehaviorError and emit a Warning event when AlreadyExists target has a mismatched hash", func() {
+		It("Should delete the mismatched snapshot, return ExpectedBehaviorError, and emit a Warning event", func() {
 			// Wire a fake recorder so we can assert the Warning event is actually emitted —
 			// production controllers set this in SetupWithManager, but this test constructs the
 			// reconciler manually.
@@ -353,16 +353,31 @@ var _ = Describe("Test ClusterResourceOverride common logic", func() {
 			snapshot0.Spec.OverrideHash = []byte("old-hash")
 			Expect(k8sClient.Create(ctx, snapshot0)).Should(Succeed())
 
-			// Pre-create snapshot 1 invisibly with a hash that does NOT match the CRO's spec —
-			// simulating etcd restore from backup or a future hash-function change. The most
-			// likely real-world trigger is an etcd restore where retry will eventually converge,
-			// so the controller surfaces an expected-behavior error rather than a hard failure.
+			// Pre-create snapshot 1 invisibly with a spec that produces a different hash than
+			// the current CRO. Simulates a manual edit or a hash-function change between
+			// controller versions. The reconciler should delete this snapshot to drive the
+			// system back toward desired state, then return ExpectedBehaviorError so the next
+			// reconcile recreates it correctly.
 			invisibleSnapshot1 := getClusterResourceOverrideSnapshot(aeCROName, 1)
 			delete(invisibleSnapshot1.Labels, placementv1beta1.OverrideTrackingLabel)
-			invisibleSnapshot1.Spec.OverrideHash = []byte("stale-hash-from-backup")
+			// Give the snapshot a spec whose computed hash will not match aeCRO's.
+			divergentSpec := getClusterResourceOverrideSpec()
+			divergentSpec.Policy = &placementv1beta1.OverridePolicy{
+				OverrideRules: []placementv1beta1.OverrideRule{
+					{
+						JSONPatchOverrides: []placementv1beta1.JSONPatchOverride{
+							{Operator: placementv1beta1.JSONPatchOverrideOpRemove, Path: "/metadata/labels/divergent-marker"},
+						},
+					},
+				},
+			}
+			invisibleSnapshot1.Spec.OverrideSpec = divergentSpec
+			divergentHash, err := resource.HashOf(divergentSpec)
+			Expect(err).Should(Succeed())
+			invisibleSnapshot1.Spec.OverrideHash = []byte(divergentHash)
 			Expect(k8sClient.Create(ctx, invisibleSnapshot1)).Should(Succeed())
 
-			err := aeReconciler.ensureClusterResourceOverrideSnapshot(ctx, aeCRO, 10)
+			err = aeReconciler.ensureClusterResourceOverrideSnapshot(ctx, aeCRO, 10)
 			Expect(err).Should(HaveOccurred(), "mismatched hash should not silently succeed")
 			Expect(errors.Is(err, controller.ErrExpectedBehavior)).Should(BeTrue(),
 				"error should wrap ErrExpectedBehavior so retry runs without stack-trace floods, got %v", err)
@@ -377,6 +392,11 @@ var _ = Describe("Test ClusterResourceOverride common logic", func() {
 			default:
 				Fail("expected a Warning event with reason OverrideSnapshotHashMismatch, got none")
 			}
+
+			By("Verifying the mismatched snapshot was deleted (driving observed → desired)")
+			Eventually(func() bool {
+				return apierrors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{Name: invisibleSnapshot1.Name}, &placementv1beta1.ClusterResourceOverrideSnapshot{}))
+			}, eventuallyTimeout, interval).Should(BeTrue(), "mismatched snapshot should have been deleted")
 
 			By("Verifying snapshot 0 was NOT demoted (we abort before the demote step)")
 			final0 := &placementv1beta1.ClusterResourceOverrideSnapshot{}
@@ -678,7 +698,7 @@ var _ = Describe("Test ResourceOverride common logic", func() {
 			Expect(final0.Labels[placementv1beta1.IsLatestSnapshotLabel]).Should(Equal("false"))
 		})
 
-		It("Should return ExpectedBehaviorError and emit a Warning event when AlreadyExists target has a mismatched hash", func() {
+		It("Should delete the mismatched snapshot, return ExpectedBehaviorError, and emit a Warning event", func() {
 			fakeRecorder := record.NewFakeRecorder(10)
 			aeReconciler.recorder = fakeRecorder
 
@@ -686,12 +706,28 @@ var _ = Describe("Test ResourceOverride common logic", func() {
 			snapshot0.Spec.OverrideHash = []byte("old-hash")
 			Expect(k8sClient.Create(ctx, snapshot0)).Should(Succeed())
 
+			// Pre-create snapshot 1 invisibly with a divergent spec — the controller must
+			// recompute the hash from the spec (not trust the stored OverrideHash field) and
+			// then delete the snapshot to drive observed → desired state.
 			invisibleSnapshot1 := getResourceOverrideSnapshot(aeROName, namespaceName, 1)
 			delete(invisibleSnapshot1.Labels, placementv1beta1.OverrideTrackingLabel)
-			invisibleSnapshot1.Spec.OverrideHash = []byte("stale-hash-from-backup")
+			divergentSpec := getResourceOverrideSpec()
+			divergentSpec.Policy = &placementv1beta1.OverridePolicy{
+				OverrideRules: []placementv1beta1.OverrideRule{
+					{
+						JSONPatchOverrides: []placementv1beta1.JSONPatchOverride{
+							{Operator: placementv1beta1.JSONPatchOverrideOpRemove, Path: "/metadata/labels/divergent-marker"},
+						},
+					},
+				},
+			}
+			invisibleSnapshot1.Spec.OverrideSpec = divergentSpec
+			divergentHash, err := resource.HashOf(divergentSpec)
+			Expect(err).Should(Succeed())
+			invisibleSnapshot1.Spec.OverrideHash = []byte(divergentHash)
 			Expect(k8sClient.Create(ctx, invisibleSnapshot1)).Should(Succeed())
 
-			err := aeReconciler.ensureResourceOverrideSnapshot(ctx, aeRO, 10)
+			err = aeReconciler.ensureResourceOverrideSnapshot(ctx, aeRO, 10)
 			Expect(err).Should(HaveOccurred(), "mismatched hash should not silently succeed")
 			Expect(errors.Is(err, controller.ErrExpectedBehavior)).Should(BeTrue(),
 				"error should wrap ErrExpectedBehavior, got %v", err)
@@ -706,6 +742,11 @@ var _ = Describe("Test ResourceOverride common logic", func() {
 			default:
 				Fail("expected a Warning event with reason OverrideSnapshotHashMismatch, got none")
 			}
+
+			By("Verifying the mismatched snapshot was deleted (driving observed → desired)")
+			Eventually(func() bool {
+				return apierrors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{Name: invisibleSnapshot1.Name, Namespace: invisibleSnapshot1.Namespace}, &placementv1beta1.ResourceOverrideSnapshot{}))
+			}, eventuallyTimeout, interval).Should(BeTrue(), "mismatched snapshot should have been deleted")
 
 			By("Verifying snapshot 0 was NOT demoted (we abort before the demote step)")
 			final0 := &placementv1beta1.ResourceOverrideSnapshot{}

--- a/pkg/controllers/overrider/common_test.go
+++ b/pkg/controllers/overrider/common_test.go
@@ -286,26 +286,26 @@ var _ = Describe("Test ClusterResourceOverride common logic", func() {
 	})
 
 	Context("Test ensureClusterResourceOverrideSnapshot AlreadyExists recovery", func() {
-		var aeReconciler *ClusterResourceReconciler
-		var aeCROName string
-		var aeCRO *placementv1beta1.ClusterResourceOverride
+		var recoveryReconciler *ClusterResourceReconciler
+		var recoveryCROName string
+		var recoveryCRO *placementv1beta1.ClusterResourceOverride
 
 		BeforeEach(func() {
 			// Use a dedicated CRO name so this Context's snapshots don't collide with the parent
 			// BeforeEach's snapshots (which all share testCROName at indices 0-4).
-			aeCROName = fmt.Sprintf("test-cro-already-exists-%s", utils.RandStr())
-			aeCRO = getClusterResourceOverride(aeCROName)
+			recoveryCROName = fmt.Sprintf("test-cro-already-exists-%s", utils.RandStr())
+			recoveryCRO = getClusterResourceOverride(recoveryCROName)
 			// We don't apply the CRO to the cluster (would trigger the real reconcile loop), but
 			// the snapshot Create inside ensureClusterResourceOverrideSnapshot adds an OwnerReference
 			// whose UID must be non-empty for API-server validation.
-			aeCRO.UID = "fake-uid-for-owner-ref"
-			aeReconciler = &ClusterResourceReconciler{Reconciler: commonReconciler}
+			recoveryCRO.UID = "fake-uid-for-owner-ref"
+			recoveryReconciler = &ClusterResourceReconciler{Reconciler: commonReconciler}
 		})
 
 		AfterEach(func() {
 			// Clean up snapshots created in this Context. Both indices may or may not exist.
 			for i := 0; i < 2; i++ {
-				snap := getClusterResourceOverrideSnapshot(aeCROName, i)
+				snap := getClusterResourceOverrideSnapshot(recoveryCROName, i)
 				Expect(k8sClient.Delete(ctx, snap)).Should(SatisfyAny(Succeed(), &utils.NotFoundMatcher{}))
 			}
 		})
@@ -313,7 +313,7 @@ var _ = Describe("Test ClusterResourceOverride common logic", func() {
 		It("Should treat AlreadyExists with matching hash as success and demote the previous snapshot", func() {
 			// Pre-create snapshot 0 fully tracked: this is the "previous latest" the controller
 			// will see via listSortedOverrideSnapshots.
-			snapshot0 := getClusterResourceOverrideSnapshot(aeCROName, 0)
+			snapshot0 := getClusterResourceOverrideSnapshot(recoveryCROName, 0)
 			snapshot0.Spec.OverrideHash = []byte("old-hash")
 			Expect(k8sClient.Create(ctx, snapshot0)).Should(Succeed())
 
@@ -325,15 +325,15 @@ var _ = Describe("Test ClusterResourceOverride common logic", func() {
 			// snapshot that exists in etcd but is invisible to the controller's listing pass),
 			// which envtest cannot simulate directly. Stripping the tracking label is the most
 			// faithful approximation available in an integration test.
-			intendedHash, err := resource.HashOf(aeCRO.Spec)
+			intendedHash, err := resource.HashOf(recoveryCRO.Spec)
 			Expect(err).Should(Succeed())
-			invisibleSnapshot1 := getClusterResourceOverrideSnapshot(aeCROName, 1)
+			invisibleSnapshot1 := getClusterResourceOverrideSnapshot(recoveryCROName, 1)
 			delete(invisibleSnapshot1.Labels, placementv1beta1.OverrideTrackingLabel)
 			invisibleSnapshot1.Spec.OverrideHash = []byte(intendedHash)
-			invisibleSnapshot1.Spec.OverrideSpec = aeCRO.Spec
+			invisibleSnapshot1.Spec.OverrideSpec = recoveryCRO.Spec
 			Expect(k8sClient.Create(ctx, invisibleSnapshot1)).Should(Succeed())
 
-			Expect(aeReconciler.ensureClusterResourceOverrideSnapshot(ctx, aeCRO, 10)).Should(Succeed(),
+			Expect(recoveryReconciler.ensureClusterResourceOverrideSnapshot(ctx, recoveryCRO, 10)).Should(Succeed(),
 				"AlreadyExists with matching hash should be treated as success")
 
 			By("Verifying snapshot 0 was demoted to latest=false")
@@ -347,9 +347,9 @@ var _ = Describe("Test ClusterResourceOverride common logic", func() {
 			// production controllers set this in SetupWithManager, but this test constructs the
 			// reconciler manually.
 			fakeRecorder := record.NewFakeRecorder(10)
-			aeReconciler.recorder = fakeRecorder
+			recoveryReconciler.recorder = fakeRecorder
 
-			snapshot0 := getClusterResourceOverrideSnapshot(aeCROName, 0)
+			snapshot0 := getClusterResourceOverrideSnapshot(recoveryCROName, 0)
 			snapshot0.Spec.OverrideHash = []byte("old-hash")
 			Expect(k8sClient.Create(ctx, snapshot0)).Should(Succeed())
 
@@ -358,9 +358,9 @@ var _ = Describe("Test ClusterResourceOverride common logic", func() {
 			// controller versions. The reconciler should delete this snapshot to drive the
 			// system back toward desired state, then return ExpectedBehaviorError so the next
 			// reconcile recreates it correctly.
-			invisibleSnapshot1 := getClusterResourceOverrideSnapshot(aeCROName, 1)
+			invisibleSnapshot1 := getClusterResourceOverrideSnapshot(recoveryCROName, 1)
 			delete(invisibleSnapshot1.Labels, placementv1beta1.OverrideTrackingLabel)
-			// Give the snapshot a spec whose computed hash will not match aeCRO's.
+			// Give the snapshot a spec whose computed hash will not match recoveryCRO's.
 			divergentSpec := getClusterResourceOverrideSpec()
 			divergentSpec.Policy = &placementv1beta1.OverridePolicy{
 				OverrideRules: []placementv1beta1.OverrideRule{
@@ -377,7 +377,7 @@ var _ = Describe("Test ClusterResourceOverride common logic", func() {
 			invisibleSnapshot1.Spec.OverrideHash = []byte(divergentHash)
 			Expect(k8sClient.Create(ctx, invisibleSnapshot1)).Should(Succeed())
 
-			err = aeReconciler.ensureClusterResourceOverrideSnapshot(ctx, aeCRO, 10)
+			err = recoveryReconciler.ensureClusterResourceOverrideSnapshot(ctx, recoveryCRO, 10)
 			Expect(err).Should(HaveOccurred(), "mismatched hash should not silently succeed")
 			Expect(errors.Is(err, controller.ErrExpectedBehavior)).Should(BeTrue(),
 				"error should wrap ErrExpectedBehavior so retry runs without stack-trace floods, got %v", err)
@@ -409,16 +409,16 @@ var _ = Describe("Test ClusterResourceOverride common logic", func() {
 			// controller lists snapshots and inspects the highest-index one (this snapshot), the
 			// hash check at the top of ensureClusterResourceOverrideSnapshot will short-circuit:
 			// no new snapshot is created and ensureSnapshotLatest + cleanupStaleLatestSiblings run.
-			intendedHash, err := resource.HashOf(aeCRO.Spec)
+			intendedHash, err := resource.HashOf(recoveryCRO.Spec)
 			Expect(err).Should(Succeed())
-			snapshot0 := getClusterResourceOverrideSnapshot(aeCROName, 0)
+			snapshot0 := getClusterResourceOverrideSnapshot(recoveryCROName, 0)
 			snapshot0.Spec.OverrideHash = []byte(intendedHash)
-			snapshot0.Spec.OverrideSpec = aeCRO.Spec
+			snapshot0.Spec.OverrideSpec = recoveryCRO.Spec
 			// ensureSnapshotLatest should flip this back to true on the hash-match path.
 			snapshot0.Labels[placementv1beta1.IsLatestSnapshotLabel] = strconv.FormatBool(false)
 			Expect(k8sClient.Create(ctx, snapshot0)).Should(Succeed())
 
-			Expect(aeReconciler.ensureClusterResourceOverrideSnapshot(ctx, aeCRO, 10)).Should(Succeed())
+			Expect(recoveryReconciler.ensureClusterResourceOverrideSnapshot(ctx, recoveryCRO, 10)).Should(Succeed())
 
 			By("Verifying ensureSnapshotLatest flipped snapshot 0 back to latest=true")
 			final0 := &placementv1beta1.ClusterResourceOverrideSnapshot{}
@@ -426,7 +426,7 @@ var _ = Describe("Test ClusterResourceOverride common logic", func() {
 			Expect(final0.Labels[placementv1beta1.IsLatestSnapshotLabel]).Should(Equal("true"))
 
 			By("Verifying no new snapshot at index 1 was created")
-			snapshot1 := getClusterResourceOverrideSnapshot(aeCROName, 1)
+			snapshot1 := getClusterResourceOverrideSnapshot(recoveryCROName, 1)
 			Expect(apierrors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{Name: snapshot1.Name}, snapshot1))).Should(BeTrue(),
 				"hash-match path must not create a new snapshot")
 		})
@@ -650,46 +650,46 @@ var _ = Describe("Test ResourceOverride common logic", func() {
 	})
 
 	Context("Test ensureResourceOverrideSnapshot AlreadyExists recovery", func() {
-		var aeReconciler *ResourceReconciler
-		var aeROName string
-		var aeRO *placementv1beta1.ResourceOverride
+		var recoveryReconciler *ResourceReconciler
+		var recoveryROName string
+		var recoveryRO *placementv1beta1.ResourceOverride
 
 		BeforeEach(func() {
 			// Use a dedicated RO so this Context's snapshots don't collide with the parent
 			// BeforeEach's snapshots (testROName at indices 0..totalSnapshots-1).
-			aeROName = fmt.Sprintf("test-ro-already-exists-%s", utils.RandStr())
-			aeRO = getResourceOverride(aeROName, namespaceName)
+			recoveryROName = fmt.Sprintf("test-ro-already-exists-%s", utils.RandStr())
+			recoveryRO = getResourceOverride(recoveryROName, namespaceName)
 			// Snapshot Create adds an OwnerReference whose UID must be non-empty for API-server
 			// validation; we don't apply the RO to the cluster (would trigger the real reconcile
 			// loop), so we synthesize a UID.
-			aeRO.UID = "fake-uid-for-owner-ref"
-			aeReconciler = &ResourceReconciler{Reconciler: commonReconciler}
+			recoveryRO.UID = "fake-uid-for-owner-ref"
+			recoveryReconciler = &ResourceReconciler{Reconciler: commonReconciler}
 		})
 
 		AfterEach(func() {
 			for i := 0; i < 2; i++ {
-				snap := getResourceOverrideSnapshot(aeROName, namespaceName, i)
+				snap := getResourceOverrideSnapshot(recoveryROName, namespaceName, i)
 				Expect(k8sClient.Delete(ctx, snap)).Should(SatisfyAny(Succeed(), &utils.NotFoundMatcher{}))
 			}
 		})
 
 		It("Should treat AlreadyExists with matching hash as success and demote the previous snapshot", func() {
-			snapshot0 := getResourceOverrideSnapshot(aeROName, namespaceName, 0)
+			snapshot0 := getResourceOverrideSnapshot(recoveryROName, namespaceName, 0)
 			snapshot0.Spec.OverrideHash = []byte("old-hash")
 			Expect(k8sClient.Create(ctx, snapshot0)).Should(Succeed())
 
 			// Pre-create snapshot 1 invisibly: stripping OverrideTrackingLabel hides it from
 			// listSortedOverrideSnapshots so the controller computes newIndex=1 and Create races
 			// into AlreadyExists. See the CRO test for the etcd-restore production rationale.
-			intendedHash, err := resource.HashOf(aeRO.Spec)
+			intendedHash, err := resource.HashOf(recoveryRO.Spec)
 			Expect(err).Should(Succeed())
-			invisibleSnapshot1 := getResourceOverrideSnapshot(aeROName, namespaceName, 1)
+			invisibleSnapshot1 := getResourceOverrideSnapshot(recoveryROName, namespaceName, 1)
 			delete(invisibleSnapshot1.Labels, placementv1beta1.OverrideTrackingLabel)
 			invisibleSnapshot1.Spec.OverrideHash = []byte(intendedHash)
-			invisibleSnapshot1.Spec.OverrideSpec = aeRO.Spec
+			invisibleSnapshot1.Spec.OverrideSpec = recoveryRO.Spec
 			Expect(k8sClient.Create(ctx, invisibleSnapshot1)).Should(Succeed())
 
-			Expect(aeReconciler.ensureResourceOverrideSnapshot(ctx, aeRO, 10)).Should(Succeed(),
+			Expect(recoveryReconciler.ensureResourceOverrideSnapshot(ctx, recoveryRO, 10)).Should(Succeed(),
 				"AlreadyExists with matching hash should be treated as success")
 
 			By("Verifying snapshot 0 was demoted to latest=false")
@@ -700,16 +700,16 @@ var _ = Describe("Test ResourceOverride common logic", func() {
 
 		It("Should delete the mismatched snapshot, return ExpectedBehaviorError, and emit a Warning event", func() {
 			fakeRecorder := record.NewFakeRecorder(10)
-			aeReconciler.recorder = fakeRecorder
+			recoveryReconciler.recorder = fakeRecorder
 
-			snapshot0 := getResourceOverrideSnapshot(aeROName, namespaceName, 0)
+			snapshot0 := getResourceOverrideSnapshot(recoveryROName, namespaceName, 0)
 			snapshot0.Spec.OverrideHash = []byte("old-hash")
 			Expect(k8sClient.Create(ctx, snapshot0)).Should(Succeed())
 
 			// Pre-create snapshot 1 invisibly with a divergent spec — the controller must
 			// recompute the hash from the spec (not trust the stored OverrideHash field) and
 			// then delete the snapshot to drive observed → desired state.
-			invisibleSnapshot1 := getResourceOverrideSnapshot(aeROName, namespaceName, 1)
+			invisibleSnapshot1 := getResourceOverrideSnapshot(recoveryROName, namespaceName, 1)
 			delete(invisibleSnapshot1.Labels, placementv1beta1.OverrideTrackingLabel)
 			divergentSpec := getResourceOverrideSpec()
 			divergentSpec.Policy = &placementv1beta1.OverridePolicy{
@@ -727,7 +727,7 @@ var _ = Describe("Test ResourceOverride common logic", func() {
 			invisibleSnapshot1.Spec.OverrideHash = []byte(divergentHash)
 			Expect(k8sClient.Create(ctx, invisibleSnapshot1)).Should(Succeed())
 
-			err = aeReconciler.ensureResourceOverrideSnapshot(ctx, aeRO, 10)
+			err = recoveryReconciler.ensureResourceOverrideSnapshot(ctx, recoveryRO, 10)
 			Expect(err).Should(HaveOccurred(), "mismatched hash should not silently succeed")
 			Expect(errors.Is(err, controller.ErrExpectedBehavior)).Should(BeTrue(),
 				"error should wrap ErrExpectedBehavior, got %v", err)
@@ -756,15 +756,15 @@ var _ = Describe("Test ResourceOverride common logic", func() {
 
 		It("Should take the hash-match path and audit siblings when the latest snapshot's hash equals the RO spec", func() {
 			// Mirror of the CRO hash-match test for the namespaced controller.
-			intendedHash, err := resource.HashOf(aeRO.Spec)
+			intendedHash, err := resource.HashOf(recoveryRO.Spec)
 			Expect(err).Should(Succeed())
-			snapshot0 := getResourceOverrideSnapshot(aeROName, namespaceName, 0)
+			snapshot0 := getResourceOverrideSnapshot(recoveryROName, namespaceName, 0)
 			snapshot0.Spec.OverrideHash = []byte(intendedHash)
-			snapshot0.Spec.OverrideSpec = aeRO.Spec
+			snapshot0.Spec.OverrideSpec = recoveryRO.Spec
 			snapshot0.Labels[placementv1beta1.IsLatestSnapshotLabel] = strconv.FormatBool(false)
 			Expect(k8sClient.Create(ctx, snapshot0)).Should(Succeed())
 
-			Expect(aeReconciler.ensureResourceOverrideSnapshot(ctx, aeRO, 10)).Should(Succeed())
+			Expect(recoveryReconciler.ensureResourceOverrideSnapshot(ctx, recoveryRO, 10)).Should(Succeed())
 
 			By("Verifying ensureSnapshotLatest flipped snapshot 0 back to latest=true")
 			final0 := &placementv1beta1.ResourceOverrideSnapshot{}
@@ -772,7 +772,7 @@ var _ = Describe("Test ResourceOverride common logic", func() {
 			Expect(final0.Labels[placementv1beta1.IsLatestSnapshotLabel]).Should(Equal("true"))
 
 			By("Verifying no new snapshot at index 1 was created")
-			snapshot1 := getResourceOverrideSnapshot(aeROName, namespaceName, 1)
+			snapshot1 := getResourceOverrideSnapshot(recoveryROName, namespaceName, 1)
 			Expect(apierrors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{Name: snapshot1.Name, Namespace: snapshot1.Namespace}, snapshot1))).Should(BeTrue(),
 				"hash-match path must not create a new snapshot")
 		})

--- a/pkg/controllers/overrider/resource_controller.go
+++ b/pkg/controllers/overrider/resource_controller.go
@@ -23,9 +23,11 @@ import (
 	"strconv"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -42,7 +44,7 @@ type ResourceReconciler struct {
 	Reconciler
 }
 
-// Reconcile triggers a single  reconcile round when scheduling policy has changed.
+// Reconcile triggers a single reconcile round when the override has changed.
 func (r *ResourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	name := req.NamespacedName
 	resourceOverride := placementv1beta1.ResourceOverride{}
@@ -82,54 +84,49 @@ func (r *ResourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 }
 
 func (r *ResourceReconciler) ensureResourceOverrideSnapshot(ctx context.Context, ro *placementv1beta1.ResourceOverride, revisionHistoryLimit int) error {
-	croKObj := klog.KObj(ro)
+	roKObj := klog.KObj(ro)
 	overridePolicy := ro.Spec
 	overrideSpecHash, err := resource.HashOf(overridePolicy)
 	if err != nil {
-		klog.ErrorS(err, "Failed to generate policy hash of ResourceOverride", "ResourceOverride", croKObj)
+		klog.ErrorS(err, "Failed to generate policy hash of ResourceOverride", "resourceOverride", roKObj)
 		return controller.NewUnexpectedBehaviorError(err)
 	}
-	// we need to list the snapshots anyway since we need to remove the extra snapshots if there are too many of them.
+	// We always list the snapshots so we can prune any that exceed the revision history limit.
 	snapshotList, err := r.listSortedOverrideSnapshots(ctx, ro)
 	if err != nil {
 		return err
 	}
-	// delete redundant snapshot revisions before creating a new snapshot to guarantee that the number of snapshots won't exceed the limit.
 	if err = r.removeExtraSnapshot(ctx, snapshotList, revisionHistoryLimit); err != nil {
 		return err
 	}
 
 	latestSnapshotIndex := -1
+	var latestSnapshot *placementv1beta1.ResourceOverrideSnapshot
 	if len(snapshotList.Items) != 0 {
-		// convert the last unstructured snapshot to the typed object
-		latestSnapshot := &placementv1beta1.ResourceOverrideSnapshot{}
+		// Convert the last (highest-index) unstructured snapshot to the typed object.
+		latestSnapshot = &placementv1beta1.ResourceOverrideSnapshot{}
 		if err = runtime.DefaultUnstructuredConverter.FromUnstructured(snapshotList.Items[len(snapshotList.Items)-1].Object, latestSnapshot); err != nil {
-			klog.ErrorS(err, "Invalid overrideSnapshot", "ResourceOverride", croKObj, "overrideSnapshot", klog.KObj(&snapshotList.Items[len(snapshotList.Items)-1]))
+			klog.ErrorS(err, "Invalid overrideSnapshot", "resourceOverride", roKObj, "overrideSnapshot", klog.KObj(&snapshotList.Items[len(snapshotList.Items)-1]))
 			return controller.NewUnexpectedBehaviorError(err)
 		}
 		if string(latestSnapshot.Spec.OverrideHash) == overrideSpecHash {
-			// the content has not changed, so we don't need to create a new snapshot.
-			return r.ensureSnapshotLatest(ctx, latestSnapshot)
-		}
-		// mark the last policy snapshot as inactive if it is different from what we have now.
-		if latestSnapshot.Labels[placementv1beta1.IsLatestSnapshotLabel] == strconv.FormatBool(true) {
-			// set the latest label to false first to make sure there is only one or none active policy snapshot
-			latestSnapshot.Labels[placementv1beta1.IsLatestSnapshotLabel] = strconv.FormatBool(false)
-			if err := r.Client.Update(ctx, latestSnapshot); err != nil {
-				klog.ErrorS(err, "Failed to set the isLatestSnapshot label to false", "ResourceOverride", croKObj, "overrideSnapshot", klog.KObj(latestSnapshot))
-				return controller.NewUpdateIgnoreConflictError(err)
+			// The content has not changed; no new snapshot is needed. Ensure the highest-index
+			// snapshot is marked latest, then audit siblings to clean up any duplicate latest=true
+			// left by a prior partial run.
+			if err := r.ensureSnapshotLatest(ctx, latestSnapshot); err != nil {
+				return err
 			}
-			klog.V(2).InfoS("Marked the latest overrideSnapshot as inactive", "ResourceOverride", croKObj, "overrideSnapshot", klog.KObj(latestSnapshot))
+			return r.cleanupStaleLatestSiblings(ctx, snapshotList)
 		}
-		// we need to figure out the last snapshot index.
 		latestSnapshotIndex, err = labels.ExtractIndex(latestSnapshot, placementv1beta1.OverrideIndexLabel)
 		if err != nil {
-			klog.ErrorS(err, "Failed to parse the override index label", "ResourceOverride", croKObj, "overrideSnapshot", klog.KObj(latestSnapshot))
+			klog.ErrorS(err, "Failed to parse the override index label", "resourceOverride", roKObj, "overrideSnapshot", klog.KObj(latestSnapshot))
 			return controller.NewUnexpectedBehaviorError(err)
 		}
 	}
 
-	// Need to create new snapshot when 1) there is no snapshots or 2) the latest snapshot hash != current one.
+	// Create the new snapshot (latest=true) BEFORE flipping the old one to false. See the CRO
+	// controller for the rationale; this avoids a zero-latest window across crashes.
 	latestSnapshotIndex++
 	newSnapshot := &placementv1beta1.ResourceOverrideSnapshot{
 		ObjectMeta: metav1.ObjectMeta{
@@ -150,15 +147,58 @@ func (r *ResourceReconciler) ensureResourceOverrideSnapshot(ctx context.Context,
 		},
 	}
 	if err = r.Client.Create(ctx, newSnapshot); err != nil {
-		klog.ErrorS(err, "Failed to create new overrideSnapshot", "newOverrideSnapshot", klog.KObj(newSnapshot))
-		return controller.NewAPIServerError(false, err)
+		if !errors.IsAlreadyExists(err) {
+			klog.ErrorS(err, "Failed to create new overrideSnapshot", "newOverrideSnapshot", klog.KObj(newSnapshot))
+			return controller.NewAPIServerError(false, err)
+		}
+		// AlreadyExists here normally means a prior reconcile succeeded the Create but failed to
+		// flip the old snapshot. Verify the existing object's hash before proceeding so we don't
+		// silently promote stale content (etcd restore from backup, manual edit, future hash bug).
+		// Read through the uncached client: the cached read can lag the just-Created object.
+		existing := &placementv1beta1.ResourceOverrideSnapshot{}
+		if getErr := r.UncachedReader.Get(ctx, types.NamespacedName{Name: newSnapshot.Name, Namespace: newSnapshot.Namespace}, existing); getErr != nil {
+			klog.ErrorS(getErr, "Failed to get existing overrideSnapshot for hash verification", "resourceOverride", roKObj, "newOverrideSnapshot", klog.KObj(newSnapshot))
+			return controller.NewAPIServerError(false, getErr)
+		}
+		if string(existing.Spec.OverrideHash) != overrideSpecHash {
+			mismatchErr := fmt.Errorf("existing overrideSnapshot %s/%s has hash %q, want %q", existing.Namespace, existing.Name, string(existing.Spec.OverrideHash), overrideSpecHash)
+			klog.ErrorS(mismatchErr, "Existing overrideSnapshot has different content than expected; will requeue and retry", "resourceOverride", roKObj)
+			// Surface to the operator via an Event on the parent RO; see CRO controller for rationale.
+			if r.recorder != nil {
+				r.recorder.Eventf(ro, corev1.EventTypeWarning, "OverrideSnapshotHashMismatch",
+					"existing snapshot %s/%s has a different hash than the current spec; retrying. If this persists, the snapshot needs operator inspection (etcd restore from backup, manual edit, or hash-function change).", newSnapshot.Namespace, newSnapshot.Name)
+			}
+			// Treat as expected-behavior so retries don't carry stack traces; see CRO controller
+			// for the rationale.
+			return controller.NewExpectedBehaviorError(mismatchErr)
+		}
+		klog.V(2).InfoS("Snapshot already exists with matching content; recovering from prior partial reconcile", "resourceOverride", roKObj, "newOverrideSnapshot", klog.KObj(newSnapshot))
+	} else {
+		klog.V(2).InfoS("Created new overrideSnapshot", "resourceOverride", roKObj, "newOverrideSnapshot", klog.KObj(newSnapshot))
 	}
-	klog.V(2).InfoS("Created a new overrideSnapshot", "ResourceOverride", croKObj, "newOverrideSnapshot", klog.KObj(newSnapshot))
-	return nil
+
+	// Demote the previous latest snapshot. Tolerate IsNotFound so we still reach the sibling audit.
+	if latestSnapshot != nil && latestSnapshot.Labels[placementv1beta1.IsLatestSnapshotLabel] == strconv.FormatBool(true) {
+		latestSnapshot.Labels[placementv1beta1.IsLatestSnapshotLabel] = strconv.FormatBool(false)
+		if err := r.Client.Update(ctx, latestSnapshot); err != nil {
+			if errors.IsNotFound(err) {
+				klog.V(2).InfoS("Old overrideSnapshot already gone; skipping demotion", "resourceOverride", roKObj, "overrideSnapshot", klog.KObj(latestSnapshot))
+			} else {
+				klog.ErrorS(err, "Failed to set the isLatestSnapshot label to false on previous snapshot", "resourceOverride", roKObj, "overrideSnapshot", klog.KObj(latestSnapshot))
+				return controller.NewUpdateIgnoreConflictError(err)
+			}
+		} else {
+			klog.V(2).InfoS("Marked previous overrideSnapshot as inactive", "resourceOverride", roKObj, "overrideSnapshot", klog.KObj(latestSnapshot))
+		}
+	}
+
+	// Audit older siblings for stale latest=true left by prior crashes.
+	return r.cleanupStaleLatestSiblings(ctx, snapshotList)
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ResourceReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	r.recorder = mgr.GetEventRecorderFor("resourceoverride-controller")
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("resourceoverride-controller").
 		For(&placementv1beta1.ResourceOverride{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).

--- a/pkg/controllers/overrider/resource_controller.go
+++ b/pkg/controllers/overrider/resource_controller.go
@@ -91,7 +91,7 @@ func (r *ResourceReconciler) ensureResourceOverrideSnapshot(ctx context.Context,
 		klog.ErrorS(err, "Failed to generate policy hash of ResourceOverride", "resourceOverride", roKObj)
 		return controller.NewUnexpectedBehaviorError(err)
 	}
-	// We always list the snapshots so we can prune any that exceed the revision history limit.
+	// List snapshots so we can prune any beyond the revision history limit.
 	snapshotList, err := r.listSortedOverrideSnapshots(ctx, ro)
 	if err != nil {
 		return err
@@ -103,16 +103,13 @@ func (r *ResourceReconciler) ensureResourceOverrideSnapshot(ctx context.Context,
 	latestSnapshotIndex := -1
 	var latestSnapshot *placementv1beta1.ResourceOverrideSnapshot
 	if len(snapshotList.Items) != 0 {
-		// Convert the last (highest-index) unstructured snapshot to the typed object.
 		latestSnapshot = &placementv1beta1.ResourceOverrideSnapshot{}
 		if err = runtime.DefaultUnstructuredConverter.FromUnstructured(snapshotList.Items[len(snapshotList.Items)-1].Object, latestSnapshot); err != nil {
 			klog.ErrorS(err, "Invalid overrideSnapshot", "resourceOverride", roKObj, "overrideSnapshot", klog.KObj(&snapshotList.Items[len(snapshotList.Items)-1]))
 			return controller.NewUnexpectedBehaviorError(err)
 		}
 		if string(latestSnapshot.Spec.OverrideHash) == overrideSpecHash {
-			// The content has not changed; no new snapshot is needed. Ensure the highest-index
-			// snapshot is marked latest, then audit siblings to clean up any duplicate latest=true
-			// left by a prior partial run.
+			// Hash matches: re-mark this snapshot latest (idempotent) and audit siblings.
 			if err := r.ensureSnapshotLatest(ctx, latestSnapshot); err != nil {
 				return err
 			}
@@ -125,8 +122,7 @@ func (r *ResourceReconciler) ensureResourceOverrideSnapshot(ctx context.Context,
 		}
 	}
 
-	// Create the new snapshot (latest=true) BEFORE flipping the old one to false. See the CRO
-	// controller for the rationale; this avoids a zero-latest window across crashes.
+	// Create-then-demote; see the CRO controller for the rationale.
 	latestSnapshotIndex++
 	newSnapshot := &placementv1beta1.ResourceOverrideSnapshot{
 		ObjectMeta: metav1.ObjectMeta{
@@ -151,25 +147,23 @@ func (r *ResourceReconciler) ensureResourceOverrideSnapshot(ctx context.Context,
 			klog.ErrorS(err, "Failed to create new overrideSnapshot", "newOverrideSnapshot", klog.KObj(newSnapshot))
 			return controller.NewAPIServerError(false, err)
 		}
-		// AlreadyExists here normally means a prior reconcile succeeded the Create but failed to
-		// flip the old snapshot. Verify the existing object's hash before proceeding so we don't
-		// silently promote stale content (etcd restore from backup, manual edit, future hash bug).
-		// Read through the uncached client: the cached read can lag the just-Created object.
+		// AlreadyExists path; see the CRO controller for the rationale.
 		existing := &placementv1beta1.ResourceOverrideSnapshot{}
 		if getErr := r.UncachedReader.Get(ctx, types.NamespacedName{Name: newSnapshot.Name, Namespace: newSnapshot.Namespace}, existing); getErr != nil {
 			klog.ErrorS(getErr, "Failed to get existing overrideSnapshot for hash verification", "resourceOverride", roKObj, "newOverrideSnapshot", klog.KObj(newSnapshot))
 			return controller.NewAPIServerError(false, getErr)
 		}
 		if string(existing.Spec.OverrideHash) != overrideSpecHash {
-			mismatchErr := fmt.Errorf("existing overrideSnapshot %s/%s has hash %q, want %q", existing.Namespace, existing.Name, string(existing.Spec.OverrideHash), overrideSpecHash)
-			klog.ErrorS(mismatchErr, "Existing overrideSnapshot has different content than expected; will requeue and retry", "resourceOverride", roKObj)
-			// Surface to the operator via an Event on the parent RO; see CRO controller for rationale.
+			mismatchErr := fmt.Errorf("existing overrideSnapshot %s/%s has stored hash %q, want %q", existing.Namespace, existing.Name, string(existing.Spec.OverrideHash), overrideSpecHash)
+			klog.ErrorS(mismatchErr, "Existing overrideSnapshot has different content than the current spec; deleting it so the next reconcile can recreate with correct content", "resourceOverride", roKObj)
 			if r.recorder != nil {
 				r.recorder.Eventf(ro, corev1.EventTypeWarning, "OverrideSnapshotHashMismatch",
-					"existing snapshot %s/%s has a different hash than the current spec; retrying. If this persists, the snapshot needs operator inspection (etcd restore from backup, manual edit, or hash-function change).", newSnapshot.Namespace, newSnapshot.Name)
+					"existing snapshot %s/%s has different content than the current spec; deleting it for the next reconcile to recreate. If this persists, investigate the snapshot for manual edits or a hash-function change between controller versions.", newSnapshot.Namespace, newSnapshot.Name)
 			}
-			// Treat as expected-behavior so retries don't carry stack traces; see CRO controller
-			// for the rationale.
+			if delErr := r.Client.Delete(ctx, existing); delErr != nil && !errors.IsNotFound(delErr) {
+				klog.ErrorS(delErr, "Failed to delete mismatched overrideSnapshot", "resourceOverride", roKObj, "overrideSnapshot", klog.KObj(existing))
+				return controller.NewAPIServerError(false, delErr)
+			}
 			return controller.NewExpectedBehaviorError(mismatchErr)
 		}
 		klog.V(2).InfoS("Snapshot already exists with matching content; recovering from prior partial reconcile", "resourceOverride", roKObj, "newOverrideSnapshot", klog.KObj(newSnapshot))

--- a/pkg/controllers/overrider/resource_controller.go
+++ b/pkg/controllers/overrider/resource_controller.go
@@ -156,10 +156,8 @@ func (r *ResourceReconciler) ensureResourceOverrideSnapshot(ctx context.Context,
 		if string(existing.Spec.OverrideHash) != overrideSpecHash {
 			mismatchErr := fmt.Errorf("existing overrideSnapshot %s/%s has stored hash %q, want %q", existing.Namespace, existing.Name, string(existing.Spec.OverrideHash), overrideSpecHash)
 			klog.ErrorS(mismatchErr, "Existing overrideSnapshot has different content than the current spec; deleting it so the next reconcile can recreate with correct content", "resourceOverride", roKObj)
-			if r.recorder != nil {
-				r.recorder.Eventf(ro, corev1.EventTypeWarning, "OverrideSnapshotHashMismatch",
-					"existing snapshot %s/%s has different content than the current spec; deleting it for the next reconcile to recreate. If this persists, investigate the snapshot for manual edits or a hash-function change between controller versions.", newSnapshot.Namespace, newSnapshot.Name)
-			}
+			r.recorder.Eventf(ro, corev1.EventTypeWarning, "OverrideSnapshotHashMismatch",
+				"existing snapshot %s/%s has different content than the current spec; deleting it for the next reconcile to recreate. If this persists, investigate the snapshot for manual edits or a hash-function change between controller versions.", newSnapshot.Namespace, newSnapshot.Name)
 			if delErr := r.Client.Delete(ctx, existing); delErr != nil && !errors.IsNotFound(delErr) {
 				klog.ErrorS(delErr, "Failed to delete mismatched overrideSnapshot", "resourceOverride", roKObj, "overrideSnapshot", klog.KObj(existing))
 				return controller.NewAPIServerError(false, delErr)

--- a/pkg/controllers/overrider/resource_controller_test.go
+++ b/pkg/controllers/overrider/resource_controller_test.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2025 The KubeFleet Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package overrider
+
+import (
+	"context"
+	stderrors "errors"
+	"fmt"
+	"strconv"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	placementv1beta1 "github.com/kubefleet-dev/kubefleet/apis/placement/v1beta1"
+	"github.com/kubefleet-dev/kubefleet/pkg/utils/controller"
+)
+
+// TestEnsureResourceOverrideSnapshotAlreadyExistsDelete is the namespaced mirror of the CRO
+// AlreadyExists Delete-branch coverage; see clusterresource_controller_test.go for the rationale.
+func TestEnsureResourceOverrideSnapshotAlreadyExistsDelete(t *testing.T) {
+	if err := placementv1beta1.AddToScheme(scheme.Scheme); err != nil {
+		t.Fatalf("scheme: %v", err)
+	}
+	tests := []struct {
+		name         string
+		deleteErr    error
+		wantSentinel error
+	}{
+		{
+			name:         "delete succeeds returns expected-behavior error",
+			wantSentinel: controller.ErrExpectedBehavior,
+		},
+		{
+			name: "delete returning IsNotFound is swallowed and still returns expected-behavior error",
+			deleteErr: apierrors.NewNotFound(
+				schema.GroupResource{Group: placementv1beta1.GroupVersion.Group, Resource: "resourceoverridesnapshots"},
+				"already-gone"),
+			wantSentinel: controller.ErrExpectedBehavior,
+		},
+		{
+			name:         "delete returning non-NotFound error returns API server error",
+			deleteErr:    apierrors.NewInternalError(fmt.Errorf("simulated transient")),
+			wantSentinel: controller.ErrAPIServerError,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ns := "ae-ns"
+			ro := &placementv1beta1.ResourceOverride{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: placementv1beta1.GroupVersion.String(),
+					Kind:       placementv1beta1.ResourceOverrideKind,
+				},
+				ObjectMeta: metav1.ObjectMeta{Name: "ae-ro", Namespace: ns, UID: "fake-uid"},
+				Spec: placementv1beta1.ResourceOverrideSpec{
+					ResourceSelectors: []placementv1beta1.ResourceSelector{
+						{Group: "", Version: "v1", Kind: "ConfigMap", Name: "cm"},
+					},
+				},
+			}
+
+			snap0 := &placementv1beta1.ResourceOverrideSnapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf(placementv1beta1.OverrideSnapshotNameFmt, ro.Name, 0),
+					Namespace: ns,
+					Labels: map[string]string{
+						placementv1beta1.OverrideTrackingLabel: ro.Name,
+						placementv1beta1.IsLatestSnapshotLabel: strconv.FormatBool(true),
+						placementv1beta1.OverrideIndexLabel:    "0",
+					},
+				},
+				Spec: placementv1beta1.ResourceOverrideSnapshotSpec{
+					OverrideSpec: ro.Spec,
+					OverrideHash: []byte("stale-hash"),
+				},
+			}
+			snap1 := &placementv1beta1.ResourceOverrideSnapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf(placementv1beta1.OverrideSnapshotNameFmt, ro.Name, 1),
+					Namespace: ns,
+					Labels: map[string]string{
+						placementv1beta1.IsLatestSnapshotLabel: strconv.FormatBool(true),
+						placementv1beta1.OverrideIndexLabel:    "1",
+					},
+				},
+				Spec: placementv1beta1.ResourceOverrideSnapshotSpec{
+					OverrideHash: []byte("different-hash"),
+				},
+			}
+
+			interceptors := interceptor.Funcs{
+				Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+					if _, ok := obj.(*placementv1beta1.ResourceOverrideSnapshot); ok && obj.GetName() == snap1.Name {
+						if tc.deleteErr != nil {
+							return tc.deleteErr
+						}
+					}
+					return c.Delete(ctx, obj, opts...)
+				},
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				WithObjects(snap0, snap1).
+				WithInterceptorFuncs(interceptors).
+				Build()
+
+			r := &ResourceReconciler{
+				Reconciler: Reconciler{
+					Client:         fakeClient,
+					UncachedReader: fakeClient,
+					recorder:       record.NewFakeRecorder(10),
+				},
+			}
+
+			err := r.ensureResourceOverrideSnapshot(context.Background(), ro, 10)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !stderrors.Is(err, tc.wantSentinel) {
+				t.Errorf("error = %v, want sentinel %v", err, tc.wantSentinel)
+			}
+		})
+	}
+}

--- a/pkg/controllers/overrider/resource_controller_test.go
+++ b/pkg/controllers/overrider/resource_controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KubeFleet Authors.
+Copyright 2026 The KubeFleet Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -25,8 +25,8 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -39,29 +39,34 @@ import (
 // TestEnsureResourceOverrideSnapshotAlreadyExistsDelete is the namespaced mirror of the CRO
 // AlreadyExists Delete-branch coverage; see clusterresource_controller_test.go for the rationale.
 func TestEnsureResourceOverrideSnapshotAlreadyExistsDelete(t *testing.T) {
-	if err := placementv1beta1.AddToScheme(scheme.Scheme); err != nil {
+	s := runtime.NewScheme()
+	if err := placementv1beta1.AddToScheme(s); err != nil {
 		t.Fatalf("scheme: %v", err)
 	}
 	tests := []struct {
-		name         string
-		deleteErr    error
-		wantSentinel error
+		name           string
+		deleteErr      error
+		wantSentinel   error
+		wantSnapDelete bool // whether the controller is expected to attempt a Delete on the mismatched snapshot
 	}{
 		{
-			name:         "delete succeeds returns expected-behavior error",
-			wantSentinel: controller.ErrExpectedBehavior,
+			name:           "delete succeeds returns expected-behavior error",
+			wantSentinel:   controller.ErrExpectedBehavior,
+			wantSnapDelete: true,
 		},
 		{
 			name: "delete returning IsNotFound is swallowed and still returns expected-behavior error",
 			deleteErr: apierrors.NewNotFound(
 				schema.GroupResource{Group: placementv1beta1.GroupVersion.Group, Resource: "resourceoverridesnapshots"},
 				"already-gone"),
-			wantSentinel: controller.ErrExpectedBehavior,
+			wantSentinel:   controller.ErrExpectedBehavior,
+			wantSnapDelete: true,
 		},
 		{
-			name:         "delete returning non-NotFound error returns API server error",
-			deleteErr:    apierrors.NewInternalError(fmt.Errorf("simulated transient")),
-			wantSentinel: controller.ErrAPIServerError,
+			name:           "delete returning non-NotFound error returns API server error",
+			deleteErr:      apierrors.NewInternalError(fmt.Errorf("simulated transient")),
+			wantSentinel:   controller.ErrAPIServerError,
+			wantSnapDelete: true,
 		},
 	}
 
@@ -110,9 +115,11 @@ func TestEnsureResourceOverrideSnapshotAlreadyExistsDelete(t *testing.T) {
 				},
 			}
 
+			deleteCalls := 0
 			interceptors := interceptor.Funcs{
 				Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
 					if _, ok := obj.(*placementv1beta1.ResourceOverrideSnapshot); ok && obj.GetName() == snap1.Name {
+						deleteCalls++
 						if tc.deleteErr != nil {
 							return tc.deleteErr
 						}
@@ -122,7 +129,7 @@ func TestEnsureResourceOverrideSnapshotAlreadyExistsDelete(t *testing.T) {
 			}
 
 			fakeClient := fake.NewClientBuilder().
-				WithScheme(scheme.Scheme).
+				WithScheme(s).
 				WithObjects(snap0, snap1).
 				WithInterceptorFuncs(interceptors).
 				Build()
@@ -141,6 +148,9 @@ func TestEnsureResourceOverrideSnapshotAlreadyExistsDelete(t *testing.T) {
 			}
 			if !stderrors.Is(err, tc.wantSentinel) {
 				t.Errorf("error = %v, want sentinel %v", err, tc.wantSentinel)
+			}
+			if tc.wantSnapDelete && deleteCalls == 0 {
+				t.Errorf("expected the controller to attempt deletion of the mismatched snapshot, but it didn't")
 			}
 		})
 	}

--- a/pkg/controllers/overrider/resource_controller_test.go
+++ b/pkg/controllers/overrider/resource_controller_test.go
@@ -39,6 +39,7 @@ import (
 // TestEnsureResourceOverrideSnapshotAlreadyExistsDelete is the namespaced mirror of the CRO
 // AlreadyExists Delete-branch coverage; see clusterresource_controller_test.go for the rationale.
 func TestEnsureResourceOverrideSnapshotAlreadyExistsDelete(t *testing.T) {
+	t.Parallel()
 	s := runtime.NewScheme()
 	if err := placementv1beta1.AddToScheme(s); err != nil {
 		t.Fatalf("scheme: %v", err)
@@ -72,6 +73,7 @@ func TestEnsureResourceOverrideSnapshotAlreadyExistsDelete(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			ns := "ae-ns"
 			ro := &placementv1beta1.ResourceOverride{
 				TypeMeta: metav1.TypeMeta{

--- a/pkg/controllers/overrider/suite_test.go
+++ b/pkg/controllers/overrider/suite_test.go
@@ -97,7 +97,8 @@ var _ = BeforeSuite(func() {
 	Expect(err).Should(Succeed())
 	// we want to test this controller alone
 	commonReconciler = Reconciler{
-		Client: mgr.GetClient(),
+		Client:         mgr.GetClient(),
+		UncachedReader: mgr.GetAPIReader(),
 	}
 	// setup the clusterResourceReconciler
 	err = (&ClusterResourceReconciler{

--- a/pkg/utils/overrider/overrider.go
+++ b/pkg/utils/overrider/overrider.go
@@ -37,6 +37,7 @@ import (
 	"github.com/kubefleet-dev/kubefleet/pkg/utils"
 	"github.com/kubefleet-dev/kubefleet/pkg/utils/controller"
 	"github.com/kubefleet-dev/kubefleet/pkg/utils/informer"
+	fleetlabels "github.com/kubefleet-dev/kubefleet/pkg/utils/labels"
 )
 
 // FetchAllMatchingOverridesForResourceSnapshot fetches all the matching overrides which are attached to the selected resources.
@@ -66,6 +67,13 @@ func FetchAllMatchingOverridesForResourceSnapshot(
 	if len(croList.Items) == 0 && len(roList.Items) == 0 {
 		return nil, nil, nil // no overrides and nothing to do
 	}
+
+	// Dedup at read time. The override controllers create the new latest=true snapshot before
+	// flipping the previous one to false, so a brief window can leave more than one snapshot per
+	// parent carrying latest=true. We collapse each parent to its highest-OverrideIndexLabel
+	// snapshot, which is always the authoritative latest.
+	croList.Items = dedupLatestSnapshots(croList.Items, croDedupKey)
+	roList.Items = dedupLatestSnapshots(roList.Items, roDedupKey)
 
 	resourceSnapshots, err := controller.FetchAllResourceSnapshotsAlongWithMaster(ctx, c, placementKey, masterResourceSnapshot)
 	if err != nil {
@@ -246,6 +254,80 @@ func isClusterMatched(cluster *clusterv1beta1.MemberCluster, policy *placementv1
 		}
 	}
 	return false, nil
+}
+
+// dedupLatestSnapshots returns at most one snapshot per parent override, choosing the highest
+// OverrideIndexLabel as the winner. The dedup key is supplied by the caller: for cluster-scoped
+// overrides it is the OverrideTrackingLabel alone; for namespace-scoped overrides it must be a
+// (namespace, OverrideTrackingLabel) composite because RO names can collide across namespaces.
+//
+// A snapshot whose tracking label is missing/empty or whose OverrideIndexLabel is unparsable is
+// logged as an error and skipped: this fetch runs in the rollout hot path, so failing the entire
+// fetch over a single corrupt snapshot would block override application for every placement.
+// The error log is loud enough for operators to notice; the affected override loses one update
+// cycle until the snapshot's labels are repaired.
+//
+// PT is *T constrained to client.Object so we can extract metadata and labels without copying.
+func dedupLatestSnapshots[T any, PT interface {
+	*T
+	client.Object
+}](items []T, keyOf func(PT) string) []T {
+	if len(items) <= 1 {
+		return items
+	}
+	winners := make(map[string]int, len(items))
+	winnerIndex := make(map[string]int, len(items))
+	for i := range items {
+		ptr := PT(&items[i])
+		key := keyOf(ptr)
+		if key == "" {
+			klog.ErrorS(fmt.Errorf("snapshot %s is missing %s label", klog.KObj(ptr), placementv1beta1.OverrideTrackingLabel),
+				"Skipping malformed snapshot during dedup; operator action required to repair labels",
+				"snapshot", klog.KObj(ptr))
+			continue
+		}
+		index, err := fleetlabels.ExtractIndex(ptr, placementv1beta1.OverrideIndexLabel)
+		if err != nil {
+			klog.ErrorS(err, "Skipping snapshot with unparsable override index label during dedup; operator action required",
+				"snapshot", klog.KObj(ptr))
+			continue
+		}
+		if _, seen := winners[key]; !seen || index > winnerIndex[key] {
+			winners[key] = i
+			winnerIndex[key] = index
+		}
+	}
+	deduped := make([]T, 0, len(winners))
+	for _, idx := range winners {
+		deduped = append(deduped, items[idx])
+	}
+	// Map iteration order is non-deterministic; sort the result by namespace+name so callers
+	// (and tests) see a stable order. Cluster-scoped snapshots have an empty namespace, which
+	// sorts naturally before namespaced ones.
+	sort.SliceStable(deduped, func(i, j int) bool {
+		ai := PT(&deduped[i])
+		aj := PT(&deduped[j])
+		if ai.GetNamespace() != aj.GetNamespace() {
+			return ai.GetNamespace() < aj.GetNamespace()
+		}
+		return ai.GetName() < aj.GetName()
+	})
+	return deduped
+}
+
+// croDedupKey keys ClusterResourceOverrideSnapshots by OverrideTrackingLabel alone (cluster-scoped).
+func croDedupKey(s *placementv1beta1.ClusterResourceOverrideSnapshot) string {
+	return s.GetLabels()[placementv1beta1.OverrideTrackingLabel]
+}
+
+// roDedupKey keys ResourceOverrideSnapshots by (namespace, OverrideTrackingLabel) so identically
+// named ROs in different namespaces are not collapsed.
+func roDedupKey(s *placementv1beta1.ResourceOverrideSnapshot) string {
+	parent := s.GetLabels()[placementv1beta1.OverrideTrackingLabel]
+	if parent == "" {
+		return ""
+	}
+	return s.Namespace + "/" + parent
 }
 
 // IsClusterMatched checks if the cluster is matched with the override rules.

--- a/pkg/utils/overrider/overrider.go
+++ b/pkg/utils/overrider/overrider.go
@@ -301,9 +301,8 @@ func dedupLatestSnapshots[T any, PT interface {
 	for _, idx := range winners {
 		deduped = append(deduped, items[idx])
 	}
-	// Map iteration order is non-deterministic; sort the result by namespace+name so callers
-	// (and tests) see a stable order. Cluster-scoped snapshots have an empty namespace, which
-	// sorts naturally before namespaced ones.
+	// Map iteration is non-deterministic; sort by (namespace, name) for stable output. All
+	// items in a single call share scope, so the namespace tier is just a defensive tie-breaker.
 	sort.SliceStable(deduped, func(i, j int) bool {
 		ai := PT(&deduped[i])
 		aj := PT(&deduped[j])

--- a/pkg/utils/overrider/overrider_test.go
+++ b/pkg/utils/overrider/overrider_test.go
@@ -42,6 +42,22 @@ var (
 	rpName  = "my-test-rp"
 )
 
+// ensureSnapshotTrackingLabels populates the OverrideTrackingLabel and OverrideIndexLabel on
+// snapshot fixtures that may have only declared the IsLatestSnapshotLabel. In production both
+// controllers always set these labels at Create time; without them, read-time dedup correctly
+// fails fast as malformed input.
+func ensureSnapshotTrackingLabels(meta *metav1.ObjectMeta, parent string, index int) {
+	if meta.Labels == nil {
+		meta.Labels = map[string]string{}
+	}
+	if _, ok := meta.Labels[placementv1beta1.OverrideTrackingLabel]; !ok {
+		meta.Labels[placementv1beta1.OverrideTrackingLabel] = parent
+	}
+	if _, ok := meta.Labels[placementv1beta1.OverrideIndexLabel]; !ok {
+		meta.Labels[placementv1beta1.OverrideIndexLabel] = fmt.Sprintf("%d", index)
+	}
+}
+
 func serviceScheme(t *testing.T) *runtime.Scheme {
 	scheme := runtime.NewScheme()
 	if err := placementv1beta1.AddToScheme(scheme); err != nil {
@@ -1482,6 +1498,149 @@ func TestFetchAllMatchingOverridesForResourceSnapshot(t *testing.T) {
 				},
 			},
 		},
+		{
+			// Exercises read-time dedup. Both CRO snapshots for parent "cro-dup" carry
+			// IsLatestSnapshotLabel=true (the transient state allowed by the create-first ordering
+			// in the override controllers). Both ROs for parent "ro-dup" do too. Dedup must keep
+			// only the highest-OverrideIndexLabel snapshot per parent. The lower-index snapshot
+			// has a stale spec that selects a different resource, so it would NOT match the master
+			// resource snapshot — if dedup leaks it through, wantCRO/wantRO would have two items.
+			name:         "duplicate latest snapshots same parent — highest index wins via dedup",
+			placementKey: crpName,
+			master: &placementv1beta1.ClusterResourceSnapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: fmt.Sprintf(placementv1beta1.ResourceSnapshotNameFmt, crpName, 0),
+					Labels: map[string]string{
+						placementv1beta1.ResourceIndexLabel:     "0",
+						placementv1beta1.PlacementTrackingLabel: crpName,
+					},
+					Annotations: map[string]string{
+						placementv1beta1.ResourceGroupHashAnnotation:         "abc",
+						placementv1beta1.NumberOfResourceSnapshotsAnnotation: "1",
+					},
+				},
+				Spec: placementv1beta1.ResourceSnapshotSpec{
+					SelectedResources: []placementv1beta1.ResourceContent{
+						*resource.ServiceResourceContentForTest(t),
+					},
+				},
+			},
+			croList: []placementv1beta1.ClusterResourceOverrideSnapshot{
+				{
+					// Stale (lower-index) latest=true: selects a different namespace.
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cro-dup-0",
+						Labels: map[string]string{
+							placementv1beta1.IsLatestSnapshotLabel: "true",
+							placementv1beta1.OverrideTrackingLabel: "cro-dup",
+							placementv1beta1.OverrideIndexLabel:    "0",
+						},
+					},
+					Spec: placementv1beta1.ClusterResourceOverrideSnapshotSpec{
+						OverrideSpec: placementv1beta1.ClusterResourceOverrideSpec{
+							ClusterResourceSelectors: []placementv1beta1.ResourceSelectorTerm{
+								{Group: "", Version: "v1", Kind: "Namespace", Name: "stale-namespace"},
+							},
+						},
+					},
+				},
+				{
+					// Authoritative (highest-index) latest=true: selects the master's namespace.
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cro-dup-1",
+						Labels: map[string]string{
+							placementv1beta1.IsLatestSnapshotLabel: "true",
+							placementv1beta1.OverrideTrackingLabel: "cro-dup",
+							placementv1beta1.OverrideIndexLabel:    "1",
+						},
+					},
+					Spec: placementv1beta1.ClusterResourceOverrideSnapshotSpec{
+						OverrideSpec: placementv1beta1.ClusterResourceOverrideSpec{
+							ClusterResourceSelectors: []placementv1beta1.ResourceSelectorTerm{
+								{Group: "", Version: "v1", Kind: "Namespace", Name: "svc-namespace"},
+							},
+						},
+					},
+				},
+			},
+			roList: []placementv1beta1.ResourceOverrideSnapshot{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ro-dup-0",
+						Namespace: "svc-namespace",
+						Labels: map[string]string{
+							placementv1beta1.IsLatestSnapshotLabel: "true",
+							placementv1beta1.OverrideTrackingLabel: "ro-dup",
+							placementv1beta1.OverrideIndexLabel:    "0",
+						},
+					},
+					Spec: placementv1beta1.ResourceOverrideSnapshotSpec{
+						OverrideSpec: placementv1beta1.ResourceOverrideSpec{
+							ResourceSelectors: []placementv1beta1.ResourceSelector{
+								{Group: "", Version: "v1", Kind: "ConfigMap", Name: "stale"},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ro-dup-1",
+						Namespace: "svc-namespace",
+						Labels: map[string]string{
+							placementv1beta1.IsLatestSnapshotLabel: "true",
+							placementv1beta1.OverrideTrackingLabel: "ro-dup",
+							placementv1beta1.OverrideIndexLabel:    "1",
+						},
+					},
+					Spec: placementv1beta1.ResourceOverrideSnapshotSpec{
+						OverrideSpec: placementv1beta1.ResourceOverrideSpec{
+							ResourceSelectors: []placementv1beta1.ResourceSelector{
+								{Group: "", Version: "v1", Kind: "Service", Name: "svc-name"},
+							},
+						},
+					},
+				},
+			},
+			wantCRO: []*placementv1beta1.ClusterResourceOverrideSnapshot{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cro-dup-1",
+						Labels: map[string]string{
+							placementv1beta1.IsLatestSnapshotLabel: "true",
+							placementv1beta1.OverrideTrackingLabel: "cro-dup",
+							placementv1beta1.OverrideIndexLabel:    "1",
+						},
+					},
+					Spec: placementv1beta1.ClusterResourceOverrideSnapshotSpec{
+						OverrideSpec: placementv1beta1.ClusterResourceOverrideSpec{
+							ClusterResourceSelectors: []placementv1beta1.ResourceSelectorTerm{
+								{Group: "", Version: "v1", Kind: "Namespace", Name: "svc-namespace"},
+							},
+						},
+					},
+				},
+			},
+			wantRO: []*placementv1beta1.ResourceOverrideSnapshot{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ro-dup-1",
+						Namespace: "svc-namespace",
+						Labels: map[string]string{
+							placementv1beta1.IsLatestSnapshotLabel: "true",
+							placementv1beta1.OverrideTrackingLabel: "ro-dup",
+							placementv1beta1.OverrideIndexLabel:    "1",
+						},
+					},
+					Spec: placementv1beta1.ResourceOverrideSnapshotSpec{
+						OverrideSpec: placementv1beta1.ResourceOverrideSpec{
+							ResourceSelectors: []placementv1beta1.ResourceSelector{
+								{Group: "", Version: "v1", Kind: "Service", Name: "svc-name"},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -1491,10 +1650,17 @@ func TestFetchAllMatchingOverridesForResourceSnapshot(t *testing.T) {
 			for i := range tc.snapshots {
 				objects = append(objects, tc.snapshots[i])
 			}
+			// Production-realistic labels: every override snapshot is created with
+			// OverrideTrackingLabel and OverrideIndexLabel by the override controllers. The
+			// fixtures only declare the latest-snapshot label they care about, so we inject the
+			// rest here. Without these the read-time dedup path correctly errors on malformed
+			// labels.
 			for i := range tc.croList {
+				ensureSnapshotTrackingLabels(&tc.croList[i].ObjectMeta, tc.croList[i].Name, 0)
 				objects = append(objects, &tc.croList[i])
 			}
 			for i := range tc.roList {
+				ensureSnapshotTrackingLabels(&tc.roList[i].ObjectMeta, tc.roList[i].Name, 0)
 				objects = append(objects, &tc.roList[i])
 			}
 			fakeClient := fake.NewClientBuilder().
@@ -1507,6 +1673,11 @@ func TestFetchAllMatchingOverridesForResourceSnapshot(t *testing.T) {
 			}
 			options := []cmp.Option{
 				cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion"),
+				// Ignore the tracking/index labels we inject in setup for production realism;
+				// the test fixtures intentionally only declare the latest-snapshot label.
+				cmpopts.IgnoreMapEntries(func(k, _ string) bool {
+					return k == placementv1beta1.OverrideTrackingLabel || k == placementv1beta1.OverrideIndexLabel
+				}),
 				cmpopts.SortSlices(func(o1, o2 *placementv1beta1.ClusterResourceOverrideSnapshot) bool {
 					return o1.Name < o2.Name
 				}),
@@ -2225,4 +2396,179 @@ func TestIsClusterMatched(t *testing.T) {
 			}
 		})
 	}
+}
+
+// dedupTestCase is the shared shape for all dedup test cases. T is the snapshot value type.
+// inputs are transformed into a slice; want is the deduped key set (order-independent).
+type dedupTestCase[T any] struct {
+	name  string
+	input []T
+	want  []string
+}
+
+// runDedupTests drives a generic dedup function over the shared cases. keyOf must match the
+// production keyer; outputKey produces the comparable string for assertions (e.g. snapshot name
+// for CRO, namespace/name for RO). Malformed snapshots are skipped with a loud log rather than
+// failing the fetch, so cases assert on the survivors via tc.want.
+func runDedupTests[T any, PT interface {
+	*T
+	client.Object
+}](t *testing.T, cases []dedupTestCase[T], keyOf func(PT) string, outputKey func(T) string) {
+	t.Helper()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := dedupLatestSnapshots(tc.input, keyOf)
+			gotKeys := make([]string, 0, len(got))
+			for i := range got {
+				gotKeys = append(gotKeys, outputKey(got[i]))
+			}
+			if diff := cmp.Diff(tc.want, gotKeys, cmpopts.SortSlices(func(a, b string) bool { return a < b }), cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("dedupLatestSnapshots() returned unexpected keys (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func croSnapshotForDedup(name, parent, indexLabel string) placementv1beta1.ClusterResourceOverrideSnapshot {
+	labelsForSnapshot := map[string]string{
+		placementv1beta1.IsLatestSnapshotLabel: "true",
+	}
+	if parent != "" {
+		labelsForSnapshot[placementv1beta1.OverrideTrackingLabel] = parent
+	}
+	if indexLabel != "" {
+		labelsForSnapshot[placementv1beta1.OverrideIndexLabel] = indexLabel
+	}
+	return placementv1beta1.ClusterResourceOverrideSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: labelsForSnapshot,
+		},
+	}
+}
+
+func roSnapshotForDedup(name, namespace, parent, indexLabel string) placementv1beta1.ResourceOverrideSnapshot {
+	labelsForSnapshot := map[string]string{
+		placementv1beta1.IsLatestSnapshotLabel: "true",
+	}
+	if parent != "" {
+		labelsForSnapshot[placementv1beta1.OverrideTrackingLabel] = parent
+	}
+	if indexLabel != "" {
+		labelsForSnapshot[placementv1beta1.OverrideIndexLabel] = indexLabel
+	}
+	return placementv1beta1.ResourceOverrideSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labelsForSnapshot,
+		},
+	}
+}
+
+func TestDedupLatestSnapshots_CRO(t *testing.T) {
+	cases := []dedupTestCase[placementv1beta1.ClusterResourceOverrideSnapshot]{
+		{
+			name:  "empty input passes through",
+			input: nil,
+			want:  nil,
+		},
+		{
+			name: "single snapshot passes through",
+			input: []placementv1beta1.ClusterResourceOverrideSnapshot{
+				croSnapshotForDedup("cro-a-0", "cro-a", "0"),
+			},
+			want: []string{"cro-a-0"},
+		},
+		{
+			name: "two snapshots same parent picks highest index",
+			input: []placementv1beta1.ClusterResourceOverrideSnapshot{
+				croSnapshotForDedup("cro-a-0", "cro-a", "0"),
+				croSnapshotForDedup("cro-a-1", "cro-a", "1"),
+			},
+			want: []string{"cro-a-1"},
+		},
+		{
+			name: "multiple parents each kept with highest index",
+			input: []placementv1beta1.ClusterResourceOverrideSnapshot{
+				croSnapshotForDedup("cro-a-0", "cro-a", "0"),
+				croSnapshotForDedup("cro-a-2", "cro-a", "2"),
+				croSnapshotForDedup("cro-a-1", "cro-a", "1"),
+				croSnapshotForDedup("cro-b-0", "cro-b", "0"),
+			},
+			want: []string{"cro-a-2", "cro-b-0"},
+		},
+		{
+			// Malformed snapshots are logged and skipped so a single corrupt entry can't block
+			// the rollout hot path; valid snapshots in the same list still survive.
+			name: "missing tracking label is skipped, valid sibling kept",
+			input: []placementv1beta1.ClusterResourceOverrideSnapshot{
+				croSnapshotForDedup("cro-a-0", "cro-a", "0"),
+				croSnapshotForDedup("cro-orphan", "", "0"),
+			},
+			want: []string{"cro-a-0"},
+		},
+		{
+			name: "missing index label is skipped, valid sibling kept",
+			input: []placementv1beta1.ClusterResourceOverrideSnapshot{
+				croSnapshotForDedup("cro-a-0", "cro-a", "0"),
+				croSnapshotForDedup("cro-a-x", "cro-a", ""),
+			},
+			want: []string{"cro-a-0"},
+		},
+		{
+			name: "non-numeric index is skipped, valid sibling for same parent wins",
+			input: []placementv1beta1.ClusterResourceOverrideSnapshot{
+				croSnapshotForDedup("cro-a-zero", "cro-a", "zero"),
+				croSnapshotForDedup("cro-a-1", "cro-a", "1"),
+			},
+			want: []string{"cro-a-1"},
+		},
+	}
+	runDedupTests(t, cases, croDedupKey, func(s placementv1beta1.ClusterResourceOverrideSnapshot) string { return s.Name })
+}
+
+func TestDedupLatestSnapshots_RO(t *testing.T) {
+	cases := []dedupTestCase[placementv1beta1.ResourceOverrideSnapshot]{
+		{
+			name:  "empty input passes through",
+			input: nil,
+			want:  nil,
+		},
+		{
+			name: "two snapshots same parent same namespace picks highest index",
+			input: []placementv1beta1.ResourceOverrideSnapshot{
+				roSnapshotForDedup("ro-a-0", "ns-1", "ro-a", "0"),
+				roSnapshotForDedup("ro-a-1", "ns-1", "ro-a", "1"),
+			},
+			want: []string{"ns-1/ro-a-1"},
+		},
+		{
+			name: "same parent name in different namespaces are not collapsed",
+			input: []placementv1beta1.ResourceOverrideSnapshot{
+				roSnapshotForDedup("ro-a-0", "ns-1", "ro-a", "0"),
+				roSnapshotForDedup("ro-a-0", "ns-2", "ro-a", "0"),
+			},
+			want: []string{"ns-1/ro-a-0", "ns-2/ro-a-0"},
+		},
+		{
+			name: "missing tracking label is skipped, valid sibling kept",
+			input: []placementv1beta1.ResourceOverrideSnapshot{
+				roSnapshotForDedup("ro-a-0", "ns-1", "ro-a", "0"),
+				roSnapshotForDedup("ro-orphan", "ns-1", "", "0"),
+			},
+			want: []string{"ns-1/ro-a-0"},
+		},
+		{
+			name: "non-numeric index is skipped, valid sibling for same parent wins",
+			input: []placementv1beta1.ResourceOverrideSnapshot{
+				roSnapshotForDedup("ro-a-zero", "ns-1", "ro-a", "first"),
+				roSnapshotForDedup("ro-a-1", "ns-1", "ro-a", "1"),
+			},
+			want: []string{"ns-1/ro-a-1"},
+		},
+	}
+	runDedupTests(t, cases, roDedupKey, func(s placementv1beta1.ResourceOverrideSnapshot) string {
+		return fmt.Sprintf("%s/%s", s.Namespace, s.Name)
+	})
 }

--- a/pkg/utils/overrider/overrider_test.go
+++ b/pkg/utils/overrider/overrider_test.go
@@ -1653,8 +1653,8 @@ func TestFetchAllMatchingOverridesForResourceSnapshot(t *testing.T) {
 			// Production-realistic labels: every override snapshot is created with
 			// OverrideTrackingLabel and OverrideIndexLabel by the override controllers. The
 			// fixtures only declare the latest-snapshot label they care about, so we inject the
-			// rest here. Without these the read-time dedup path correctly errors on malformed
-			// labels.
+			// rest here. Without these the read-time dedup path logs an error and skips the
+			// malformed snapshot, which would change the test's expected outputs.
 			for i := range tc.croList {
 				ensureSnapshotTrackingLabels(&tc.croList[i].ObjectMeta, tc.croList[i].Name, 0)
 				objects = append(objects, &tc.croList[i])


### PR DESCRIPTION
### Description of your changes

When a `ClusterResourceOverride` or `ResourceOverride` is updated, the controller previously flipped `is-latest-snapshot=false` on the old snapshot **before** creating the new one. The rollout snapshot watcher only handles `Create`/`Generic` events (no `UpdateFunc`), so a crash between flip and create left rollout un-enqueued until the next resync (6 h hub-agent default) or parent-CR mutation, and `FetchAllMatchingOverridesForResourceSnapshot` would silently drop the affected override.

This PR reorders the controller to **create-first, demote-after**, with two additional safety steps so transient duplicate `latest=true` is benign:

- New snapshot is `Create`d with `latest=true` first; the previous snapshot is flipped to `false` afterwards.
- On `AlreadyExists`, the existing snapshot is fetched via `mgr.GetAPIReader()` (uncached) and its `OverrideHash` verified before proceeding. Mismatches surface as a `Warning` event on the parent CRO/RO and an `ExpectedBehaviorError` (no stack trace, requeues for transient causes like etcd restore).
- A new `cleanupStaleLatestSiblings` helper flips any older sibling that still carries `latest=true`. Runs on both the hash-match and new-snapshot paths.
- `FetchAllMatchingOverridesForResourceSnapshot` deduplicates at read time, picking the highest `OverrideIndexLabel` per parent (CRO key: tracking label; RO key: namespace + tracking label). Malformed labels log loudly and skip rather than blocking the entire rollout hot path.
- `IsNotFound` on the demote `Update` is tolerated so the sibling audit still runs after a concurrent prune or parent deletion.

Fixes #

I have:

- [x] Associated this change with a known KubeFleet Issue (Bug, Feature, etc).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- New unit tests in `pkg/utils/overrider/overrider_test.go` cover the generic dedup helper (CRO and RO, including the namespace-collision and malformed-label cases) and a `FetchAllMatchingOverridesForResourceSnapshot` integration case with two `latest=true` snapshots for the same parent.
- New integration tests in `pkg/controllers/overrider/common_test.go` cover the sibling-audit helper (steady-state no-op, post-crash recovery) and the `AlreadyExists` recovery branch (matching hash → demote proceeds; mismatched hash → `ExpectedBehaviorError` + Warning event, no demote).
- All existing override controller integration tests (envtest) and `pkg/utils/overrider` unit tests pass.

### Special notes for your reviewer

- `Placement == nil` rollout watcher skip (`pkg/controllers/rollout/controller.go:849, :882`) and the same flip-then-create antipattern in `pkg/utils/controller/resource_snapshot_resolver.go` are left out of scope; both deserve their own follow-up issues.
- Long-term we should consider migrating to a `status.latestSnapshotName` pointer on the parent CRO/RO so labels stop being load-bearing for "current" semantics; that would be a separate, larger change.