### PR TITLE
feat: publish a standalone CRD tarball as a release asset

### DIFF
--- a/.github/workflows/code-lint.yml
+++ b/.github/workflows/code-lint.yml
@@ -87,3 +87,6 @@ jobs:
         run: |
           helm lint charts/hub-agent
           helm lint charts/member-agent
+
+      - name: Verify chart CRDs cover config/crd/bases
+        run: make crd-verify

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,3 +94,49 @@ jobs:
               echo "  - ${{ env.REGISTRY }}/${IMAGE}:${VERSION}"
             fi
           done
+
+  # Publish the raw CRDs as a standalone release asset so consumers can install
+  # them without pulling a Helm chart. The bundle carries the unmodified CRDs the
+  # charts install (no downstream-specific labels), split into crds/hub and
+  # crds/member so each set can be applied to the right cluster. Runs after the
+  # images are published so a release is only created once the build succeeds.
+  publish-crds:
+    needs: [export-registry, build-and-publish]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      TAG: ${{ needs.export-registry.outputs.tag }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ needs.export-registry.outputs.tag }}
+
+      - name: Package CRDs
+        run: make crd-package TAG="${TAG}"
+
+      - name: Create or update the release and upload the CRD bundle
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          created_draft=""
+          if ! gh release view "${TAG}" >/dev/null 2>&1; then
+            # Any semver pre-release suffix (-rc.N, -alpha, -beta, ...) is a prerelease.
+            prerelease=""
+            case "${TAG}" in *-*) prerelease="--prerelease" ;; esac
+            # Create as a draft first so a partially uploaded release is never public.
+            gh release create "${TAG}" --title "${TAG}" --generate-notes --draft ${prerelease}
+            created_draft="true"
+          fi
+          gh release upload "${TAG}" \
+            "_crd-package/kubefleet-crds-${TAG}.tgz" \
+            "_crd-package/kubefleet-crds-${TAG}.tgz.sha256" \
+            --clobber
+          # Only publish releases this job created; never flip a maintainer's existing release.
+          if [ "${created_draft}" = "true" ]; then
+            gh release edit "${TAG}" --draft=false
+          elif [ "$(gh release view "${TAG}" --json isDraft --jq .isDraft)" = "true" ]; then
+            echo "::warning::Release ${TAG} already existed as a draft; the CRD bundle was uploaded but the release was left unpublished. Publish it manually."
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,10 @@ ut-coverage.xml
 
 # Helm chart packaging
 .helm-packages/
+
+# CRD release bundle
+_crd-package/
+
 # Squad: ignore runtime state (logs, inbox, sessions)
 .squad/orchestration-log/
 .squad/log/

--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ collect-e2e-logs: ## Collect logs from hub and member agent pods after e2e tests
 
 ## reviewable
 .PHONY: reviewable
-reviewable: fmt vet lint staticcheck ## Run all quality checks before PR
+reviewable: fmt vet lint staticcheck crd-verify ## Run all quality checks before PR
 	go mod tidy
 
 ## --------------------------------------
@@ -254,6 +254,46 @@ helm-push: ## Package and push Helm charts to OCI registry
 	helm push .helm-packages/hub-agent-$(CHART_VERSION).tgz oci://$(REGISTRY)
 	helm push .helm-packages/member-agent-$(CHART_VERSION).tgz oci://$(REGISTRY)
 	rm -rf .helm-packages
