### PR TITLE
docs: add VERSIONING.md for release versioning and agent skew

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ KubeFleet's scheduler evaluates member cluster properties, available capacity, a
 
 To learn more about KubeFleet go to the [KubeFleet documentation](https://kubefleet-dev.github.io/website/).
 
+For release versioning, supported agent version skew, and upgrade ordering, see [VERSIONING.md](VERSIONING.md).
+
 ## Community
 
 You can reach the KubeFleet community and developers via the following channels:

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,0 +1,151 @@
+# Versioning and upgrades
+
+This document describes how KubeFleet versions its releases, which agent
+version combinations are supported, and how to upgrade a fleet safely. It
+complements the support-window policy in [SECURITY.md](SECURITY.md) and the
+contribution conventions in [CONTRIBUTING.md](CONTRIBUTING.md).
+
+> KubeFleet is pre-1.0. The guarantees below reflect the project's current
+> intent and are validated by CI today, but they may tighten as the project
+> approaches a 1.0 release.
+
+## Versioning scheme
+
+KubeFleet releases follow [Semantic Versioning](https://semver.org/) using the
+form `vMAJOR.MINOR.PATCH` (for example, `v0.4.0`). Release candidates use the
+Kubernetes-style pre-release suffix `vMAJOR.MINOR.PATCH-rc.N` (for example,
+`v0.4.0-rc.1`). These are the only tag formats accepted by the release tooling;
+the validation lives in
+[`.github/workflows/setup-release.yml`](.github/workflows/setup-release.yml).
+
+Because KubeFleet is still in the `0.y.z` series, the usual SemVer rule that
+"only a major bump may carry breaking changes" does not yet apply. While the
+major version is `0`, **a minor bump (`0.Y` → `0.Y+1`) may include breaking
+changes**, and patch releases (`0.Y.Z` → `0.Y.Z+1`) are reserved for
+backward-compatible bug fixes and security patches. SemVer does not require this
+for the `0.y.z` range — it permits anything to change at any time — but KubeFleet
+commits to it explicitly so that users on a given minor can take patch and
+security updates without fear of a behavior change.
+
+### What warrants a minor versus a patch bump (0.x)
+
+| Change | Bump |
+| --- | --- |
+| New CRD, or a new field/value on an existing CRD | Minor |
+| Breaking change to an existing CRD (removed/renamed field, tightened validation, changed default) | Minor |
+| Change to scheduling, override, rollout, or apply semantics that re-ranks or re-applies existing placements | Minor |
+| A new agent flag whose default changes observable behavior | Minor |
+| Backward-compatible bug fix or security patch with no API or behavior change | Patch |
+| Dependency bumps with no user-visible behavior change | Patch |
+
+When in doubt, prefer the higher bump: a minor is cheaper than a surprised user.
+
+## Release cadence and supported versions
+
+KubeFleet targets a roughly three-month minor-release cadence and supports the
+two most recent minors (`N` and `N-1`) for security and bug-fix patches.
+Cadence slippage is possible while the project is pre-1.0. The authoritative
+support-window statement, including the security-patch policy, lives in
+[SECURITY.md](SECURITY.md).
+
+## Agent version skew
+
+A KubeFleet deployment runs two agents:
+
+| Agent | Role | Kubernetes analogue |
+| --- | --- | --- |
+| **hub-agent** | Runs on the hub cluster; owns scheduling, placement, and the source of truth for desired state | Control plane |
+| **member-agent** | Runs on each member cluster; applies workloads and reports status and health back to the hub | kubelet |
+
+**Supported skew: the hub-agent and member-agent may differ by at most one
+minor version (`N`/`N-1`).** Within that window either agent may be the newer
+one — KubeFleet does not require the hub to be upgraded before the members for
+correctness, only that the two stay within one minor of each other.
+
+This deliberately differs from the Kubernetes kubelet skew policy that inspired
+the control-plane/kubelet analogy above. That policy is *asymmetric* (the kubelet
+may trail the API server by up to three minors but must never be newer) because a
+node and the control plane are loosely coupled. KubeFleet's hub and member agents
+are more tightly coupled, so the project instead guarantees a *symmetric, single*
+minor of skew: simpler to reason about, and validated directly in CI rather than
+inherited from the Kubernetes rule.
+
+This is exercised by the three jobs in
+[`.github/workflows/upgrade.yml`](.github/workflows/upgrade.yml), which run on
+pushes to `main` and `release-*` branches and on pull requests against them
+(documentation-only pull requests are skipped via the workflow's `paths-ignore`).
+The jobs build the previous release and the current commit and together cover
+both skew directions:
+
+| Job | Scenario it validates |
+| --- | --- |
+| `hub-agent-backward-compatibility` | Newer hub-agent against an older member-agent |
+| `member-agent-backward-compatibility` | Newer member-agent against an older hub-agent |
+| `full-backward-compatibility` | Both agents upgraded together |
+
+The suite exercises the previous-release-to-current-commit skew, which the
+release cadence keeps within one minor. Running agents more than one minor apart
+is unsupported and untested; upgrade through each minor in turn rather than
+skipping one.
+
+### Recommended upgrade ordering
+
+Although both skew directions are supported, the recommended order mirrors the
+Kubernetes convention of upgrading the control plane first:
+
+1. Upgrade the **hub-agent** on the hub cluster.
+2. Upgrade the **member-agent** on each member cluster.
+
+This keeps the hub — the source of truth for desired state — at the newest
+version while members catch up, and it matches the operational model operators
+already know from Kubernetes node upgrades. The supported one-minor skew gives
+you a window to roll members forward without taking the whole fleet down at
+once. The flow is the same one the compatibility suite drives through
+[`test/upgrade/upgrade.sh`](test/upgrade/upgrade.sh).
+
+### Cross-agent contracts held stable across a skew window
+
+For the one-minor skew guarantee to hold, the contracts the two agents exchange
+must remain backward-compatible across adjacent minors:
+
+- **`Work` / `AppliedWork`** — the hub publishes desired manifests as `Work`
+  objects; the member applies them and reports results via `AppliedWork`.
+- **Member heartbeat and status** — the member reports health and resource usage
+  to the hub by patching the status of `InternalMemberCluster` (in the member's
+  namespace on the hub). The hub-side `MemberCluster` controller then mirrors that
+  data onto `MemberCluster`; the member agent never writes to `MemberCluster`
+  directly. `InternalMemberCluster` is the actual hub↔member status contract.
+
+Changes to these contracts within a minor must be additive; a breaking change to
+either is a minor bump (see the table above) and must preserve compatibility
+with the immediately preceding minor so that a mid-upgrade fleet keeps working.
+
+## API versioning and lifecycle
+
+KubeFleet's core CRDs are served at more than one API version. For the placement
+(`placement.kubernetes-fleet.io`) and cluster (`cluster.kubernetes-fleet.io`)
+groups, both `v1` and `v1beta1` are served: `v1` is the externally promoted,
+stable surface that `kubectl` returns by default, while `v1beta1` remains the
+current storage version. Both refer to the same underlying objects, so a request
+for either version returns the same resource.
+
+Per-API maturity — the promotion path through alpha, beta, and stable, and the
+deprecation windows for removing an API version — follows the upstream
+[Kubernetes API deprecation policy](https://kubernetes.io/docs/reference/using-api/deprecation-policy/)
+as a model rather than restating it here. Note that the upstream policy formally
+governs built-in Kubernetes APIs; KubeFleet adopts it by convention for its CRDs.
+
+When upgrading with raw manifests, apply the CRDs shipped with the target release
+before rolling the agents, as you would for any Kubernetes operator. Helm-based
+installs need no separate step: KubeFleet ships its CRDs under
+`charts/hub-agent/templates/crds/` and `charts/member-agent/templates/crds/`
+(regular templates, not Helm's special unmanaged `crds/` directory), so
+`helm upgrade` applies them — ahead of the Deployments — automatically.
+
+## See also
+
+- [SECURITY.md](SECURITY.md) — supported versions and security-patch policy.
+- [CONTRIBUTING.md](CONTRIBUTING.md) — PR conventions and release-note labels.
+- [Kubernetes version skew policy](https://kubernetes.io/releases/version-skew-policy/)
+  — the policy whose structure inspired this document; see
+  [Agent version skew](#agent-version-skew) for how KubeFleet deliberately differs.

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -57,10 +57,12 @@ A KubeFleet deployment runs two agents:
 | **hub-agent** | Runs on the hub cluster; owns scheduling, placement, and the source of truth for desired state | Control plane |
 | **member-agent** | Runs on each member cluster; applies workloads and reports status and health back to the hub | kubelet |
 
-**Supported skew: the hub-agent and member-agent may differ by at most one
-minor version (`N`/`N-1`).** Within that window either agent may be the newer
-one — KubeFleet does not require the hub to be upgraded before the members for
-correctness, only that the two stay within one minor of each other.
+**Supported skew: the hub-agent and member-agent may run adjacent minor
+versions — at most one minor apart, in either direction.** For example, a
+`v0.5.z` hub-agent is supported with `v0.4.z` or `v0.6.z` member-agents (and
+vice versa), but not with `v0.3.z` ones. KubeFleet does not require the hub to
+be upgraded before the members for correctness, only that the two stay within
+one minor of each other.
 
 This deliberately differs from the Kubernetes kubelet skew policy that inspired
 the control-plane/kubelet analogy above. That policy is *asymmetric* (the kubelet


### PR DESCRIPTION
### Description of your changes

Adds `VERSIONING.md`, the versioning and upgrade policy document tracked under the Phase 1 release-process work in #693. It complements the support-window policy in `SECURITY.md` and the contribution conventions in `CONTRIBUTING.md`.

The document covers:

- **Versioning scheme** — SemVer `vMAJOR.MINOR.PATCH` with `-rc.N` pre-releases (matching the tag validation in `setup-release.yml`), and the pre-1.0 `0.y.z` semantics (minors may break; patches are a deliberate backward-compatible commitment stricter than SemVer requires for `0.y.z`).
- **Minor-vs-patch bump criteria for 0.x** — a table for deciding when a change warrants a minor versus a patch.
- **Release cadence and supported versions** — ~3-month minors, `N`/`N-1` supported, deferring the authoritative statement to `SECURITY.md`.
- **Agent version skew** — hub-agent and member-agent may differ by at most one minor in either direction. This is grounded in, and validated by, the three compatibility jobs already running in `upgrade.yml` (`hub-agent-backward-compatibility`, `member-agent-backward-compatibility`, `full-backward-compatibility`). The doc explicitly notes where this symmetric one-minor guarantee deliberately diverges from the asymmetric Kubernetes kubelet skew policy and why.
- **Recommended upgrade ordering** — hub first, then members, mirroring the Kubernetes control-plane-first convention.
- **Cross-agent contracts** — the `Work`/`AppliedWork` and `InternalMemberCluster` status contracts that must stay backward-compatible across a skew window.
- **API versioning** — both `v1` and `v1beta1` are served for the placement and cluster groups (`v1` the promoted surface, `v1beta1` the storage version), deferring per-API lifecycle to the upstream Kubernetes API deprecation policy by convention, plus Helm-vs-raw-YAML CRD upgrade guidance.

Also adds a one-line pointer to `VERSIONING.md` from the README.

Maps to #693 Phase 1.

Refs #693

I have:

- [x] Associated this change with a known KubeFleet Issue (Bug, Feature, etc).
- [x] Run `make reviewable` to ensure this PR is ready for review. (No-op for this PR: no Go sources touched; docs/markdown CI covers the changed files.)

### How has this code been tested

- All relative links in `VERSIONING.md` were verified to resolve to real paths in the repo (`SECURITY.md`, `CONTRIBUTING.md`, `.github/workflows/setup-release.yml`, `.github/workflows/upgrade.yml`, `test/upgrade/upgrade.sh`, both chart `templates/crds/` directories).
- All external links return HTTP 200 (`semver.org`, the Kubernetes version-skew and API-deprecation policy pages).
- Every factual claim was cross-checked against the source: the three compat jobs and `paths-ignore`/`detect-noop` scoping in `upgrade.yml`; the member-to-hub heartbeat path (member patches `InternalMemberCluster` status, hub mirrors to `MemberCluster`); the `v1`/`v1beta1` served-and-storage settings in the CRD manifests; and the Helm `templates/crds/` upgrade behavior.
- The new file ends with a trailing newline per repo convention; markdown link-check CI will exercise the changes end-to-end.

### Special notes for your reviewer

- This is documentation only — no Go sources, workflows, or CRDs are modified.
- The agent-skew guarantee is described as **symmetric one-minor**, which is intentionally stronger and simpler than the Kubernetes kubelet rule; the doc calls this out so Kubernetes-literate readers are not surprised. If maintainers prefer a more conservative (asymmetric, hub-first-only) statement, that is a one-paragraph change.
