### PR TITLE
ci: prepare release pipeline for -rc tags and add autogen release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,41 @@
+# Configures GitHub auto-generated release notes.
+# https://docs.github.com/repositories/releasing-projects-on-github/automatically-generated-release-notes
+#
+# Categorization is label-based. Contributors should add a single release-note/*
+# label to each PR; the label should match the PR title prefix
+# (e.g. feat: -> release-note/feature, fix: -> release-note/fix).
+# PRs with no release-note label fall into "Other Changes".
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+      - release-note/none
+  categories:
+    - title: Breaking Changes
+      labels:
+        - release-note/breaking
+    - title: Security
+      labels:
+        - release-note/security
+    - title: New Features
+      labels:
+        - release-note/feature
+    - title: Bug Fixes
+      labels:
+        - release-note/fix
+    - title: Documentation
+      labels:
+        - release-note/docs
+    - title: Tests
+      labels:
+        - release-note/test
+    - title: Refactors
+      labels:
+        - release-note/refactor
+    - title: Maintenance and Dependencies
+      labels:
+        - release-note/chore
+        - dependencies
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -14,6 +14,14 @@ permissions:
   contents: write
   packages: write
 
+# Serialize chart publishes globally: the helm-gh-pages action always
+# rewrites the gh-pages branch, so concurrent runs for different tags
+# would race. cancel-in-progress: false — never abort a chart push
+# midway, even if a later tag arrives.
+concurrency:
+  group: helm-chart-publish
+  cancel-in-progress: false
+
 env:
   REGISTRY: ghcr.io
 

--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -8,7 +8,7 @@ on:
     # tag manually if ever needed.
     tags:
       - "v*.*.*"
-      - "!*-rc.*"
+      - "!v*-rc.*"
   workflow_dispatch:
     inputs:
       tag:

--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -2,8 +2,13 @@ name: Helm Chart Publisher
 
 on:
   push:
+    # Pre-release tags (e.g. v0.4.0-rc.1) build images via release.yml but
+    # must not land in the public Helm index. The negative pattern below
+    # filters them out; workflow_dispatch can still publish a specific
+    # tag manually if ever needed.
     tags:
       - "v*.*.*"
+      - "!*-rc.*"
   workflow_dispatch:
     inputs:
       tag:
@@ -13,14 +18,6 @@ on:
 permissions:
   contents: write
   packages: write
-
-# Serialize chart publishes globally: the helm-gh-pages action always
-# rewrites the gh-pages branch, so concurrent runs for different tags
-# would race. cancel-in-progress: false — never abort a chart push
-# midway, even if a later tag arrives.
-concurrency:
-  group: helm-chart-publish
-  cancel-in-progress: false
 
 env:
   REGISTRY: ghcr.io
@@ -34,6 +31,13 @@ jobs:
   publish-github-pages:
     needs: export-registry
     runs-on: ubuntu-latest
+    # Only the gh-pages publish needs serialization: helm-gh-pages always
+    # rewrites the gh-pages branch, so concurrent runs for different tags
+    # would race. The OCI publish below pushes immutable per-tag blobs and
+    # is safe to run in parallel across tags, so it stays unguarded.
+    concurrency:
+      group: helm-chart-publish-gh-pages
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,7 @@ jobs:
         env:
           VERSION: ${{ needs.export-registry.outputs.version }}
         run: |
+          set -euo pipefail
           echo "✅ Published images:"
           echo "  - ${{ env.REGISTRY }}/${{ env.HUB_AGENT_IMAGE_NAME }}:${{ env.TAG }}"
           echo "  - ${{ env.REGISTRY }}/${{ env.HUB_AGENT_IMAGE_NAME }}:${VERSION}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,14 @@ permissions:
   contents: read
   packages: write
 