+
+## --------------------------------------
+## CRD release bundle
+## --------------------------------------
+
+# Directory and artifact names for the standalone CRD release tarball.
+CRD_PACKAGE_DIR ?= _crd-package
+CRD_PACKAGE_NAME ?= kubefleet-crds-$(TAG)
+# Use sha256sum when available (Linux/CI), fall back to shasum (macOS).
+SHA256SUM ?= $(shell command -v sha256sum >/dev/null 2>&1 && echo "sha256sum" || echo "shasum -a 256")
+
+.PHONY: crd-package
+crd-package: ## Package the raw CRDs into a release tarball with a SHA-256 checksum
+	rm -rf $(CRD_PACKAGE_DIR)
+	mkdir -p $(CRD_PACKAGE_DIR)/crds/hub $(CRD_PACKAGE_DIR)/crds/member
+	# Source from the charts' CRD sets (symlinks into config/crd/bases) so the
+	# bundle mirrors exactly what each agent installs: hub-cluster CRDs under
+	# crds/hub, member-cluster CRDs under crds/member. cp -L dereferences the
+	# symlinks so the archive holds the raw CRD YAML, not dangling links.
+	cp -L charts/hub-agent/templates/crds/*.yaml $(CRD_PACKAGE_DIR)/crds/hub/
+	cp -L charts/member-agent/templates/crds/*.yaml $(CRD_PACKAGE_DIR)/crds/member/
+	tar -czf $(CRD_PACKAGE_DIR)/$(CRD_PACKAGE_NAME).tgz -C $(CRD_PACKAGE_DIR) crds
+	cd $(CRD_PACKAGE_DIR) && $(SHA256SUM) $(CRD_PACKAGE_NAME).tgz > $(CRD_PACKAGE_NAME).tgz.sha256
+	@echo "Packaged CRDs into $(CRD_PACKAGE_DIR)/$(CRD_PACKAGE_NAME).tgz"
+
+.PHONY: crd-verify
+crd-verify: ## Verify the chart CRD directories cover every CRD in config/crd/bases
+	@bases="$$(mktemp)"; charts="$$(mktemp)"; \
+	ls config/crd/bases/ | sort > "$$bases"; \
+	{ ls charts/hub-agent/templates/crds/; ls charts/member-agent/templates/crds/; } | sort > "$$charts"; \
+	missing="$$(comm -3 "$$bases" "$$charts")"; \
+	rm -f "$$bases" "$$charts"; \
+	if [ -n "$$missing" ]; then \
+		echo "ERROR: chart CRD directories are out of sync with config/crd/bases."; \
+		echo "Left column = only in config/crd/bases; right column = only in the charts:"; \
+		echo "$$missing"; \
+		echo "If you added a CRD, symlink it into charts/hub-agent/templates/crds/ or charts/member-agent/templates/crds/."; \
+		exit 1; \
+	fi; \
+	echo "crd-verify: chart CRD directories cover all CRDs in config/crd/bases"
 
 # By default, docker buildx create will pull image moby/buildkit:buildx-stable-1 and hit the too many requests error
 .PHONY: docker-buildx-builder


### PR DESCRIPTION
### Description of your changes

Publishes the project's CRDs as a standalone GitHub Release asset, so consumers can install them without pulling a Helm chart. Part of the Phase 1 release-process work tracked in #693.

**What's added**

- **`make crd-package`** — bundles the CRDs the charts actually install into `kubefleet-crds-<tag>.tgz`, split into `crds/hub/` (hub-cluster CRDs) and `crds/member/` (member-cluster CRDs), each with a portable SHA-256 checksum (`sha256sum` on CI, `shasum` on macOS). It sources from the charts' `templates/crds/` (via `cp -L` to dereference the symlinks into `config/crd/bases`), so the bundle is byte-identical to what the charts ship and carries no downstream-specific labels. It does not regenerate via `controller-gen` — it ships the CRDs exactly as committed at the tag.
- **`publish-crds` job in `release.yml`** — a separate job (least-privilege `contents: write`) that runs after the images are published, builds the bundle, and attaches it to the release using the runner's built-in `gh` (no new third-party action). It creates the release as a draft first and publishes only after the upload succeeds; it never flips a maintainer's pre-existing release, and emits a `::warning::` if it finds the release already exists as a draft. Any semver pre-release tag (`-rc.N`, `-alpha`, ...) is marked `--prerelease`.
- **`make crd-verify`** — guards against drift between `config/crd/bases/` and the chart CRD directories, so a newly added CRD can't be silently dropped from the charts or the bundle. Wired into `make reviewable` and the `helm-lint` CI job.

**Deferred (Phase 2a, per #693):** signing the checksums (`cosign`/signed `SHA256SUMS`) and byte-reproducible packaging. Only an unsigned checksum is added here.

Refs #693

I have:

- [x] Associated this change with a known KubeFleet Issue (Bug, Feature, etc).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- `make crd-package` produces a bundle whose 28 CRDs are **byte-identical** to `config/crd/bases/`, laid out as `crds/hub/` (27) + `crds/member/` (1, `appliedworks`), with the checksum verifying via `sha256sum -c`.
- `make crd-verify` passes on the current tree and was confirmed to fail when a chart CRD is missing (drift detection).
- The `publish-crds` shell logic was exercised across tag scenarios (new stable, new pre-release, pre-existing published release, pre-existing draft): create-as-draft → upload → publish for new tags; upload-only for existing published releases; upload + warning, no flip, for a maintainer's existing draft.
- `actionlint` is clean on both `release.yml` and `code-lint.yml`.

### Special notes for your reviewer

- The `publish-crds` job is intentionally a separate job appended to `release.yml` so it does not conflict with the in-flight #713, which edits the existing `build-and-publish` job.
- The bundle's hub/member split is sourced from the charts, so it always matches what each agent installs; `crd-verify` enforces that the chart CRD set stays in sync with `config/crd/bases`.

