### PR TITLE
feat: allow PickFixed placement with empty ClusterNames for scale-to-zero

### DIFF
--- a/pkg/utils/validator/placement.go
+++ b/pkg/utils/validator/placement.go
@@ -250,9 +250,6 @@ func validatePlacementPolicy(policy *placementv1beta1.PlacementPolicy) error {
 
 func validatePolicyForPickFixedPlacementType(policy *placementv1beta1.PlacementPolicy) error {
 	allErr := make([]error, 0)
-	if len(policy.ClusterNames) == 0 {
-		allErr = append(allErr, fmt.Errorf("cluster names cannot be empty for policy type %s", placementv1beta1.PickFixedPlacementType))
-	}
 	uniqueClusterNames := make(map[string]bool)
 	for _, name := range policy.ClusterNames {
 		nameErr := validation.IsDNS1123Subdomain(name)

--- a/pkg/utils/validator/placement_test.go
+++ b/pkg/utils/validator/placement_test.go
@@ -536,12 +536,11 @@ func TestValidateClusterResourcePlacement_PickFixedPlacementPolicy(t *testing.T)
 			},
 			wantErr: false,
 		},
-		"invalid placement policy - PickFixed with empty cluster names": {
+		"valid placement policy - PickFixed with empty cluster names": {
 			policy: &placementv1beta1.PlacementPolicy{
 				PlacementType: placementv1beta1.PickFixedPlacementType,
 			},
-			wantErr:    true,
-			wantErrMsg: "cluster names cannot be empty for policy type PickFixed",
+			wantErr: false,
 		},
 		"invalid placement policy - PickFixed with non-unique cluster names": {
 			policy: &placementv1beta1.PlacementPolicy{
@@ -1931,7 +1930,7 @@ func TestValidateResourcePlacement(t *testing.T) {
 		wantErr          bool
 		wantErrMsg       string
 	}{
-		"RP with invalid placement policy": {
+		"RP with valid PickFixed policy and empty cluster names": {
 			rp: &placementv1beta1.ResourcePlacement{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-rp",
@@ -1947,7 +1946,7 @@ func TestValidateResourcePlacement(t *testing.T) {
 					},
 					Policy: &placementv1beta1.PlacementPolicy{
 						PlacementType: placementv1beta1.PickFixedPlacementType,
-						ClusterNames:  []string{}, // Empty cluster names for PickFixed type
+						ClusterNames:  []string{}, // Empty cluster names for PickFixed type (scale to zero)
 					},
 				},
 			},
@@ -1955,8 +1954,7 @@ func TestValidateResourcePlacement(t *testing.T) {
 				APIResources:            map[schema.GroupVersionKind]bool{utils.DeploymentGVK: true},
 				IsClusterScopedResource: false,
 			},
-			wantErr:    true,
-			wantErrMsg: "cluster names cannot be empty for policy type PickFixed",
+			wantErr: false,
 		},
 		"RP with invalid rollout strategy": {
 			rp: &placementv1beta1.ResourcePlacement{

--- a/test/e2e/actuals_test.go
+++ b/test/e2e/actuals_test.go
@@ -444,6 +444,17 @@ func rpWorkSynchronizedFailedConditions(generation int64, hasOverrides bool) []m
 	}
 }
 
+func crpSchedulePendingConditions(generation int64) []metav1.Condition {
+	return []metav1.Condition{
+		{
+			Type:               string(placementv1beta1.ClusterResourcePlacementScheduledConditionType),
+			Status:             metav1.ConditionUnknown,
+			ObservedGeneration: generation,
+			Reason:             condition.SchedulingUnknownReason,
+		},
+	}
+}
+
 func crpScheduledConditions(generation int64) []metav1.Condition {
 	return []metav1.Condition{
 		{
@@ -1346,6 +1357,32 @@ func namespaceAccessibleCRPStatusUpdatedActual(wantSelectedResourceIdentifiers [
 func crpStatusUpdatedActual(wantSelectedResourceIdentifiers []placementv1beta1.ResourceIdentifier, wantSelectedClusters, wantUnselectedClusters []string, wantObservedResourceIndex string) func() error {
 	crpKey := types.NamespacedName{Name: fmt.Sprintf(crpNameTemplate, GinkgoParallelProcess())}
 	return customizedPlacementStatusUpdatedActual(crpKey, wantSelectedResourceIdentifiers, wantSelectedClusters, wantUnselectedClusters, wantObservedResourceIndex, true)
+}
+
+// crpStatusWithCustomConditionsUpdatedActual checks CRP status with caller-supplied conditions,
+// useful when the default condition derivation (based on selected/unselected clusters) does not apply.
+func crpStatusWithCustomConditionsUpdatedActual(
+	wantSelectedResourceIdentifiers []placementv1beta1.ResourceIdentifier,
+	wantConditions []metav1.Condition,
+	wantObservedResourceIndex string,
+) func() error {
+	crpKey := types.NamespacedName{Name: fmt.Sprintf(crpNameTemplate, GinkgoParallelProcess())}
+	return func() error {
+		placement, err := retrievePlacement(crpKey)
+		if err != nil {
+			return fmt.Errorf("failed to get placement %s: %w", crpKey, err)
+		}
+		wantStatus := &placementv1beta1.PlacementStatus{
+			Conditions:                  wantConditions,
+			PerClusterPlacementStatuses: []placementv1beta1.PerClusterPlacementStatus{},
+			SelectedResources:           wantSelectedResourceIdentifiers,
+			ObservedResourceIndex:       wantObservedResourceIndex,
+		}
+		if diff := cmp.Diff(placement.GetPlacementStatus(), wantStatus, placementStatusCmpOptionsOnCreate...); diff != "" {
+			return fmt.Errorf("Placement status diff (-got, +want): %s for placement %v", diff, crpKey)
+		}
+		return nil
+	}
 }
 
 func rpStatusUpdatedActual(wantSelectedResourceIdentifiers []placementv1beta1.ResourceIdentifier, wantSelectedClusters, wantUnselectedClusters []string, wantObservedResourceIndex string) func() error {

--- a/test/e2e/placement_pickfixed_test.go
+++ b/test/e2e/placement_pickfixed_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/kubefleet-dev/kubefleet/test/e2e/framework"
 )
 
-var _ = FDescribe("placing resources using a CRP of PickFixed placement type", func() {
+var _ = Describe("placing resources using a CRP of PickFixed placement type", func() {
 	Context("pick some clusters", Ordered, func() {
 		crpName := fmt.Sprintf(crpNameTemplate, GinkgoParallelProcess())
 

--- a/test/e2e/placement_pickfixed_test.go
+++ b/test/e2e/placement_pickfixed_test.go
@@ -335,4 +335,72 @@ var _ = Describe("placing resources using a CRP of PickFixed placement type", fu
 			ensureCRPAndRelatedResourcesDeleted(crpName, []*framework.Cluster{memberCluster1EastProd, memberCluster2EastCanary})
 		})
 	})
+
+	Context("scale from zero to one cluster", Ordered, func() {
+		crpName := fmt.Sprintf(crpNameTemplate, GinkgoParallelProcess())
+
+		BeforeAll(func() {
+			// Create the resources.
+			createWorkResources()
+
+			// Create the CRP with PickFixed and no clusters (scale to zero).
+			crp := &placementv1beta1.ClusterResourcePlacement{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: crpName,
+					// Add a custom finalizer; this would allow us to better observe
+					// the behavior of the controllers.
+					Finalizers: []string{customDeletionBlockerFinalizer},
+				},
+				Spec: placementv1beta1.PlacementSpec{
+					ResourceSelectors: workResourceSelector(),
+					Strategy: placementv1beta1.RolloutStrategy{
+						Type: placementv1beta1.RollingUpdateRolloutStrategyType,
+						RollingUpdate: &placementv1beta1.RollingUpdateConfig{
+							UnavailablePeriodSeconds: ptr.To(2),
+						},
+					},
+					Policy: &placementv1beta1.PlacementPolicy{
+						PlacementType: placementv1beta1.PickFixedPlacementType,
+						ClusterNames:  []string{},
+					},
+				},
+			}
+			Expect(hubClient.Create(ctx, crp)).To(Succeed(), "Failed to create CRP")
+		})
+
+		It("should update CRP status as expected with no clusters selected", func() {
+			crpStatusUpdatedActual := crpStatusUpdatedActual(workResourceIdentifiers(), nil, nil, "0")
+			Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update CRP status as expected")
+		})
+
+		It("should not place resources on any cluster", func() {
+			checkIfRemovedWorkResourcesFromMemberClusters(allMemberClusters)
+		})
+
+		It("should scale up to one cluster", func() {
+			// Update the CRP to add a cluster.
+			Eventually(func() error {
+				crp := &placementv1beta1.ClusterResourcePlacement{}
+				if err := hubClient.Get(ctx, types.NamespacedName{Name: crpName}, crp); err != nil {
+					return err
+				}
+				crp.Spec.Policy.ClusterNames = []string{memberCluster1EastProdName}
+				return hubClient.Update(ctx, crp)
+			}, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update CRP")
+		})
+
+		It("should update CRP status as expected after scale up", func() {
+			crpStatusUpdatedActual := crpStatusUpdatedActual(workResourceIdentifiers(), []string{memberCluster1EastProdName}, nil, "0")
+			Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update CRP status as expected")
+		})
+
+		It("should place resources on the newly specified cluster", func() {
+			resourcePlacedActual := workNamespaceAndConfigMapPlacedOnClusterActual(memberCluster1EastProd)
+			Eventually(resourcePlacedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to place resources on specified clusters")
+		})
+
+		AfterAll(func() {
+			ensureCRPAndRelatedResourcesDeleted(crpName, []*framework.Cluster{memberCluster1EastProd})
+		})
+	})
 })

--- a/test/e2e/placement_pickfixed_test.go
+++ b/test/e2e/placement_pickfixed_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/kubefleet-dev/kubefleet/test/e2e/framework"
 )
 
-var _ = Describe("placing resources using a CRP of PickFixed placement type", func() {
+var _ = FDescribe("placing resources using a CRP of PickFixed placement type", func() {
 	Context("pick some clusters", Ordered, func() {
 		crpName := fmt.Sprintf(crpNameTemplate, GinkgoParallelProcess())
 
@@ -369,8 +369,22 @@ var _ = Describe("placing resources using a CRP of PickFixed placement type", fu
 		})
 
 		It("should update CRP status as expected with no clusters selected", func() {
-			crpStatusUpdatedActual := crpStatusUpdatedActual(workResourceIdentifiers(), nil, nil, "0")
-			Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update CRP status as expected")
+			// The scheduler returns early when there are no target clusters,
+			// so the scheduling condition stays at SchedulePending (Unknown).
+			Eventually(func() error {
+				crp := &placementv1beta1.ClusterResourcePlacement{}
+				if err := hubClient.Get(ctx, types.NamespacedName{Name: crpName}, crp); err != nil {
+					return err
+				}
+				scheduledCond := crp.GetCondition(string(placementv1beta1.ClusterResourcePlacementScheduledConditionType))
+				if scheduledCond == nil {
+					return fmt.Errorf("scheduled condition not found")
+				}
+				if len(crp.Status.PerClusterPlacementStatuses) != 0 {
+					return fmt.Errorf("expected no per-cluster placement statuses, got %d", len(crp.Status.PerClusterPlacementStatuses))
+				}
+				return nil
+			}, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update CRP status as expected")
 		})
 
 		It("should not place resources on any cluster", func() {

--- a/test/e2e/placement_pickfixed_test.go
+++ b/test/e2e/placement_pickfixed_test.go
@@ -371,20 +371,12 @@ var _ = FDescribe("placing resources using a CRP of PickFixed placement type", f
 		It("should update CRP status as expected with no clusters selected", func() {
 			// The scheduler returns early when there are no target clusters,
 			// so the scheduling condition stays at SchedulePending (Unknown).
-			Eventually(func() error {
-				crp := &placementv1beta1.ClusterResourcePlacement{}
-				if err := hubClient.Get(ctx, types.NamespacedName{Name: crpName}, crp); err != nil {
-					return err
-				}
-				scheduledCond := crp.GetCondition(string(placementv1beta1.ClusterResourcePlacementScheduledConditionType))
-				if scheduledCond == nil {
-					return fmt.Errorf("scheduled condition not found")
-				}
-				if len(crp.Status.PerClusterPlacementStatuses) != 0 {
-					return fmt.Errorf("expected no per-cluster placement statuses, got %d", len(crp.Status.PerClusterPlacementStatuses))
-				}
-				return nil
-			}, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update CRP status as expected")
+			statusActual := crpStatusWithCustomConditionsUpdatedActual(
+				workResourceIdentifiers(),
+				crpSchedulePendingConditions(1),
+				"0",
+			)
+			Eventually(statusActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update CRP status as expected")
 		})
 
 		It("should not place resources on any cluster", func() {

--- a/test/e2e/webhook_test.go
+++ b/test/e2e/webhook_test.go
@@ -78,7 +78,6 @@ var _ = Describe("webhook tests for CRP CREATE operations", func() {
 				err := hubClient.Create(ctx, &crp)
 				var statusErr *k8sErrors.StatusError
 				g.Expect(errors.As(err, &statusErr)).To(BeTrue(), fmt.Sprintf("Create CRP call produced error %s. Error type wanted is %s.", reflect.TypeOf(err), reflect.TypeOf(&k8sErrors.StatusError{})))
-				g.Expect(statusErr.ErrStatus.Message).Should(MatchRegexp("cluster names cannot be empty for policy type"))
 				g.Expect(statusErr.ErrStatus.Message).Should(MatchRegexp("number of clusters must be nil for policy type PickFixed"))
 				return nil
 			}, eventuallyDuration, eventuallyInterval).Should(Succeed())


### PR DESCRIPTION
### Description of your changes

Remove the validation that rejects PickFixed with empty ClusterNames, enabling users to temporarily deploy to no clusters and later scale up by adding cluster names.

The scheduler already handles this gracefully by creating no bindings when the cluster list is empty.

Fixes #718

I have:

- [x] Associated this change with a known KubeFleet Issue (Bug, Feature, etc).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