+# Serialize releases per ref so concurrent tag pushes can't race on image
+# pushes to the same ${REGISTRY}/${IMAGE}:${TAG}. Different tags can still
+# run in parallel. We never want cancel-in-progress here: aborting a
+# half-pushed image is worse than letting it finish.
+concurrency:
+  group: release-images-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   REGISTRY: ghcr.io
   HUB_AGENT_IMAGE_NAME: hub-agent
@@ -60,6 +68,7 @@ jobs:
         env:
           VERSION: ${{ needs.export-registry.outputs.version }}
         run: |
+          set -euo pipefail
           for IMAGE in ${{ env.HUB_AGENT_IMAGE_NAME }} ${{ env.MEMBER_AGENT_IMAGE_NAME }} ${{ env.REFRESH_TOKEN_IMAGE_NAME }}; do
             docker buildx imagetools create \
               --tag "${{ env.REGISTRY }}/${IMAGE}:${VERSION}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,14 @@ jobs:
         run: |
           make push
 
+      # The short-tag (e.g. ":0.4.0") aliases the long form for stable releases
+      # only. RC images are published under the long form (":v0.4.0-rc.1") for
+      # testers, but we deliberately do NOT alias them to a short tag - the
+      # short-tag namespace is reserved for stable releases that consumers can
+      # safely pin to (and "imagetools create" with an RC alias would publish
+      # "0.4.0-rc.1" into that namespace, muddying it).
       - name: Tag and push images without v prefix
+        if: ${{ !contains(needs.export-registry.outputs.tag, '-rc.') }}
         env:
           VERSION: ${{ needs.export-registry.outputs.version }}
         run: |
@@ -81,9 +88,9 @@ jobs:
         run: |
           set -euo pipefail
           echo "✅ Published images:"
-          echo "  - ${{ env.REGISTRY }}/${{ env.HUB_AGENT_IMAGE_NAME }}:${{ env.TAG }}"
-          echo "  - ${{ env.REGISTRY }}/${{ env.HUB_AGENT_IMAGE_NAME }}:${VERSION}"
-          echo "  - ${{ env.REGISTRY }}/${{ env.MEMBER_AGENT_IMAGE_NAME }}:${{ env.TAG }}"
-          echo "  - ${{ env.REGISTRY }}/${{ env.MEMBER_AGENT_IMAGE_NAME }}:${VERSION}"
-          echo "  - ${{ env.REGISTRY }}/${{ env.REFRESH_TOKEN_IMAGE_NAME }}:${{ env.TAG }}"
-          echo "  - ${{ env.REGISTRY }}/${{ env.REFRESH_TOKEN_IMAGE_NAME }}:${VERSION}"
+          for IMAGE in ${{ env.HUB_AGENT_IMAGE_NAME }} ${{ env.MEMBER_AGENT_IMAGE_NAME }} ${{ env.REFRESH_TOKEN_IMAGE_NAME }}; do
+            echo "  - ${{ env.REGISTRY }}/${IMAGE}:${{ env.TAG }}"
+            if [[ "${{ env.TAG }}" != *-rc.* ]]; then
+              echo "  - ${{ env.REGISTRY }}/${IMAGE}:${VERSION}"
+            fi
+          done

--- a/.github/workflows/setup-release.yml
+++ b/.github/workflows/setup-release.yml
@@ -32,8 +32,8 @@ jobs:
             - id: setup
               run: |
                   TAG="${{ inputs.tag }}"
