### PR TITLE
feat: refactor: use tree-based CEL building for the VAP manager (migrating to VAP 3/)

### DIFF
--- a/pkg/admissionpolicymanager/cel.go
+++ b/pkg/admissionpolicymanager/cel.go
@@ -1,0 +1,194 @@
+/*
+Copyright 2026 The KubeFleet Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admissionpolicymanager
+
+import (
+	"fmt"
+	"strings"
+)
+
+// CELExprTreeNode is the interface for CEL tree nodes. It helps build CEL expressions in a
+// structured way.
+type CELExprTreeNode interface {
+	// Parse returns the CEL expression represented by the node and its children.
+	Parse() (string, error)
+	// Children returns the child nodes of the current node.
+	Children() []CELExprTreeNode
+}
+
+// CELExprTreeEditableNode is the interface for CEL tree nodes that can be edited (i.e., have child nodes added to them).
+//
+// This is added to simplify cases where a CEL tree node need to be built step-by-step.
+type CELExprTreeEditableNode interface {
+	CELExprTreeNode
+	// Add adds a child node to the current node.
+	Add(child CELExprTreeNode)
+}
+
+var (
+	// Verify that all node types implement the CELExprTreeNode interface.
+	_ CELExprTreeNode = &rawCELExprTreeNode{}
+	_ CELExprTreeNode = &orCELExprTreeNode{}
+	_ CELExprTreeNode = &andCELExprTreeNode{}
+	_ CELExprTreeNode = &notCELExprTreeNode{}
+
+	_ CELExprTreeEditableNode = &orCELExprTreeNode{}
+	_ CELExprTreeEditableNode = &andCELExprTreeNode{}
+)
+
+// rawCELExprTreeNode represents a raw CEL expression. It is a leaf node in the CEL expression tree.
+type rawCELExprTreeNode struct {
+	expr string
+}
+
+// Parse returns the raw CEL expression.
+func (n *rawCELExprTreeNode) Parse() (string, error) {
+	if len(n.expr) == 0 {
+		return "", fmt.Errorf("raw CEL expression cannot be empty")
+	}
+	return n.expr, nil
+}
+
+// Children returns the child nodes of the current node.
+//
+// For rawCELExprTreeNode, it always returns nil.
+func (n *rawCELExprTreeNode) Children() []CELExprTreeNode {
+	return nil
+}
+
+// RawCELExpr returns a new rawCELExprTreeNode with the given expression.
+func RawCELExpr(expr string) CELExprTreeNode {
+	return &rawCELExprTreeNode{expr: expr}
+}
+
+// orCELExprTreeNode represents a logical OR of its child nodes' expressions.
+type orCELExprTreeNode struct {
+	children []CELExprTreeNode
+}
+
+// Parse returns the CEL expression representing the logical OR of its child nodes' expressions.
+func (n *orCELExprTreeNode) Parse() (string, error) {
+	exprs := make([]string, len(n.children))
+	for i, child := range n.children {
+		if child == nil {
+			return "", fmt.Errorf("a child node is nil")
+		}
+		expr, err := child.Parse()
+		if err != nil {
+			return "", fmt.Errorf("failed to parse child node: %w", err)
+		}
+		if len(expr) == 0 {
+			return "", fmt.Errorf("a child node parsed to an empty expression")
+		}
+		exprs[i] = fmt.Sprintf("(%s)", expr)
+	}
+
+	res := strings.Join(exprs, " || ")
+	if len(res) == 0 {
+		return "", fmt.Errorf("parsed to an empty expression")
+	}
+	return res, nil
+}
+
+// Children returns the child nodes of the current node.
+func (n *orCELExprTreeNode) Children() []CELExprTreeNode {
+	return n.children
+}
+
+// Add adds a child node to the current node.
+func (n *orCELExprTreeNode) Add(child CELExprTreeNode) {
+	n.children = append(n.children, child)
+}
+
+// LogicalOr returns a new orCELExprTreeNode with the given child nodes.
+func LogicalOr(children ...CELExprTreeNode) CELExprTreeEditableNode {
+	return &orCELExprTreeNode{children: children}
+}
+
+// andCELExprTreeNode represents a logical AND of its child nodes' expressions.
+type andCELExprTreeNode struct {
+	children []CELExprTreeNode
+}
+
+// Parse returns the CEL expression representing the logical AND of its child nodes' expressions.
+func (n *andCELExprTreeNode) Parse() (string, error) {
+	exprs := make([]string, len(n.children))
+	for i, child := range n.children {
+		if child == nil {
+			return "", fmt.Errorf("a child node is nil")
+		}
+		expr, err := child.Parse()
+		if err != nil {
+			return "", fmt.Errorf("failed to parse child node: %w", err)
+		}
+		if len(expr) == 0 {
+			return "", fmt.Errorf("a child node parsed to an empty expression")
+		}
+		exprs[i] = fmt.Sprintf("(%s)", expr)
+	}
+
+	res := strings.Join(exprs, " && ")
+	if len(res) == 0 {
+		return "", fmt.Errorf("parsed to an empty expression")
+	}
+	return res, nil
+}
+
+// Children returns the child nodes of the current node.
+func (n *andCELExprTreeNode) Children() []CELExprTreeNode {
+	return n.children
+}
+
+// Add adds a child node to the current node.
+func (n *andCELExprTreeNode) Add(child CELExprTreeNode) {
+	n.children = append(n.children, child)
+}
+
+// LogicalAnd returns a new andCELExprTreeNode with the given child nodes.
+func LogicalAnd(children ...CELExprTreeNode) CELExprTreeEditableNode {
+	return &andCELExprTreeNode{children: children}
+}
+
+// notCELExprTreeNode represents a logical NOT of its child node's expression.
+type notCELExprTreeNode struct {
+	child CELExprTreeNode
+}
+
+// Parse returns the CEL expression representing the logical NOT of its child node's expression.
+func (n *notCELExprTreeNode) Parse() (string, error) {
+	if n.child == nil {
+		return "", fmt.Errorf("child node is nil")
+	}
+	expr, err := n.child.Parse()
+	if err != nil {
+		return "", fmt.Errorf("failed to parse child node: %w", err)
+	}
+	if len(expr) == 0 {
+		return "", fmt.Errorf("child node parsed to an empty expression")
+	}
+	return fmt.Sprintf("!(%s)", expr), nil
+}
+
+// Children returns the child node of the current node.
+func (n *notCELExprTreeNode) Children() []CELExprTreeNode {
+	return []CELExprTreeNode{n.child}
+}
+
+// LogicalNot returns a new notCELExprTreeNode with the given child node.
+func LogicalNot(child CELExprTreeNode) CELExprTreeNode {
+	return &notCELExprTreeNode{child: child}
+}

--- a/pkg/admissionpolicymanager/cel.go
+++ b/pkg/admissionpolicymanager/cel.go
@@ -24,8 +24,8 @@ import (
 // CELExprTreeNode is the interface for CEL tree nodes. It helps build CEL expressions in a
 // structured way.
 type CELExprTreeNode interface {
-	// Parse returns the CEL expression represented by the node and its children.
-	Parse() (string, error)
+	// Build returns the CEL expression represented by the node and its children.
+	Build() (string, error)
 	// Children returns the child nodes of the current node.
 	Children() []CELExprTreeNode
 }
@@ -55,8 +55,8 @@ type rawCELExprTreeNode struct {
 	expr string
 }
 
-// Parse returns the raw CEL expression.
-func (n *rawCELExprTreeNode) Parse() (string, error) {
+// Build returns the raw CEL expression.
+func (n *rawCELExprTreeNode) Build() (string, error) {
 	if len(n.expr) == 0 {
 		return "", fmt.Errorf("raw CEL expression cannot be empty")
 	}
@@ -80,26 +80,26 @@ type orCELExprTreeNode struct {
 	children []CELExprTreeNode
 }
 
-// Parse returns the CEL expression representing the logical OR of its child nodes' expressions.
-func (n *orCELExprTreeNode) Parse() (string, error) {
+// Build returns the CEL expression representing the logical OR of its child nodes' expressions.
+func (n *orCELExprTreeNode) Build() (string, error) {
 	exprs := make([]string, len(n.children))
 	for i, child := range n.children {
 		if child == nil {
 			return "", fmt.Errorf("a child node is nil")
 		}
-		expr, err := child.Parse()
+		expr, err := child.Build()
 		if err != nil {
-			return "", fmt.Errorf("failed to parse child node: %w", err)
+			return "", fmt.Errorf("failed to build child node: %w", err)
 		}
 		if len(expr) == 0 {
-			return "", fmt.Errorf("a child node parsed to an empty expression")
+			return "", fmt.Errorf("a child node built to an empty expression")
 		}
 		exprs[i] = fmt.Sprintf("(%s)", expr)
 	}
 
 	res := strings.Join(exprs, " || ")
 	if len(res) == 0 {
-		return "", fmt.Errorf("parsed to an empty expression")
+		return "", fmt.Errorf("built to an empty expression")
 	}
 	return res, nil
 }
@@ -124,26 +124,26 @@ type andCELExprTreeNode struct {
 	children []CELExprTreeNode
 }
 
-// Parse returns the CEL expression representing the logical AND of its child nodes' expressions.
-func (n *andCELExprTreeNode) Parse() (string, error) {
+// Build returns the CEL expression representing the logical AND of its child nodes' expressions.
+func (n *andCELExprTreeNode) Build() (string, error) {
 	exprs := make([]string, len(n.children))
 	for i, child := range n.children {
 		if child == nil {
 			return "", fmt.Errorf("a child node is nil")
 		}
-		expr, err := child.Parse()
+		expr, err := child.Build()
 		if err != nil {
-			return "", fmt.Errorf("failed to parse child node: %w", err)
+			return "", fmt.Errorf("failed to build child node: %w", err)
 		}
 		if len(expr) == 0 {
-			return "", fmt.Errorf("a child node parsed to an empty expression")
+			return "", fmt.Errorf("a child node built to an empty expression")
 		}
 		exprs[i] = fmt.Sprintf("(%s)", expr)
 	}
 
 	res := strings.Join(exprs, " && ")
 	if len(res) == 0 {
-		return "", fmt.Errorf("parsed to an empty expression")
+		return "", fmt.Errorf("built to an empty expression")
 	}
 	return res, nil
 }
@@ -168,17 +168,17 @@ type notCELExprTreeNode struct {
 	child CELExprTreeNode
 }
 
-// Parse returns the CEL expression representing the logical NOT of its child node's expression.
-func (n *notCELExprTreeNode) Parse() (string, error) {
+// Build returns the CEL expression representing the logical NOT of its child node's expression.
+func (n *notCELExprTreeNode) Build() (string, error) {
 	if n.child == nil {
 		return "", fmt.Errorf("child node is nil")
 	}
-	expr, err := n.child.Parse()
+	expr, err := n.child.Build()
 	if err != nil {
-		return "", fmt.Errorf("failed to parse child node: %w", err)
+		return "", fmt.Errorf("failed to build child node: %w", err)
 	}
 	if len(expr) == 0 {
-		return "", fmt.Errorf("child node parsed to an empty expression")
+		return "", fmt.Errorf("child node built to an empty expression")
 	}
 	return fmt.Sprintf("!(%s)", expr), nil
 }

--- a/pkg/admissionpolicymanager/cel_test.go
+++ b/pkg/admissionpolicymanager/cel_test.go
@@ -154,7 +154,7 @@ func TestCELExprTreeNode_LogicalOr_Erred(t *testing.T) {
 		{
 			name:             "no children",
 			children:         nil,
-			wantErrSubstring: "parsed to an empty expression",
+			wantErrSubstring: "built to an empty expression",
 		},
 		{
 			name:             "nil child",
@@ -336,7 +336,7 @@ func TestCELExprTreeNode_LogicalAnd_Erred(t *testing.T) {
 		{
 			name:             "no children",
 			children:         nil,
-			wantErrSubstring: "parsed to an empty expression",
+			wantErrSubstring: "built to an empty expression",
 		},
 		{
 			name:             "nil child",

--- a/pkg/admissionpolicymanager/cel_test.go
+++ b/pkg/admissionpolicymanager/cel_test.go
@@ -28,20 +28,20 @@ func TestCELExprTreeNode_Raw(t *testing.T) {
 	testCases := []struct {
 		name             string
 		expr             string
-		wantParsed       string
+		wantBuilt        string
 		wantErred        bool
 		wantErrSubstring string
 	}{
 		{
-			name:       "valid",
-			expr:       "x = y",
-			wantParsed: "x = y",
-			wantErred:  false,
+			name:      "valid",
+			expr:      "x = y",
+			wantBuilt: "x = y",
+			wantErred: false,
 		},
 		{
 			name:             "empty expression",
 			expr:             "",
-			wantParsed:       "",
+			wantBuilt:        "",
 			wantErred:        true,
 			wantErrSubstring: "raw CEL expression cannot be empty",
 		},
@@ -51,21 +51,21 @@ func TestCELExprTreeNode_Raw(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			node := RawCELExpr(tc.expr)
 
-			gotParsed, err := node.Parse()
+			gotBuilt, err := node.Build()
 			if tc.wantErred {
 				if err == nil {
-					t.Fatal("Parse() = nil, want erred")
+					t.Fatal("Build() = nil, want erred")
 				}
 				if !strings.Contains(err.Error(), tc.wantErrSubstring) {
-					t.Errorf("Parse() error = %v, want error with substring %s", err, tc.wantErrSubstring)
+					t.Errorf("Build() error = %v, want error with substring %s", err, tc.wantErrSubstring)
 				}
 				return
 			}
 			if err != nil {
-				t.Fatalf("Parse() = %v, want no error", err)
+				t.Fatalf("Build() = %v, want no error", err)
 			}
-			if !cmp.Equal(gotParsed, tc.wantParsed) {
-				t.Errorf("Parse() = %v, want %v", gotParsed, tc.wantParsed)
+			if !cmp.Equal(gotBuilt, tc.wantBuilt) {
+				t.Errorf("Build() = %v, want %v", gotBuilt, tc.wantBuilt)
 			}
 
 			gotChildren := node.Children()
@@ -82,13 +82,13 @@ func TestCELExprTreeNode_LogicalOr(t *testing.T) {
 	testCases := []struct {
 		name         string
 		children     []CELExprTreeNode
-		wantParsed   string
+		wantBuilt    string
 		wantChildren []CELExprTreeNode
 	}{
 		{
 			name:         "single child",
 			children:     []CELExprTreeNode{RawCELExpr("x = y")},
-			wantParsed:   "(x = y)",
+			wantBuilt:    "(x = y)",
 			wantChildren: []CELExprTreeNode{RawCELExpr("x = y")},
 		},
 		{
@@ -98,7 +98,7 @@ func TestCELExprTreeNode_LogicalOr(t *testing.T) {
 				RawCELExpr("y = z"),
 				RawCELExpr("z = a"),
 			},
-			wantParsed: "(x = y) || (y = z) || (z = a)",
+			wantBuilt: "(x = y) || (y = z) || (z = a)",
 			wantChildren: []CELExprTreeNode{
 				RawCELExpr("x = y"),
 				RawCELExpr("y = z"),
@@ -111,7 +111,7 @@ func TestCELExprTreeNode_LogicalOr(t *testing.T) {
 				RawCELExpr("x = y"),
 				LogicalAnd(RawCELExpr("y = z"), RawCELExpr("z = a")),
 			},
-			wantParsed: "(x = y) || ((y = z) && (z = a))",
+			wantBuilt: "(x = y) || ((y = z) && (z = a))",
 			wantChildren: []CELExprTreeNode{
 				RawCELExpr("x = y"),
 				LogicalAnd(RawCELExpr("y = z"), RawCELExpr("z = a")),
@@ -123,12 +123,12 @@ func TestCELExprTreeNode_LogicalOr(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			node := LogicalOr(tc.children...)
 
-			gotParsed, err := node.Parse()
+			gotBuilt, err := node.Build()
 			if err != nil {
-				t.Fatalf("Parse() = %v", err)
+				t.Fatalf("Build() = %v", err)
 			}
-			if !cmp.Equal(gotParsed, tc.wantParsed) {
-				t.Errorf("Parse() = %v, want %v", gotParsed, tc.wantParsed)
+			if !cmp.Equal(gotBuilt, tc.wantBuilt) {
+				t.Errorf("Build() = %v, want %v", gotBuilt, tc.wantBuilt)
 			}
 
 			gotChildren := node.Children()
@@ -164,7 +164,7 @@ func TestCELExprTreeNode_LogicalOr_Erred(t *testing.T) {
 		{
 			name:             "child parse error",
 			children:         []CELExprTreeNode{RawCELExpr("x = y"), RawCELExpr("")},
-			wantErrSubstring: "failed to parse child node: raw CEL expression cannot be empty",
+			wantErrSubstring: "failed to build child node: raw CEL expression cannot be empty",
 		},
 	}
 
@@ -172,15 +172,15 @@ func TestCELExprTreeNode_LogicalOr_Erred(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			node := LogicalOr(tc.children...)
 
-			gotParsed, err := node.Parse()
+			gotBuilt, err := node.Build()
 			if err == nil {
-				t.Fatalf("Parse() = nil, want error")
+				t.Fatalf("Build() = nil, want error")
 			}
 			if !strings.Contains(err.Error(), tc.wantErrSubstring) {
-				t.Errorf("Parse() error = %v, want error with substring %s", err, tc.wantErrSubstring)
+				t.Errorf("Build() error = %v, want error with substring %s", err, tc.wantErrSubstring)
 			}
-			if gotParsed != "" {
-				t.Errorf("Parse() = %v, want empty string on error", gotParsed)
+			if gotBuilt != "" {
+				t.Errorf("Build() = %v, want empty string on error", gotBuilt)
 			}
 		})
 	}
@@ -191,7 +191,7 @@ func TestCELExprTreeNode_LogicalOr_Add(t *testing.T) {
 	testCases := []struct {
 		name             string
 		childrenToAdd    []CELExprTreeNode
-		wantParsed       string
+		wantBuilt        string
 		wantChildren     []CELExprTreeNode
 		wantErred        bool
 		wantErrSubstring string
@@ -199,14 +199,14 @@ func TestCELExprTreeNode_LogicalOr_Add(t *testing.T) {
 		{
 			name:          "append valid children",
 			childrenToAdd: []CELExprTreeNode{RawCELExpr("x = y"), RawCELExpr("y = z")},
-			wantParsed:    "(x = y) || (y = z)",
+			wantBuilt:     "(x = y) || (y = z)",
 			wantChildren:  []CELExprTreeNode{RawCELExpr("x = y"), RawCELExpr("y = z")},
 			wantErred:     false,
 		},
 		{
 			name:             "append nil child",
 			childrenToAdd:    []CELExprTreeNode{RawCELExpr("x = y"), nil},
-			wantParsed:       "",
+			wantBuilt:        "",
 			wantChildren:     []CELExprTreeNode{RawCELExpr("x = y"), nil},
 			wantErred:        true,
 			wantErrSubstring: "a child node is nil",
@@ -214,10 +214,10 @@ func TestCELExprTreeNode_LogicalOr_Add(t *testing.T) {
 		{
 			name:             "append child that fails parse",
 			childrenToAdd:    []CELExprTreeNode{RawCELExpr("x = y"), RawCELExpr("")},
-			wantParsed:       "",
+			wantBuilt:        "",
 			wantChildren:     []CELExprTreeNode{RawCELExpr("x = y"), RawCELExpr("")},
 			wantErred:        true,
-			wantErrSubstring: "failed to parse child node: raw CEL expression cannot be empty",
+			wantErrSubstring: "failed to build child node: raw CEL expression cannot be empty",
 		},
 	}
 
@@ -229,20 +229,20 @@ func TestCELExprTreeNode_LogicalOr_Add(t *testing.T) {
 				orNode.Add(child)
 			}
 
-			gotParsed, err := orNode.Parse()
+			gotBuilt, err := orNode.Build()
 			if tc.wantErred {
 				if err == nil {
-					t.Fatal("Parse() = nil, want erred")
+					t.Fatal("Build() = nil, want erred")
 				}
 				if !strings.Contains(err.Error(), tc.wantErrSubstring) {
-					t.Errorf("Parse() error = %v, want error with substring %s", err, tc.wantErrSubstring)
+					t.Errorf("Build() error = %v, want error with substring %s", err, tc.wantErrSubstring)
 				}
 			} else {
 				if err != nil {
-					t.Fatalf("Parse() = %v, want no error", err)
+					t.Fatalf("Build() = %v, want no error", err)
 				}
-				if !cmp.Equal(gotParsed, tc.wantParsed) {
-					t.Errorf("Parse() = %v, want %v", gotParsed, tc.wantParsed)
+				if !cmp.Equal(gotBuilt, tc.wantBuilt) {
+					t.Errorf("Build() = %v, want %v", gotBuilt, tc.wantBuilt)
 				}
 			}
 
@@ -264,13 +264,13 @@ func TestCELExprTreeNode_LogicalAnd(t *testing.T) {
 	testCases := []struct {
 		name         string
 		children     []CELExprTreeNode
-		wantParsed   string
+		wantBuilt    string
 		wantChildren []CELExprTreeNode
 	}{
 		{
 			name:         "single child",
 			children:     []CELExprTreeNode{RawCELExpr("x = y")},
-			wantParsed:   "(x = y)",
+			wantBuilt:    "(x = y)",
 			wantChildren: []CELExprTreeNode{RawCELExpr("x = y")},
 		},
 		{
@@ -280,7 +280,7 @@ func TestCELExprTreeNode_LogicalAnd(t *testing.T) {
 				RawCELExpr("y = z"),
 				RawCELExpr("z = a"),
 			},
-			wantParsed: "(x = y) && (y = z) && (z = a)",
+			wantBuilt: "(x = y) && (y = z) && (z = a)",
 			wantChildren: []CELExprTreeNode{
 				RawCELExpr("x = y"),
 				RawCELExpr("y = z"),
@@ -293,7 +293,7 @@ func TestCELExprTreeNode_LogicalAnd(t *testing.T) {
 				RawCELExpr("x = y"),
 				LogicalOr(RawCELExpr("y = z"), RawCELExpr("z = a")),
 			},
-			wantParsed: "(x = y) && ((y = z) || (z = a))",
+			wantBuilt: "(x = y) && ((y = z) || (z = a))",
 			wantChildren: []CELExprTreeNode{
 				RawCELExpr("x = y"),
 				LogicalOr(RawCELExpr("y = z"), RawCELExpr("z = a")),
@@ -305,12 +305,12 @@ func TestCELExprTreeNode_LogicalAnd(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			node := LogicalAnd(tc.children...)
 
-			gotParsed, err := node.Parse()
+			gotBuilt, err := node.Build()
 			if err != nil {
-				t.Fatalf("Parse() = %v", err)
+				t.Fatalf("Build() = %v", err)
 			}
-			if !cmp.Equal(gotParsed, tc.wantParsed) {
-				t.Errorf("Parse() = %v, want %v", gotParsed, tc.wantParsed)
+			if !cmp.Equal(gotBuilt, tc.wantBuilt) {
+				t.Errorf("Build() = %v, want %v", gotBuilt, tc.wantBuilt)
 			}
 
 			gotChildren := node.Children()
@@ -346,7 +346,7 @@ func TestCELExprTreeNode_LogicalAnd_Erred(t *testing.T) {
 		{
 			name:             "child parse error",
 			children:         []CELExprTreeNode{RawCELExpr("x = y"), RawCELExpr("")},
-			wantErrSubstring: "failed to parse child node: raw CEL expression cannot be empty",
+			wantErrSubstring: "failed to build child node: raw CEL expression cannot be empty",
 		},
 	}
 
@@ -354,15 +354,15 @@ func TestCELExprTreeNode_LogicalAnd_Erred(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			node := LogicalAnd(tc.children...)
 
-			gotParsed, err := node.Parse()
+			gotBuilt, err := node.Build()
 			if err == nil {
-				t.Fatalf("Parse() = nil, want error")
+				t.Fatalf("Build() = nil, want error")
 			}
 			if !strings.Contains(err.Error(), tc.wantErrSubstring) {
-				t.Errorf("Parse() error = %v, want error with substring %s", err, tc.wantErrSubstring)
+				t.Errorf("Build() error = %v, want error with substring %s", err, tc.wantErrSubstring)
 			}
-			if gotParsed != "" {
-				t.Errorf("Parse() = %v, want empty string on error", gotParsed)
+			if gotBuilt != "" {
+				t.Errorf("Build() = %v, want empty string on error", gotBuilt)
 			}
 		})
 	}
@@ -373,7 +373,7 @@ func TestCELExprTreeNode_LogicalAnd_Add(t *testing.T) {
 	testCases := []struct {
 		name             string
 		childrenToAdd    []CELExprTreeNode
-		wantParsed       string
+		wantBuilt        string
 		wantChildren     []CELExprTreeNode
 		wantErred        bool
 		wantErrSubstring string
@@ -381,14 +381,14 @@ func TestCELExprTreeNode_LogicalAnd_Add(t *testing.T) {
 		{
 			name:          "append valid children",
 			childrenToAdd: []CELExprTreeNode{RawCELExpr("x = y"), RawCELExpr("y = z")},
-			wantParsed:    "(x = y) && (y = z)",
+			wantBuilt:     "(x = y) && (y = z)",
 			wantChildren:  []CELExprTreeNode{RawCELExpr("x = y"), RawCELExpr("y = z")},
 			wantErred:     false,
 		},
 		{
 			name:             "append nil child",
 			childrenToAdd:    []CELExprTreeNode{RawCELExpr("x = y"), nil},
-			wantParsed:       "",
+			wantBuilt:        "",
 			wantChildren:     []CELExprTreeNode{RawCELExpr("x = y"), nil},
 			wantErred:        true,
 			wantErrSubstring: "a child node is nil",
@@ -396,10 +396,10 @@ func TestCELExprTreeNode_LogicalAnd_Add(t *testing.T) {
 		{
 			name:             "append child that fails parse",
 			childrenToAdd:    []CELExprTreeNode{RawCELExpr("x = y"), RawCELExpr("")},
-			wantParsed:       "",
+			wantBuilt:        "",
 			wantChildren:     []CELExprTreeNode{RawCELExpr("x = y"), RawCELExpr("")},
 			wantErred:        true,
-			wantErrSubstring: "failed to parse child node: raw CEL expression cannot be empty",
+			wantErrSubstring: "failed to build child node: raw CEL expression cannot be empty",
 		},
 	}
 
@@ -411,20 +411,20 @@ func TestCELExprTreeNode_LogicalAnd_Add(t *testing.T) {
 				andNode.Add(child)
 			}
 
-			gotParsed, err := andNode.Parse()
+			gotBuilt, err := andNode.Build()
 			if tc.wantErred {
 				if err == nil {
-					t.Fatal("Parse() = nil, want erred")
+					t.Fatal("Build() = nil, want erred")
 				}
 				if !strings.Contains(err.Error(), tc.wantErrSubstring) {
-					t.Errorf("Parse() error = %v, want error with substring %s", err, tc.wantErrSubstring)
+					t.Errorf("Build() error = %v, want error with substring %s", err, tc.wantErrSubstring)
 				}
 			} else {
 				if err != nil {
-					t.Fatalf("Parse() = %v, want no error", err)
+					t.Fatalf("Build() = %v, want no error", err)
 				}
-				if !cmp.Equal(gotParsed, tc.wantParsed) {
-					t.Errorf("Parse() = %v, want %v", gotParsed, tc.wantParsed)
+				if !cmp.Equal(gotBuilt, tc.wantBuilt) {
+					t.Errorf("Build() = %v, want %v", gotBuilt, tc.wantBuilt)
 				}
 			}
 
@@ -446,25 +446,25 @@ func TestCELExprTreeNode_LogicalNot(t *testing.T) {
 	testCases := []struct {
 		name         string
 		child        CELExprTreeNode
-		wantParsed   string
+		wantBuilt    string
 		wantChildren []CELExprTreeNode
 	}{
 		{
 			name:         "raw child",
 			child:        RawCELExpr("x = y"),
-			wantParsed:   "!(x = y)",
+			wantBuilt:    "!(x = y)",
 			wantChildren: []CELExprTreeNode{RawCELExpr("x = y")},
 		},
 		{
 			name:         "and child",
 			child:        LogicalAnd(RawCELExpr("x = y"), RawCELExpr("y = z")),
-			wantParsed:   "!((x = y) && (y = z))",
+			wantBuilt:    "!((x = y) && (y = z))",
 			wantChildren: []CELExprTreeNode{LogicalAnd(RawCELExpr("x = y"), RawCELExpr("y = z"))},
 		},
 		{
 			name:         "or child",
 			child:        LogicalOr(RawCELExpr("x = y"), RawCELExpr("y = z")),
-			wantParsed:   "!((x = y) || (y = z))",
+			wantBuilt:    "!((x = y) || (y = z))",
 			wantChildren: []CELExprTreeNode{LogicalOr(RawCELExpr("x = y"), RawCELExpr("y = z"))},
 		},
 	}
@@ -473,12 +473,12 @@ func TestCELExprTreeNode_LogicalNot(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			node := LogicalNot(tc.child)
 
-			gotParsed, err := node.Parse()
+			gotBuilt, err := node.Build()
 			if err != nil {
-				t.Fatalf("Parse() = %v", err)
+				t.Fatalf("Build() = %v", err)
 			}
-			if !cmp.Equal(gotParsed, tc.wantParsed) {
-				t.Errorf("Parse() = %v, want %v", gotParsed, tc.wantParsed)
+			if !cmp.Equal(gotBuilt, tc.wantBuilt) {
+				t.Errorf("Build() = %v, want %v", gotBuilt, tc.wantBuilt)
 			}
 
 			gotChildren := node.Children()
@@ -509,7 +509,7 @@ func TestCELExprTreeNode_LogicalNot_Erred(t *testing.T) {
 		{
 			name:             "child parse error",
 			child:            RawCELExpr(""),
-			wantErrSubstring: "failed to parse child node: raw CEL expression cannot be empty",
+			wantErrSubstring: "failed to build child node: raw CEL expression cannot be empty",
 		},
 	}
 
@@ -517,15 +517,15 @@ func TestCELExprTreeNode_LogicalNot_Erred(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			node := LogicalNot(tc.child)
 
-			gotParsed, err := node.Parse()
+			gotBuilt, err := node.Build()
 			if err == nil {
-				t.Fatalf("Parse() = nil, want error")
+				t.Fatalf("Build() = nil, want error")
 			}
 			if !strings.Contains(err.Error(), tc.wantErrSubstring) {
-				t.Errorf("Parse() error = %v, want error with substring %s", err, tc.wantErrSubstring)
+				t.Errorf("Build() error = %v, want error with substring %s", err, tc.wantErrSubstring)
 			}
-			if gotParsed != "" {
-				t.Errorf("Parse() = %v, want empty string on error", gotParsed)
+			if gotBuilt != "" {
+				t.Errorf("Build() = %v, want empty string on error", gotBuilt)
 			}
 		})
 	}

--- a/pkg/admissionpolicymanager/cel_test.go
+++ b/pkg/admissionpolicymanager/cel_test.go
@@ -1,0 +1,532 @@
+/*
+Copyright 2026 The KubeFleet Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admissionpolicymanager
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// TestCELExprTreeNode_Raw tests the RawCELExprTreeNode implementation of the CELExprTreeNode interface.
+func TestCELExprTreeNode_Raw(t *testing.T) {
+	testCases := []struct {
+		name             string
+		expr             string
+		wantParsed       string
+		wantErred        bool
+		wantErrSubstring string
+	}{
+		{
+			name:       "valid",
+			expr:       "x = y",
+			wantParsed: "x = y",
+			wantErred:  false,
+		},
+		{
+			name:             "empty expression",
+			expr:             "",
+			wantParsed:       "",
+			wantErred:        true,
+			wantErrSubstring: "raw CEL expression cannot be empty",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			node := RawCELExpr(tc.expr)
+
+			gotParsed, err := node.Parse()
+			if tc.wantErred {
+				if err == nil {
+					t.Fatal("Parse() = nil, want erred")
+				}
+				if !strings.Contains(err.Error(), tc.wantErrSubstring) {
+					t.Errorf("Parse() error = %v, want error with substring %s", err, tc.wantErrSubstring)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Parse() = %v, want no error", err)
+			}
+			if !cmp.Equal(gotParsed, tc.wantParsed) {
+				t.Errorf("Parse() = %v, want %v", gotParsed, tc.wantParsed)
+			}
+
+			gotChildren := node.Children()
+			wantChildren := []CELExprTreeNode(nil)
+			if !cmp.Equal(gotChildren, wantChildren) {
+				t.Errorf("Children() = %v, want %v", gotChildren, wantChildren)
+			}
+		})
+	}
+}
+
+// TestCELExprTreeNode_LogicalOr tests the orCELExprTreeNode implementation of the CELExprTreeNode interface.
+func TestCELExprTreeNode_LogicalOr(t *testing.T) {
+	testCases := []struct {
+		name         string
+		children     []CELExprTreeNode
+		wantParsed   string
+		wantChildren []CELExprTreeNode
+	}{
+		{
+			name:         "single child",
+			children:     []CELExprTreeNode{RawCELExpr("x = y")},
+			wantParsed:   "(x = y)",
+			wantChildren: []CELExprTreeNode{RawCELExpr("x = y")},
+		},
+		{
+			name: "multiple children",
+			children: []CELExprTreeNode{
+				RawCELExpr("x = y"),
+				RawCELExpr("y = z"),
+				RawCELExpr("z = a"),
+			},
+			wantParsed: "(x = y) || (y = z) || (z = a)",
+			wantChildren: []CELExprTreeNode{
+				RawCELExpr("x = y"),
+				RawCELExpr("y = z"),
+				RawCELExpr("z = a"),
+			},
+		},
+		{
+			name: "nested child",
+			children: []CELExprTreeNode{
+				RawCELExpr("x = y"),
+				LogicalAnd(RawCELExpr("y = z"), RawCELExpr("z = a")),
+			},
+			wantParsed: "(x = y) || ((y = z) && (z = a))",
+			wantChildren: []CELExprTreeNode{
+				RawCELExpr("x = y"),
+				LogicalAnd(RawCELExpr("y = z"), RawCELExpr("z = a")),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			node := LogicalOr(tc.children...)
+
+			gotParsed, err := node.Parse()
+			if err != nil {
+				t.Fatalf("Parse() = %v", err)
+			}
+			if !cmp.Equal(gotParsed, tc.wantParsed) {
+				t.Errorf("Parse() = %v, want %v", gotParsed, tc.wantParsed)
+			}
+
+			gotChildren := node.Children()
+			if !cmp.Equal(gotChildren, tc.wantChildren,
+				cmp.AllowUnexported(rawCELExprTreeNode{}),
+				cmp.AllowUnexported(andCELExprTreeNode{}),
+				cmp.AllowUnexported(orCELExprTreeNode{}),
+				cmp.AllowUnexported(notCELExprTreeNode{}),
+			) {
+				t.Errorf("Children() = %v, want %v", gotChildren, tc.wantChildren)
+			}
+		})
+	}
+}
+
+// TestCELExprTreeNode_LogicalOr_Erred tests LogicalOr error scenarios.
+func TestCELExprTreeNode_LogicalOr_Erred(t *testing.T) {
+	testCases := []struct {
+		name             string
+		children         []CELExprTreeNode
+		wantErrSubstring string
+	}{
+		{
+			name:             "no children",
+			children:         nil,
+			wantErrSubstring: "parsed to an empty expression",
+		},
+		{
+			name:             "nil child",
+			children:         []CELExprTreeNode{RawCELExpr("x = y"), nil},
+			wantErrSubstring: "a child node is nil",
+		},
+		{
+			name:             "child parse error",
+			children:         []CELExprTreeNode{RawCELExpr("x = y"), RawCELExpr("")},
+			wantErrSubstring: "failed to parse child node: raw CEL expression cannot be empty",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			node := LogicalOr(tc.children...)
+
+			gotParsed, err := node.Parse()
+			if err == nil {
+				t.Fatalf("Parse() = nil, want error")
+			}
+			if !strings.Contains(err.Error(), tc.wantErrSubstring) {
+				t.Errorf("Parse() error = %v, want error with substring %s", err, tc.wantErrSubstring)
+			}
+			if gotParsed != "" {
+				t.Errorf("Parse() = %v, want empty string on error", gotParsed)
+			}
+		})
+	}
+}
+
+// TestCELExprTreeNode_LogicalOr_Add tests Add behavior for LogicalOr nodes.
+func TestCELExprTreeNode_LogicalOr_Add(t *testing.T) {
+	testCases := []struct {
+		name             string
+		childrenToAdd    []CELExprTreeNode
+		wantParsed       string
+		wantChildren     []CELExprTreeNode
+		wantErred        bool
+		wantErrSubstring string
+	}{
+		{
+			name:          "append valid children",
+			childrenToAdd: []CELExprTreeNode{RawCELExpr("x = y"), RawCELExpr("y = z")},
+			wantParsed:    "(x = y) || (y = z)",
+			wantChildren:  []CELExprTreeNode{RawCELExpr("x = y"), RawCELExpr("y = z")},
+			wantErred:     false,
+		},
+		{
+			name:             "append nil child",
+			childrenToAdd:    []CELExprTreeNode{RawCELExpr("x = y"), nil},
+			wantParsed:       "",
+			wantChildren:     []CELExprTreeNode{RawCELExpr("x = y"), nil},
+			wantErred:        true,
+			wantErrSubstring: "a child node is nil",
+		},
+		{
+			name:             "append child that fails parse",
+			childrenToAdd:    []CELExprTreeNode{RawCELExpr("x = y"), RawCELExpr("")},
+			wantParsed:       "",
+			wantChildren:     []CELExprTreeNode{RawCELExpr("x = y"), RawCELExpr("")},
+			wantErred:        true,
+			wantErrSubstring: "failed to parse child node: raw CEL expression cannot be empty",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			orNode := LogicalOr()
+
+			for _, child := range tc.childrenToAdd {
+				orNode.Add(child)
+			}
+
+			gotParsed, err := orNode.Parse()
+			if tc.wantErred {
+				if err == nil {
+					t.Fatal("Parse() = nil, want erred")
+				}
+				if !strings.Contains(err.Error(), tc.wantErrSubstring) {
+					t.Errorf("Parse() error = %v, want error with substring %s", err, tc.wantErrSubstring)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("Parse() = %v, want no error", err)
+				}
+				if !cmp.Equal(gotParsed, tc.wantParsed) {
+					t.Errorf("Parse() = %v, want %v", gotParsed, tc.wantParsed)
+				}
+			}
+
+			gotChildren := orNode.Children()
+			if !cmp.Equal(gotChildren, tc.wantChildren,
+				cmp.AllowUnexported(rawCELExprTreeNode{}),
+				cmp.AllowUnexported(andCELExprTreeNode{}),
+				cmp.AllowUnexported(orCELExprTreeNode{}),
+				cmp.AllowUnexported(notCELExprTreeNode{}),
+			) {
+				t.Errorf("Children() = %v, want %v", gotChildren, tc.wantChildren)
+			}
+		})
+	}
+}
+
+// TestCELExprTreeNode_LogicalAnd tests the andCELExprTreeNode implementation of the CELExprTreeNode interface.
+func TestCELExprTreeNode_LogicalAnd(t *testing.T) {
+	testCases := []struct {
+		name         string
+		children     []CELExprTreeNode
+		wantParsed   string
+		wantChildren []CELExprTreeNode
+	}{
+		{
+			name:         "single child",
+			children:     []CELExprTreeNode{RawCELExpr("x = y")},
+			wantParsed:   "(x = y)",
+			wantChildren: []CELExprTreeNode{RawCELExpr("x = y")},
+		},
+		{
+			name: "multiple children",
+			children: []CELExprTreeNode{
+				RawCELExpr("x = y"),
+				RawCELExpr("y = z"),
+				RawCELExpr("z = a"),
+			},
+			wantParsed: "(x = y) && (y = z) && (z = a)",
+			wantChildren: []CELExprTreeNode{
+				RawCELExpr("x = y"),
+				RawCELExpr("y = z"),
+				RawCELExpr("z = a"),
+			},
+		},
+		{
+			name: "nested child",
+			children: []CELExprTreeNode{
+				RawCELExpr("x = y"),
+				LogicalOr(RawCELExpr("y = z"), RawCELExpr("z = a")),
+			},
+			wantParsed: "(x = y) && ((y = z) || (z = a))",
+			wantChildren: []CELExprTreeNode{
+				RawCELExpr("x = y"),
+				LogicalOr(RawCELExpr("y = z"), RawCELExpr("z = a")),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			node := LogicalAnd(tc.children...)
+
+			gotParsed, err := node.Parse()
+			if err != nil {
+				t.Fatalf("Parse() = %v", err)
+			}
+			if !cmp.Equal(gotParsed, tc.wantParsed) {
+				t.Errorf("Parse() = %v, want %v", gotParsed, tc.wantParsed)
+			}
+
+			gotChildren := node.Children()
+			if !cmp.Equal(gotChildren, tc.wantChildren,
+				cmp.AllowUnexported(rawCELExprTreeNode{}),
+				cmp.AllowUnexported(andCELExprTreeNode{}),
+				cmp.AllowUnexported(orCELExprTreeNode{}),
+				cmp.AllowUnexported(notCELExprTreeNode{}),
+			) {
+				t.Errorf("Children() = %v, want %v", gotChildren, tc.wantChildren)
+			}
+		})
+	}
+}
+
+// TestCELExprTreeNode_LogicalAnd_Erred tests LogicalAnd error scenarios.
+func TestCELExprTreeNode_LogicalAnd_Erred(t *testing.T) {
+	testCases := []struct {
+		name             string
+		children         []CELExprTreeNode
+		wantErrSubstring string
+	}{
+		{
+			name:             "no children",
+			children:         nil,
+			wantErrSubstring: "parsed to an empty expression",
+		},
+		{
+			name:             "nil child",
+			children:         []CELExprTreeNode{RawCELExpr("x = y"), nil},
+			wantErrSubstring: "a child node is nil",
+		},
+		{
+			name:             "child parse error",
+			children:         []CELExprTreeNode{RawCELExpr("x = y"), RawCELExpr("")},
+			wantErrSubstring: "failed to parse child node: raw CEL expression cannot be empty",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			node := LogicalAnd(tc.children...)
+
+			gotParsed, err := node.Parse()
+			if err == nil {
+				t.Fatalf("Parse() = nil, want error")
+			}
+			if !strings.Contains(err.Error(), tc.wantErrSubstring) {
+				t.Errorf("Parse() error = %v, want error with substring %s", err, tc.wantErrSubstring)
+			}
+			if gotParsed != "" {
+				t.Errorf("Parse() = %v, want empty string on error", gotParsed)
+			}
+		})
+	}
+}
+
+// TestCELExprTreeNode_LogicalAnd_Add tests Add behavior for LogicalAnd nodes.
+func TestCELExprTreeNode_LogicalAnd_Add(t *testing.T) {
+	testCases := []struct {
+		name             string
+		childrenToAdd    []CELExprTreeNode
+		wantParsed       string
+		wantChildren     []CELExprTreeNode
+		wantErred        bool
+		wantErrSubstring string
+	}{
+		{
+			name:          "append valid children",
+			childrenToAdd: []CELExprTreeNode{RawCELExpr("x = y"), RawCELExpr("y = z")},
+			wantParsed:    "(x = y) && (y = z)",
+			wantChildren:  []CELExprTreeNode{RawCELExpr("x = y"), RawCELExpr("y = z")},
+			wantErred:     false,
+		},
+		{
+			name:             "append nil child",
+			childrenToAdd:    []CELExprTreeNode{RawCELExpr("x = y"), nil},
+			wantParsed:       "",
+			wantChildren:     []CELExprTreeNode{RawCELExpr("x = y"), nil},
+			wantErred:        true,
+			wantErrSubstring: "a child node is nil",
+		},
+		{
+			name:             "append child that fails parse",
+			childrenToAdd:    []CELExprTreeNode{RawCELExpr("x = y"), RawCELExpr("")},
+			wantParsed:       "",
+			wantChildren:     []CELExprTreeNode{RawCELExpr("x = y"), RawCELExpr("")},
+			wantErred:        true,
+			wantErrSubstring: "failed to parse child node: raw CEL expression cannot be empty",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			andNode := LogicalAnd()
+
+			for _, child := range tc.childrenToAdd {
+				andNode.Add(child)
+			}
+
+			gotParsed, err := andNode.Parse()
+			if tc.wantErred {
+				if err == nil {
+					t.Fatal("Parse() = nil, want erred")
+				}
+				if !strings.Contains(err.Error(), tc.wantErrSubstring) {
+					t.Errorf("Parse() error = %v, want error with substring %s", err, tc.wantErrSubstring)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("Parse() = %v, want no error", err)
+				}
+				if !cmp.Equal(gotParsed, tc.wantParsed) {
+					t.Errorf("Parse() = %v, want %v", gotParsed, tc.wantParsed)
+				}
+			}
+
+			gotChildren := andNode.Children()
+			if !cmp.Equal(gotChildren, tc.wantChildren,
+				cmp.AllowUnexported(rawCELExprTreeNode{}),
+				cmp.AllowUnexported(andCELExprTreeNode{}),
+				cmp.AllowUnexported(orCELExprTreeNode{}),
+				cmp.AllowUnexported(notCELExprTreeNode{}),
+			) {
+				t.Errorf("Children() = %v, want %v", gotChildren, tc.wantChildren)
+			}
+		})
+	}
+}
+
+// TestCELExprTreeNode_LogicalNot tests the notCELExprTreeNode implementation of the CELExprTreeNode interface.
+func TestCELExprTreeNode_LogicalNot(t *testing.T) {
+	testCases := []struct {
+		name         string
+		child        CELExprTreeNode
+		wantParsed   string
+		wantChildren []CELExprTreeNode
+	}{
+		{
+			name:         "raw child",
+			child:        RawCELExpr("x = y"),
+			wantParsed:   "!(x = y)",
+			wantChildren: []CELExprTreeNode{RawCELExpr("x = y")},
+		},
+		{
+			name:         "and child",
+			child:        LogicalAnd(RawCELExpr("x = y"), RawCELExpr("y = z")),
+			wantParsed:   "!((x = y) && (y = z))",
+			wantChildren: []CELExprTreeNode{LogicalAnd(RawCELExpr("x = y"), RawCELExpr("y = z"))},
+		},
+		{
+			name:         "or child",
+			child:        LogicalOr(RawCELExpr("x = y"), RawCELExpr("y = z")),
+			wantParsed:   "!((x = y) || (y = z))",
+			wantChildren: []CELExprTreeNode{LogicalOr(RawCELExpr("x = y"), RawCELExpr("y = z"))},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			node := LogicalNot(tc.child)
+
+			gotParsed, err := node.Parse()
+			if err != nil {
+				t.Fatalf("Parse() = %v", err)
+			}
+			if !cmp.Equal(gotParsed, tc.wantParsed) {
+				t.Errorf("Parse() = %v, want %v", gotParsed, tc.wantParsed)
+			}
+
+			gotChildren := node.Children()
+			if !cmp.Equal(gotChildren, tc.wantChildren,
+				cmp.AllowUnexported(rawCELExprTreeNode{}),
+				cmp.AllowUnexported(andCELExprTreeNode{}),
+				cmp.AllowUnexported(orCELExprTreeNode{}),
+				cmp.AllowUnexported(notCELExprTreeNode{}),
+			) {
+				t.Errorf("Children() = %v, want %v", gotChildren, tc.wantChildren)
+			}
+		})
+	}
+}
+
+// TestCELExprTreeNode_LogicalNot_Erred tests LogicalNot error scenarios.
+func TestCELExprTreeNode_LogicalNot_Erred(t *testing.T) {
+	testCases := []struct {
+		name             string
+		child            CELExprTreeNode
+		wantErrSubstring string
+	}{
+		{
+			name:             "nil child",
+			child:            nil,
+			wantErrSubstring: "child node is nil",
+		},
+		{
+			name:             "child parse error",
+			child:            RawCELExpr(""),
+			wantErrSubstring: "failed to parse child node: raw CEL expression cannot be empty",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			node := LogicalNot(tc.child)
+
+			gotParsed, err := node.Parse()
+			if err == nil {
+				t.Fatalf("Parse() = nil, want error")
+			}
+			if !strings.Contains(err.Error(), tc.wantErrSubstring) {
+				t.Errorf("Parse() error = %v, want error with substring %s", err, tc.wantErrSubstring)
+			}
+			if gotParsed != "" {
+				t.Errorf("Parse() = %v, want empty string on error", gotParsed)
+			}
+		})
+	}
+}

--- a/pkg/admissionpolicymanager/commons.go
+++ b/pkg/admissionpolicymanager/commons.go
@@ -18,6 +18,7 @@ package admissionpolicymanager
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -80,4 +81,16 @@ func validateCELStringLiterals(strs ...string) error {
 		}
 	}
 	return nil
+}
+
+func isInNamespaceWithPrefix(p string) CELExprTreeNode {
+	return RawCELExpr(fmt.Sprintf(`request.namespace.startsWith("%s")`, p))
+}
+
+func isFromUsername(u string) CELExprTreeNode {
+	return RawCELExpr(fmt.Sprintf(`request.userInfo.username == "%s"`, u))
+}
+
+func isFromUserGroup(g string) CELExprTreeNode {
+	return RawCELExpr(fmt.Sprintf(`"%s" in request.userInfo.groups`, g))
 }

--- a/pkg/admissionpolicymanager/manager.go
+++ b/pkg/admissionpolicymanager/manager.go
@@ -88,7 +88,7 @@ type PolicyWithBindings struct {
 type ValidatingAdmissionPolicyGenerator interface {
 	Name() string
 	Validate() error
-	PoliciesWithBindings() []PolicyWithBindings
+	PoliciesWithBindings() ([]PolicyWithBindings, error)
 }
 
 type PolicyManager struct {
@@ -165,7 +165,10 @@ func (m *PolicyManager) createOrUpdatePoliciesAndBindingsForEnabledGenerators(ct
 			return nil, nil, errors.Wraps(err, "policy generator is invalid", "generator", gen.Name())
 		}
 
-		policiesWithBindings := gen.PoliciesWithBindings()
+		policiesWithBindings, err := gen.PoliciesWithBindings()
+		if err != nil {
+			return nil, nil, errors.Wraps(err, "failed to build policies with bindings", "generator", gen.Name())
+		}
 
 		for _, pb := range policiesWithBindings {
 			policy := pb.Policy

--- a/pkg/admissionpolicymanager/manager_integration_test.go
+++ b/pkg/admissionpolicymanager/manager_integration_test.go
@@ -111,7 +111,7 @@ var _ = Describe("Policies, Policy Bindings and their Effects", Ordered, func() 
 					},
 					Validations: []admissionregistrationv1.Validation{
 						{
-							Expression: `request.namespace.startsWith("fleet-") || request.namespace.startsWith("kube-")`,
+							Expression: `(request.namespace.startsWith("fleet-")) || (request.namespace.startsWith("kube-"))`,
 							Message:    "creating pods and replicas is disallowed in the fleet hub cluster",
 							Reason:     ptr.To(metav1.StatusReasonForbidden),
 						},
@@ -166,7 +166,7 @@ var _ = Describe("Policies, Policy Bindings and their Effects", Ordered, func() 
 					},
 					Validations: []admissionregistrationv1.Validation{
 						{
-							Expression: `!(request.namespace.startsWith("fleet-") || request.namespace.startsWith("kube-")) || (request.userInfo.username == "system:kube-scheduler" || request.userInfo.username == "system:kube-controller-manager" || "system:nodes" in request.userInfo.groups || "system:masters" in request.userInfo.groups || "kubeadm:cluster-admins" in request.userInfo.groups || "system:serviceaccounts" in request.userInfo.groups)`,
+							Expression: `(!((request.namespace.startsWith("fleet-")) || (request.namespace.startsWith("kube-")))) || ((request.userInfo.username == "system:kube-scheduler") || (request.userInfo.username == "system:kube-controller-manager") || ("system:nodes" in request.userInfo.groups) || ("system:masters" in request.userInfo.groups) || ("kubeadm:cluster-admins" in request.userInfo.groups) || ("system:serviceaccounts" in request.userInfo.groups))`,
 							Message:    "writing service accounts in reserved namespaces or requesting tokens from such service accounts is disallowed",
 							Reason:     ptr.To(metav1.StatusReasonForbidden),
 						},

--- a/pkg/admissionpolicymanager/podsnreplicasets.go
+++ b/pkg/admissionpolicymanager/podsnreplicasets.go
@@ -20,9 +20,6 @@ limitations under the License.
 package admissionpolicymanager
 
 import (
-	"fmt"
-	"strings"
-
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -73,12 +70,16 @@ func (g *PodsAndReplicaSetsValidatingAdmissionPolicyGenerator) Validate() error 
 // replicasets in non-reserved namespaces.
 //
 // For simplicity reasons, the code here assumes that the generator has been validated before PoliciesWithBindings() is called.
-func (g *PodsAndReplicaSetsValidatingAdmissionPolicyGenerator) PoliciesWithBindings() []PolicyWithBindings {
-	celExprSegs := []string{}
+func (g *PodsAndReplicaSetsValidatingAdmissionPolicyGenerator) PoliciesWithBindings() ([]PolicyWithBindings, error) {
+	isInReservedNamespaces := LogicalOr()
 	for _, prefix := range g.ReservedNamespacePrefixes {
-		celExprSegs = append(celExprSegs, fmt.Sprintf(`request.namespace.startsWith("%s")`, prefix))
+		isInReservedNamespaces.Add(isInNamespaceWithPrefix(prefix))
 	}
-	celExpr := strings.Join(celExprSegs, " || ")
+
+	celExpr, err := isInReservedNamespaces.Parse()
+	if err != nil {
+		return nil, errors.Wraps(err, "failed to parse CEL expression tree")
+	}
 
 	policy := &admissionregistrationv1.ValidatingAdmissionPolicy{
 		ObjectMeta: metav1.ObjectMeta{
@@ -142,5 +143,5 @@ func (g *PodsAndReplicaSetsValidatingAdmissionPolicyGenerator) PoliciesWithBindi
 			Policy:   policy,
 			Bindings: []*admissionregistrationv1.ValidatingAdmissionPolicyBinding{binding},
 		},
-	}
+	}, nil
 }

--- a/pkg/admissionpolicymanager/podsnreplicasets.go
+++ b/pkg/admissionpolicymanager/podsnreplicasets.go
@@ -76,9 +76,9 @@ func (g *PodsAndReplicaSetsValidatingAdmissionPolicyGenerator) PoliciesWithBindi
 		isInReservedNamespaces.Add(isInNamespaceWithPrefix(prefix))
 	}
 
-	celExpr, err := isInReservedNamespaces.Parse()
+	celExpr, err := isInReservedNamespaces.Build()
 	if err != nil {
-		return nil, errors.Wraps(err, "failed to parse CEL expression tree")
+		return nil, errors.Wraps(err, "failed to build CEL expression")
 	}
 
 	policy := &admissionregistrationv1.ValidatingAdmissionPolicy{

--- a/pkg/admissionpolicymanager/svcaccountsntokenreqs.go
+++ b/pkg/admissionpolicymanager/svcaccountsntokenreqs.go
@@ -20,9 +20,6 @@ limitations under the License.
 package admissionpolicymanager
 
 import (
-	"fmt"
-	"strings"
-
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -100,17 +97,7 @@ func (g *ServiceAccountsAndTokenRequestsValidatingAdmissionPolicyGenerator) Vali
 // except for requests from certain whitelisted users and user groups.
 //
 // For simplicity reasons, the code here assumes that the generator has been validated before PoliciesWithBindings() is called.
-func (g *ServiceAccountsAndTokenRequestsValidatingAdmissionPolicyGenerator) PoliciesWithBindings() []PolicyWithBindings {
-	celExprAccSegs := []string{}
-
-	// Exempt whitelisted users from this admission policy.
-	for _, username := range g.WhitelistedUsernames {
-		celExprAccSegs = append(celExprAccSegs, fmt.Sprintf(`request.userInfo.username == "%s"`, username))
-	}
-	// Exempt whitelisted user groups from this admission policy.
-	for _, userGroup := range g.WhitelistedUserGroups {
-		celExprAccSegs = append(celExprAccSegs, fmt.Sprintf(`"%s" in request.userInfo.groups`, userGroup))
-	}
+func (g *ServiceAccountsAndTokenRequestsValidatingAdmissionPolicyGenerator) PoliciesWithBindings() ([]PolicyWithBindings, error) {
 	// Exempt requests from the Kubernetes scheduler, any of the nodes, and (esp.) the
 	// Kubernetes controller manager from this admission policy.
 	//
@@ -118,29 +105,58 @@ func (g *ServiceAccountsAndTokenRequestsValidatingAdmissionPolicyGenerator) Poli
 	// --use-service-account-credentials=true, creates a service account token for many of its controllers
 	// and uses those tokens to authenticate to the Kubernetes API server. It retrieves a token
 	// via the TokenRequest API; failure to exempt this scenario may lead to critical errors.
-	celExprAccSegs = append(celExprAccSegs, fmt.Sprintf(`request.userInfo.username == "%s"`, kubeSchedulerUserName))
-	celExprAccSegs = append(celExprAccSegs, fmt.Sprintf(`request.userInfo.username == "%s"`, kubeControllerManagerUserName))
-	celExprAccSegs = append(celExprAccSegs, fmt.Sprintf(`"%s" in request.userInfo.groups`, kubeNodeUserGroup))
+	isFromKubeScheduler := isFromUsername(kubeSchedulerUserName)
+	isFromKubeControllerManager := isFromUsername(kubeControllerManagerUserName)
+	isFromNodeUserGroup := isFromUserGroup(kubeNodeUserGroup)
+
 	// Exempt requests from cluster admin users from this admission policy.
-	celExprAccSegs = append(celExprAccSegs, fmt.Sprintf(`"%s" in request.userInfo.groups`, adminUserGroup))
+	isFromClusterAdmins := isFromUserGroup(adminUserGroup)
+
 	// Exempt kubeadm cluster admins from this policy as well, so that bootstrapping a hub cluster with
 	// kubeadm credentials can proceed without being blocked.
-	celExprAccSegs = append(celExprAccSegs, fmt.Sprintf(`"%s" in request.userInfo.groups`, kubeadmAdminUserGroup))
+	isFromKubeadmClusterAdmins := isFromUserGroup(kubeadmAdminUserGroup)
+
 	// Exempt service accounts from this admission policy. Note that VAP check happens after authentication and
 	// authorization have been performed. This is added to keep things consistent with the original webhook behavior,
 	// and also for the reason that some controller manager components (e.g., the service account controller)
 	// need to create service accounts as part of their normal operations.
-	celExprAccSegs = append(celExprAccSegs, fmt.Sprintf(`"%s" in request.userInfo.groups`, svcAccountUserGroup))
+	isFromSvcAccounts := isFromUserGroup(svcAccountUserGroup)
 
-	celExprAcc := strings.Join(celExprAccSegs, " || ")
+	isFromAllowedRequesters := LogicalOr(
+		isFromKubeScheduler,
+		isFromKubeControllerManager,
+		isFromNodeUserGroup,
+		isFromClusterAdmins,
+		isFromKubeadmClusterAdmins,
+		isFromSvcAccounts,
+	)
 
-	celExprNSSegs := []string{}
-	for _, prefix := range g.ReservedNamespacePrefixes {
-		celExprNSSegs = append(celExprNSSegs, fmt.Sprintf(`request.namespace.startsWith("%s")`, prefix))
+	// Exempt additionally configured users from this admission policy.
+	for _, username := range g.WhitelistedUsernames {
+		isFromAllowedRequesters.Add(isFromUsername(username))
 	}
-	celExprNS := strings.Join(celExprNSSegs, " || ")
 
-	celExpr := fmt.Sprintf("!(%s) || (%s)", celExprNS, celExprAcc)
+	// Exempt additionally configured user groups from this admission policy.
+	for _, userGroup := range g.WhitelistedUserGroups {
+		isFromAllowedRequesters.Add(isFromUserGroup(userGroup))
+	}
+
+	// Allow the request if it is not targeting reserved namespaces.
+	isInReservedNamespaces := LogicalOr()
+	for _, prefix := range g.ReservedNamespacePrefixes {
+		isInReservedNamespaces.Add(isInNamespaceWithPrefix(prefix))
+	}
+
+	celExprTree := LogicalOr(
+		LogicalNot(
+			isInReservedNamespaces,
+		),
+		isFromAllowedRequesters,
+	)
+	celExpr, err := celExprTree.Parse()
+	if err != nil {
+		return nil, errors.Wraps(err, "failed to parse CEL expression tree")
+	}
 
 	policy := &admissionregistrationv1.ValidatingAdmissionPolicy{
 		ObjectMeta: metav1.ObjectMeta{
@@ -209,5 +225,5 @@ func (g *ServiceAccountsAndTokenRequestsValidatingAdmissionPolicyGenerator) Poli
 			Policy:   policy,
 			Bindings: []*admissionregistrationv1.ValidatingAdmissionPolicyBinding{binding},
 		},
-	}
+	}, nil
 }

--- a/pkg/admissionpolicymanager/svcaccountsntokenreqs.go
+++ b/pkg/admissionpolicymanager/svcaccountsntokenreqs.go
@@ -153,9 +153,9 @@ func (g *ServiceAccountsAndTokenRequestsValidatingAdmissionPolicyGenerator) Poli
 		),
 		isFromAllowedRequesters,
 	)
-	celExpr, err := celExprTree.Parse()
+	celExpr, err := celExprTree.Build()
 	if err != nil {
-		return nil, errors.Wraps(err, "failed to parse CEL expression tree")
+		return nil, errors.Wraps(err, "failed to build CEL expression")
 	}
 
 	policy := &admissionregistrationv1.ValidatingAdmissionPolicy{


### PR DESCRIPTION
### Description of your changes

This PR tweaks the CEL building flow in our VAP manager, uses tree building to complete the work, as previously discussed.

Related to #707.

I have:

- [x] Associated this change with a known KubeFleet Issue (Bug, Feature, etc).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- [x] UTs
- [x] ITs
- [x] E2E tests

### Special notes for your reviewer

N/A