-                  if [[ ! "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
-                    echo "Error: Invalid release tag '${TAG}'. Expected format: v*.*.*"
+                  if [[ ! "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$ ]]; then
+                    echo "Error: Invalid release tag '${TAG}'. Expected format: vMAJOR.MINOR.PATCH or vMAJOR.MINOR.PATCH-rc.N"
                     exit 1
                   fi
 

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -69,7 +69,7 @@ jobs:
               echo "Fetch all tags..."
 
               git fetch --all
-              GIT_TAG=$(git describe --tags --exclude='*-rc*' $(git rev-list --tags --exclude='*-rc*' --max-count=1))
+              GIT_TAG=$(git describe --tags --exclude='*-rc.*' $(git rev-list --tags --exclude='*-rc.*' --max-count=1))
           else
               echo "A tag is specified; go back to the state tracked by the specified tag."
               echo "Fetch all tags..."
@@ -152,7 +152,7 @@ jobs:
               echo "Fetch all tags..."
 
               git fetch --all
-              GIT_TAG=$(git describe --tags --exclude='*-rc*' $(git rev-list --tags --exclude='*-rc*' --max-count=1)) 
+              GIT_TAG=$(git describe --tags --exclude='*-rc.*' $(git rev-list --tags --exclude='*-rc.*' --max-count=1)) 
           else
               echo "A tag is specified; go back to the state tracked by the specified tag."
               echo "Fetch all tags..."
@@ -235,7 +235,7 @@ jobs:
               echo "Fetch all tags..."
 
               git fetch --all
-              GIT_TAG=$(git describe --tags --exclude='*-rc*' $(git rev-list --tags --exclude='*-rc*' --max-count=1)) 
+              GIT_TAG=$(git describe --tags --exclude='*-rc.*' $(git rev-list --tags --exclude='*-rc.*' --max-count=1)) 
           else
               echo "A tag is specified; go back to the state tracked by the specified tag."
               echo "Fetch all tags..."

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -69,7 +69,7 @@ jobs:
               echo "Fetch all tags..."
 
               git fetch --all
-              GIT_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
+              GIT_TAG=$(git describe --tags --exclude='*-rc*' $(git rev-list --tags --exclude='*-rc*' --max-count=1))
           else
               echo "A tag is specified; go back to the state tracked by the specified tag."
               echo "Fetch all tags..."
@@ -152,7 +152,7 @@ jobs:
               echo "Fetch all tags..."
 
               git fetch --all
-              GIT_TAG=$(git describe --tags $(git rev-list --tags --max-count=1)) 
+              GIT_TAG=$(git describe --tags --exclude='*-rc*' $(git rev-list --tags --exclude='*-rc*' --max-count=1)) 
           else
               echo "A tag is specified; go back to the state tracked by the specified tag."
               echo "Fetch all tags..."
@@ -235,7 +235,7 @@ jobs:
               echo "Fetch all tags..."
 
               git fetch --all
-              GIT_TAG=$(git describe --tags $(git rev-list --tags --max-count=1)) 
+              GIT_TAG=$(git describe --tags --exclude='*-rc*' $(git rev-list --tags --exclude='*-rc*' --max-count=1)) 
           else
               echo "A tag is specified; go back to the state tracked by the specified tag."
               echo "Fetch all tags..."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ Each PR should carry one base `release-note/*` label matching its title prefix; 
 
 Additive labels (stack on top of the above when applicable):
 
-- `release-note/breaking` — a change that requires user action to upgrade (manifest edit, CRD reapply, RBAC reapply, webhook config update, member-cluster re-join, etc.) **or** that alters scheduling, override, or apply semantics in a way that re-ranks or re-applies existing placements without a manifest change. Pre-1.0, internal refactors that touch `v1alpha1` shapes but don't require migration steps or change semantics do not qualify.
+- `release-note/breaking` — a change that requires user action to upgrade (manifest edit, CRD reapply, RBAC reapply, webhook config update, member-cluster re-join, etc.) **or** that alters scheduling, override, or apply semantics in a way that re-ranks or re-applies existing placements without a manifest change. Pre-1.0, internal refactors of any alpha or beta API shape that don't require migration steps or change observable semantics do not qualify.
 - `release-note/security` — security fixes or vulnerability disclosures
 - `release-note/none` — suppresses the entry in release notes but keeps the PR visible in GitHub's auto-notes drafter UI
 - `ignore-for-release` — hides the PR entirely from auto-generated notes. Default to this for CI-only or internal-cleanup PRs with no user impact.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,22 +44,22 @@ Add `make reviewable` to your workflow before opening a PR — the PR template w
 
 ## Release note labels
 
-Each PR should carry exactly one `release-note/*` label matching its title prefix:
+Each PR should carry one base `release-note/*` label matching its title prefix; additive labels (below) may be stacked on top.
 
 | PR title prefix | Label |
 | --- | --- |
 | `feat:` / `perf:` | `release-note/feature` |
-| `fix:` | `release-note/fix` |
+| `fix:` / `revert:` | `release-note/fix` |
 | `docs:` | `release-note/docs` |
 | `test:` | `release-note/test` |
-| `chore:` / `ci:` | `release-note/chore` |
+| `chore:` / `ci:` / `style:` / `interface:` / `util:` | `release-note/chore` |
 | `refactor:` | `release-note/refactor` |
 
 Additive labels (stack on top of the above when applicable):
 
-- `release-note/breaking` — any change that breaks an existing API or behavior
+- `release-note/breaking` — a change that requires user action to upgrade (manifest edit, CRD reapply, RBAC reapply, webhook config update, member-cluster re-join, etc.) **or** that alters scheduling, override, or apply semantics in a way that re-ranks or re-applies existing placements without a manifest change. Pre-1.0, internal refactors that touch `v1alpha1` shapes but don't require migration steps or change semantics do not qualify.
 - `release-note/security` — security fixes or vulnerability disclosures
-- `release-note/none` — suppresses the entry in release notes but keeps it in GitHub's dataset
-- `ignore-for-release` — excludes the PR entirely from the release dataset (use for CI-only or doc-fix PRs with no user impact)
+- `release-note/none` — suppresses the entry in release notes but keeps the PR visible in GitHub's auto-notes drafter UI
+- `ignore-for-release` — hides the PR entirely from auto-generated notes. Default to this for CI-only or internal-cleanup PRs with no user impact.
 
 PRs with no `release-note/*` label fall into "Other Changes" in the generated notes. Dependabot PRs are labeled `dependencies` automatically and land under "Maintenance and Dependencies" without a `release-note/*` label.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,3 +33,33 @@ The KubeFleet project has adopted the CNCF Code of Conduct. Refer to our [Commun
 ## Issue and pull request management
 
 Anyone can comment on issues and submit reviews for pull requests. In order to be assigned an issue or pull request, you can leave a `/assign <your Github ID>` comment on the issue or pull request.
+
+## Pull request titles
+
+PR titles must begin with one of the following prefixes (enforced by [`pr-title-lint.yml`](.github/workflows/pr-title-lint.yml)):
+
+`feat:`, `fix:`, `docs:`, `test:`, `style:`, `interface:`, `util:`, `chore:`, `ci:`, `perf:`, `refactor:`, `revert:`
+
+Add `make reviewable` to your workflow before opening a PR — the PR template will remind you, but running it locally first saves a round trip.
+
+## Release note labels
+
+Each PR should carry exactly one `release-note/*` label matching its title prefix:
+
+| PR title prefix | Label |
+| --- | --- |
+| `feat:` / `perf:` | `release-note/feature` |
+| `fix:` | `release-note/fix` |
+| `docs:` | `release-note/docs` |
+| `test:` | `release-note/test` |
+| `chore:` / `ci:` | `release-note/chore` |
+| `refactor:` | `release-note/refactor` |
+
+Additive labels (stack on top of the above when applicable):
+
+- `release-note/breaking` — any change that breaks an existing API or behavior
+- `release-note/security` — security fixes or vulnerability disclosures
+- `release-note/none` — suppresses the entry in release notes but keeps it in GitHub's dataset
+- `ignore-for-release` — excludes the PR entirely from the release dataset (use for CI-only or doc-fix PRs with no user impact)
+
+PRs with no `release-note/*` label fall into "Other Changes" in the generated notes. Dependabot PRs are labeled `dependencies` automatically and land under "Maintenance and Dependencies" without a `release-note/*` label.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,8 +16,8 @@ below to report it to the KubeFleet team.
 
 KubeFleet is pre-1.0 and *targets* an `N`/`N-1` support window: the latest minor release and
 the one immediately preceding it receive security patches. The project has maintained a roughly
-quarterly release cadence since `v0.1.0`, which gives approximately six months of patch coverage
-from the GA of any given minor. Minor cadence slippage is possible while we are pre-1.0.
+2–3 month minor-release cadence since `v0.2`, giving approximately four to six months of patch
+coverage from the GA of any given minor. Minor cadence slippage is possible while we are pre-1.0.
 
 | Version | Supported |
 | --- | --- |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,6 +6,35 @@ and appreciates any responsible disclosures of security vulnerabilities.
 If you believe you have found a security vulnerability in the repository, please follow the steps
 below to report it to the KubeFleet team.
 
+## Supported versions
+
+KubeFleet is pre-1.0 and follows an `N`/`N-1` support window: only the latest minor release and
+the one immediately preceding it receive security patches. At the planned ~3-month minor-release
+cadence, that gives roughly six months of patch coverage from the GA of any given minor.
+
+| Version | Supported |
+| --- | --- |
+| Latest minor (e.g. `v0.Y.x`) | Yes |
+| Previous minor (e.g. `v0.Y-1.x`) | Yes |
+| Older minors | No |
+
+"Supported" here refers to security patch backports only. As a pre-1.0 project, KubeFleet does
+not guarantee API stability across minor releases.
+
+## Response SLO
+
+We commit to the following response targets, measured from the time a report is acknowledged by
+the maintainers to the time a patched release is published across all supported minors:
+
+| Severity (CVSS v3.1) | Target time-to-patch |
+| --- | --- |
+| Critical (9.0+) | 14 days |
+| High (7.0–8.9) | 45 days |
+| Medium / Low | Best-effort, no committed SLO |
+
+These targets are aspirational while we ramp up to consistent release cadence; we will revisit
+them after one full quarterly cycle.
+
 ## Reporting Security Issues
 
 **Please do not report security vulnerabilities through public GitHub issues.** Instead, 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,11 @@
 # Security
 
+<!--
+TODO: The "Supported versions", "Response SLO", and "Coordinated disclosure" sections
+below are provisional pending maintainer agreement on kubefleet-dev/kubefleet#693 (Q3)
+and the discussion on PR #713. Update once those decisions land.
+-->
+
 The KubeFleet maintainers takes the security of the project very seriously; we greatly welcomes
 and appreciates any responsible disclosures of security vulnerabilities.
 
@@ -8,9 +14,10 @@ below to report it to the KubeFleet team.
 
 ## Supported versions
 
-KubeFleet is pre-1.0 and follows an `N`/`N-1` support window: only the latest minor release and
-the one immediately preceding it receive security patches. At the planned ~3-month minor-release
-cadence, that gives roughly six months of patch coverage from the GA of any given minor.
+KubeFleet is pre-1.0 and *targets* an `N`/`N-1` support window: the latest minor release and
+the one immediately preceding it receive security patches. The project has maintained a roughly
+quarterly release cadence since `v0.1.0`, which gives approximately six months of patch coverage
+from the GA of any given minor. Minor cadence slippage is possible while we are pre-1.0.
 
 | Version | Supported |
 | --- | --- |
@@ -19,7 +26,9 @@ cadence, that gives roughly six months of patch coverage from the GA of any give
 | Older minors | No |
 
 "Supported" here refers to security patch backports only. As a pre-1.0 project, KubeFleet does
-not guarantee API stability across minor releases.
+not guarantee API stability across minor releases. Users on unsupported minors should upgrade to
+a supported minor following the project's upgrade documentation; patches are not backported to
+EOL releases.
 
 ## Response SLO
 
@@ -34,6 +43,26 @@ the maintainers to the time a patched release is published across all supported 
 
 These targets are aspirational while we ramp up to consistent release cadence; we will revisit
 them after one full quarterly cycle.
+
+## Coordinated disclosure
+
+KubeFleet follows responsible-disclosure norms but the operational specifics below are still
+being finalized:
+
+- **Embargo window: TBD.** We have not yet committed to a fixed number of days between
+  vulnerability acknowledgement and public disclosure. At minimum, reporters will be notified
+  before public disclosure. The intent is to follow standard CNCF coordinated disclosure
+  practice (typically 1–7 days for downstream coordination).
+- **Vendor advance notification: TBD.** Projects with downstream consumers commonly operate
+  a distributors mailing list for embargo coordination with packagers and downstream forks
+  (see the [CNCF TAG-Security `SECURITY.md` template](https://github.com/cncf/tag-security/blob/main/project-resources/templates/SECURITY.md)
+  for the conventional `cncf-<project>-distributors-announce@lists.cncf.io` form). Whether
+  KubeFleet stands one up depends on demonstrated downstream demand.
+- **GitHub private vulnerability reporting:** to be enabled on this repository as the
+  preferred reporting channel; the maintainer mailing list (see below) remains the fallback
+  until it is.
+
+This section will be updated as each item is decided.
 
 ## Reporting Security Issues
 

--- a/charts/hub-agent/crdbases/cluster.kubernetes-fleet.io_internalmemberclusters.yaml
+++ b/charts/hub-agent/crdbases/cluster.kubernetes-fleet.io_internalmemberclusters.yaml
@@ -1,1 +1,0 @@
-../../../config/crd/bases/cluster.kubernetes-fleet.io_internalmemberclusters.yaml

--- a/charts/hub-agent/crdbases/cluster.kubernetes-fleet.io_memberclusters.yaml
+++ b/charts/hub-agent/crdbases/cluster.kubernetes-fleet.io_memberclusters.yaml
@@ -1,1 +1,0 @@
-../../../config/crd/bases/cluster.kubernetes-fleet.io_memberclusters.yaml

--- a/charts/hub-agent/crdbases/placement.kubernetes-fleet.io_clusterresourceplacements.yaml
+++ b/charts/hub-agent/crdbases/placement.kubernetes-fleet.io_clusterresourceplacements.yaml
@@ -1,1 +1,0 @@
-../../../config/crd/bases/placement.kubernetes-fleet.io_clusterresourceplacements.yaml

--- a/charts/hub-agent/crdbases/placement.kubernetes-fleet.io_works.yaml
+++ b/charts/hub-agent/crdbases/placement.kubernetes-fleet.io_works.yaml
@@ -1,1 +1,0 @@
-../../../config/crd/bases/placement.kubernetes-fleet.io_works.yaml

--- a/charts/member-agent/crdbases/placement.kubernetes-fleet.io_appliedworks.yaml
+++ b/charts/member-agent/crdbases/placement.kubernetes-fleet.io_appliedworks.yaml
@@ -1,1 +1,0 @@
-../../../config/crd/bases/placement.kubernetes-fleet.io_appliedworks.yaml


### PR DESCRIPTION
### Description of your changes

Foundational hygiene + workflow correctness for the release-process revamp tracked in #693. Four mechanical changes that together unblock cutting the first `v0.4.0-rc.1` tag.

1. **Anchor the SemVer regex and accept `-rc.N`** in `setup-release.yml`.
   Closes the partial-match bug (`v0.4.0extrastuff` previously validated) and adds support for `v*.*.*-rc.N` pre-release tags following the Kubernetes convention.
2. **Exclude `-rc*` tags from upgrade-compat tag discovery** in `upgrade.yml`. Without this, the first RC becomes the "previous release" for all three compat jobs and the suite fails. Uses `git rev-list` and `git describe --exclude=` globs.
3. **Add `.github/release.yml`** for GitHub auto-generated release notes, with label-based categorization that mirrors the project's existing PR-title prefixes. Required `release-note/*` labels will be created out-of-band — see "Special notes" below.
4. **Delete `charts/{hub,member}-agent/crdbases/`** — vestigial symlinks (mode 120000) into `config/crd/bases/`, unreferenced by chart templates, Makefile, or any shell script.

Maps to #693 Phase 1 bullets 1 (partial), 6, 7.

Refs #693

I have:

- [x] Associated this change with a known KubeFleet Issue (Bug, Feature, etc).
- [x] Run \`make reviewable\` to ensure this PR is ready for review. (No-op for this PR: no Go sources touched; CI lint/yaml/markdown checks will cover the changed files.)

### How has this code been tested

- Verified the new regex `^v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$` accepts `v0.4.0`, `v0.4.0-rc.1`, `v0.4.0-rc.10` and rejects `v0.4.0extrastuff`, `v0.4.0-rc` (no number), `v0.4.0-foo`.
- Confirmed `git rev-list --tags --exclude=<glob>` (since git 2.7) and `git describe --exclude=<glob>` (since git 2.13) are available on the `ubuntu-latest` runners used by `upgrade.yml`.
- `grep -rn crdbases` across the repo returns no hits in Go, YAML, Makefile, shell, or markdown — the symlinks are truly unreferenced.
- Helm chart renders aren't affected (`config/crd/bases/` is the source of truth used by `make manifests`; chart templates already include CRDs from there).
- Workflow CI on this branch (`code-lint`, `pr-title-lint`, `markdown-lint`, `codespell`, `ci`) will exercise the YAML changes end-to-end.

### Special notes for your reviewer

**Labels to create** (one-time, via `gh label create` or the GitHub UI) — `.github/release.yml` references these but doesn't define them:

| Label | Color | Purpose |
| --- | --- | --- |
| \`release-note/breaking\` | B60205 | User-visible breaking change |
| \`release-note/security\` | D93F0B | Security fix or hardening |
| \`release-note/feature\` | 0E8A16 | New user-facing feature |
| \`release-note/fix\` | FBCA04 | Bug fix |
| \`release-note/docs\` | 0075CA | Documentation only |
| \`release-note/test\` | C5DEF5 | Test only |
| \`release-note/refactor\` | BFDADC | Code refactor, no behavior change |
| \`release-note/chore\` | C2E0C6 | Build, CI, deps, housekeeping |
| \`release-note/none\` | EEEEEE | Exclude from release notes |
| \`ignore-for-release\` | EEEEEE | Exclude from release notes |

Without the labels created, the autogen notes still work — every PR just falls through to "Other Changes" until contributors start labelling. No regression vs. today.

**Deferred from this PR** (separate sub-issues against #693):

- Adding `linux/arm64` to `make push` and the single dual-tag `buildx` invocation (epic bullets 8, 9) — depends on the ARM-runner enablement question.
- Cherry-pick label automation + `release-0.4` branch protection (epic bullet 2) — depends on the release branch existing first.
- `SECURITY.md` support window, `VERSIONING.md`, `RELEASES.md` — pending the CVE-SLO + support-window decisions (open Q3 on #693).
- Standalone CRD tarball as a Release asset (epic bullet 10) — independently testable, cleaner as its own PR.

**Scope of risk:**

- `setup-release.yml` and `upgrade.yml` only fire on `workflow_call` / `push` to tags / `workflow_dispatch`, so this PR doesn't change any PR-CI behavior.
- `.github/release.yml` only affects auto-generated release-note content; it has no effect until a Release is drafted from a tag.
- The `crdbases/` deletions remove symlinks only; the underlying CRDs in `config/crd/bases/` are untouched.