### PR TITLE
feat: build multi-arch (amd64/arm64) images and publish both tags in a single buildx

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,9 +61,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       # A single multi-arch `docker buildx build` per image publishes the full
-      # tag (e.g. ":v0.4.0") and, for stable releases, the short alias
-      # (e.g. ":0.4.0") in the same push - no separate retag step. RC images are
-      # published under the long form (":v0.4.0-rc.1") for testers only: the
+      # tag (e.g. "v0.4.0") and, for stable releases, the short alias
+      # (e.g. "0.4.0") in the same push - no separate retag step. RC images are
+      # published under the long form ("v0.4.0-rc.1") for testers only: the
       # short-tag namespace is deliberately reserved for stable releases that
       # consumers can safely pin to, so RC tags get no short alias.
       - name: Build and push images with tag ${{ env.TAG }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,39 +60,47 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # A single multi-arch `docker buildx build` per image publishes the full
+      # tag (e.g. ":v0.4.0") and, for stable releases, the short alias
+      # (e.g. ":0.4.0") in the same push - no separate retag step. RC images are
+      # published under the long form (":v0.4.0-rc.1") for testers only: the
+      # short-tag namespace is deliberately reserved for stable releases that
+      # consumers can safely pin to, so RC tags get no short alias.
       - name: Build and push images with tag ${{ env.TAG }}
-        run: |
-          make push
-
-      # The short-tag (e.g. ":0.4.0") aliases the long form for stable releases
-      # only. RC images are published under the long form (":v0.4.0-rc.1") for
-      # testers, but we deliberately do NOT alias them to a short tag - the
-      # short-tag namespace is reserved for stable releases that consumers can
-      # safely pin to (and "imagetools create" with an RC alias would publish
-      # "0.4.0-rc.1" into that namespace, muddying it).
-      - name: Tag and push images without v prefix
-        if: ${{ !contains(needs.export-registry.outputs.tag, '-rc.') }}
         env:
           VERSION: ${{ needs.export-registry.outputs.version }}
         run: |
           set -euo pipefail
-          for IMAGE in ${{ env.HUB_AGENT_IMAGE_NAME }} ${{ env.MEMBER_AGENT_IMAGE_NAME }} ${{ env.REFRESH_TOKEN_IMAGE_NAME }}; do
-            docker buildx imagetools create \
-              --tag "${{ env.REGISTRY }}/${IMAGE}:${VERSION}" \
-              "${{ env.REGISTRY }}/${IMAGE}:${{ env.TAG }}"
-          done
+          if [[ "${TAG}" == *-rc.* ]]; then
+            make push
+          else
+            make push IMAGE_EXTRA_TAG="${VERSION}"
+          fi
 
-      - name: Verify images
+      # Confirm every published tag is a real multi-arch manifest list rather
+      # than a silently degraded single-arch image: a build that pushed only one
+      # architecture would otherwise go unnoticed until a consumer on the other
+      # architecture failed to pull. Stable releases also carry the short alias.
+      - name: Verify images are multi-arch
         env:
           VERSION: ${{ needs.export-registry.outputs.version }}
         run: |
           set -euo pipefail
-          echo "✅ Published images:"
+          tags="${TAG}"
+          if [[ "${TAG}" != *-rc.* ]]; then
+            tags="${tags} ${VERSION}"
+          fi
+          echo "✅ Verifying published images:"
           for IMAGE in ${{ env.HUB_AGENT_IMAGE_NAME }} ${{ env.MEMBER_AGENT_IMAGE_NAME }} ${{ env.REFRESH_TOKEN_IMAGE_NAME }}; do
-            echo "  - ${{ env.REGISTRY }}/${IMAGE}:${{ env.TAG }}"
-            if [[ "${TAG}" != *-rc.* ]]; then
-              echo "  - ${{ env.REGISTRY }}/${IMAGE}:${VERSION}"
-            fi
+            for tag in ${tags}; do
+              ref="${{ env.REGISTRY }}/${IMAGE}:${tag}"
+              echo "  - ${ref}"
+              manifest="$(docker buildx imagetools inspect "${ref}")"
+              for platform in linux/amd64 linux/arm64; do
+                grep -q "Platform:.*${platform}" <<<"${manifest}" \
+                  || { echo "::error::${ref} is missing platform ${platform}"; exit 1; }
+              done
+            done
           done
 
   # Publish the raw CRDs as a standalone release asset so consumers can install

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,12 @@ HUB_AGENT_IMAGE_VERSION ?= $(TAG)
 MEMBER_AGENT_IMAGE_VERSION ?= $(TAG)
 REFRESH_TOKEN_IMAGE_VERSION ?= $(TAG)
 
+# Optional additional tag applied to every image within the same `docker buildx
+# build` invocation. A stable release sets this to the short, v-less version
+# (e.g. "0.4.0") so both "v0.4.0" and "0.4.0" are published from one build,
+# which replaces a separate `docker buildx imagetools create` retag step.
+IMAGE_EXTRA_TAG ?=
+
 HUB_AGENT_IMAGE_NAME ?= hub-agent
 MEMBER_AGENT_IMAGE_NAME ?= member-agent
 REFRESH_TOKEN_IMAGE_NAME := refresh-token
@@ -243,9 +249,16 @@ BUILDX_BUILDER_NAME ?= img-builder
 QEMU_VERSION ?= 7.2.0-1
 BUILDKIT_VERSION ?= v0.18.1
 
+# Platforms to build container images for. Defaults to the host/target platform
+# so local single-arch builds (e.g. loading into kind, which cannot load a
+# multi-platform image) keep working unchanged; `push` overrides this to build a
+# multi-arch manifest for the release.
+PLATFORMS ?= $(TARGET_OS)/$(TARGET_ARCH)
+RELEASE_PLATFORMS ?= linux/amd64,linux/arm64
+
 .PHONY: push
-push: ## Build and push all Docker images
-	$(MAKE) OUTPUT_TYPE="type=registry" docker-build-hub-agent docker-build-member-agent docker-build-refresh-token
+push: ## Build and push all Docker images as multi-arch manifests
+	$(MAKE) OUTPUT_TYPE="type=registry" PLATFORMS="$(RELEASE_PLATFORMS)" docker-build-hub-agent docker-build-member-agent docker-build-refresh-token
 
 .PHONY: helm-push
 helm-push: ## Package and push Helm charts to OCI registry
@@ -295,25 +308,34 @@ crd-verify: ## Verify the chart CRD directories cover every CRD in config/crd/ba
 	fi; \
 	echo "crd-verify: chart CRD directories cover all CRDs in config/crd/bases"
 
+# Register QEMU binfmt handlers so the host can build/run non-native binaries.
+# This must run for any multi-platform build regardless of whether the buildx
+# builder already exists (a pre-existing builder would otherwise skip emulation
+# setup and the foreign-arch build would fail with "exec format error"). The
+# registration is idempotent, so it is safe to re-run. It is skipped for
+# single-platform builds, which are native and never need emulation.
+#
+# On some systems the emulation setup might not work at all (e.g., macOS on Apple
+# Silicon -> Rosetta 2 will be used by Docker Desktop as the default emulation
+# option for AMD64 on ARM64 container compatibility).
+.PHONY: setup-qemu
+setup-qemu: ## Register QEMU emulation for multi-architecture image builds
+	$(info Auto-detected system architecture: $(TARGET_ARCH))
+	@case "$(PLATFORMS)" in \
+		*,*) \
+			echo "Multi-platform build ($(PLATFORMS)); registering QEMU emulation"; \
+			if [ "$(TARGET_ARCH)" = "amd64" ] ; then \
+				docker run --rm --privileged mcr.microsoft.com/mirror/docker/multiarch/qemu-user-static:$(QEMU_VERSION) --reset -p yes; \
+			else \
+				docker run --rm --privileged tonistiigi/binfmt --install all; \
+			fi ;; \
+		*) echo "Single-platform build ($(PLATFORMS)); skipping QEMU setup" ;; \
+	esac
+
 # By default, docker buildx create will pull image moby/buildkit:buildx-stable-1 and hit the too many requests error
 .PHONY: docker-buildx-builder
-# Note (chenyu1): the step below sets up emulation for building/running non-native binaries on the host. The original
-# setup assumes that the Makefile is always run on an x86_64 platform, and adds support for non-x86_64 hosts. Here
-# we keep the original setup if the build target is x86_64 platforms (default) for compatibility reasons, but will switch to
-# a more general setup for non-x86_64 hosts.
-#
-# On some systems the emulation setup might not work at all (e.g., macOS on Apple Silicon -> Rosetta 2 will be used 
-# by Docker Desktop as the default emulation option for AMD64 on ARM64 container compatibility).
-docker-buildx-builder:
-	$(info Auto-detected system architecture: $(TARGET_ARCH))
+docker-buildx-builder: setup-qemu
 	@if ! docker buildx ls | grep $(BUILDX_BUILDER_NAME); then \
-		if [ "$(TARGET_ARCH)" = "amd64" ] ; then \
-			echo "The target is an x86_64 platform; setting up emulation for other known architectures"; \
-			docker run --rm --privileged mcr.microsoft.com/mirror/docker/multiarch/qemu-user-static:$(QEMU_VERSION) --reset -p yes; \
-		else \
-			echo "Setting up emulation for known architectures"; \
-			docker run --rm --privileged tonistiigi/binfmt --install all; \
-		fi ;\
 		docker buildx create --driver-opt image=mcr.microsoft.com/oss/v2/moby/buildkit:$(BUILDKIT_VERSION) --name $(BUILDX_BUILDER_NAME) --use; \
 		docker buildx inspect $(BUILDX_BUILDER_NAME) --bootstrap; \
 	fi
@@ -323,36 +345,33 @@ docker-build-hub-agent: docker-buildx-builder ## Build hub-agent image
 	docker buildx build \
 		--file docker/$(HUB_AGENT_IMAGE_NAME).Dockerfile \
 		--output=$(OUTPUT_TYPE) \
-		--platform=$(TARGET_OS)/$(TARGET_ARCH) \
+		--platform=$(PLATFORMS) \
 		--pull \
 		--tag $(REGISTRY)/$(HUB_AGENT_IMAGE_NAME):$(HUB_AGENT_IMAGE_VERSION) \
-		--progress=$(BUILDKIT_PROGRESS_TYPE) \
-		--build-arg GOARCH=$(TARGET_ARCH) \
-		--build-arg GOOS=$(TARGET_OS) .
+		$(if $(IMAGE_EXTRA_TAG),--tag $(REGISTRY)/$(HUB_AGENT_IMAGE_NAME):$(IMAGE_EXTRA_TAG)) \
+		--progress=$(BUILDKIT_PROGRESS_TYPE) .
 
 .PHONY: docker-build-member-agent
 docker-build-member-agent: docker-buildx-builder ## Build member-agent image
 	docker buildx build \
 		--file docker/$(MEMBER_AGENT_IMAGE_NAME).Dockerfile \
 		--output=$(OUTPUT_TYPE) \
-		--platform=$(TARGET_OS)/$(TARGET_ARCH) \
+		--platform=$(PLATFORMS) \
 		--pull \
 		--tag $(REGISTRY)/$(MEMBER_AGENT_IMAGE_NAME):$(MEMBER_AGENT_IMAGE_VERSION) \
-		--progress=$(BUILDKIT_PROGRESS_TYPE) \
-		--build-arg GOARCH=$(TARGET_ARCH) \
-		--build-arg GOOS=$(TARGET_OS) .
+		$(if $(IMAGE_EXTRA_TAG),--tag $(REGISTRY)/$(MEMBER_AGENT_IMAGE_NAME):$(IMAGE_EXTRA_TAG)) \
+		--progress=$(BUILDKIT_PROGRESS_TYPE) .
 
 .PHONY: docker-build-refresh-token
 docker-build-refresh-token: docker-buildx-builder ## Build refresh-token image
 	docker buildx build \
 		--file docker/$(REFRESH_TOKEN_IMAGE_NAME).Dockerfile \
 		--output=$(OUTPUT_TYPE) \
-		--platform=$(TARGET_OS)/$(TARGET_ARCH) \
+		--platform=$(PLATFORMS) \
 		--pull \
 		--tag $(REGISTRY)/$(REFRESH_TOKEN_IMAGE_NAME):$(REFRESH_TOKEN_IMAGE_VERSION) \
-		--progress=$(BUILDKIT_PROGRESS_TYPE) \
-		--build-arg GOARCH=$(TARGET_ARCH) \
-		--build-arg GOOS=${TARGET_OS} .
+		$(if $(IMAGE_EXTRA_TAG),--tag $(REGISTRY)/$(REFRESH_TOKEN_IMAGE_NAME):$(IMAGE_EXTRA_TAG)) \
+		--progress=$(BUILDKIT_PROGRESS_TYPE) .
 
 ## -----------------------------------
 ## Cleanup

--- a/Makefile
+++ b/Makefile
@@ -318,11 +318,13 @@ crd-verify: ## Verify the chart CRD directories cover every CRD in config/crd/ba
 	echo "crd-verify: chart CRD directories cover all CRDs in config/crd/bases"
 
 # Register QEMU binfmt handlers so the host can build/run non-native binaries.
-# This must run for any multi-platform build regardless of whether the buildx
-# builder already exists (a pre-existing builder would otherwise skip emulation
-# setup and the foreign-arch build would fail with "exec format error"). The
-# registration is idempotent, so it is safe to re-run. It is skipped for
-# single-platform builds, which are native and never need emulation.
+# This must run for any build that targets a non-native platform - whether a
+# multi-platform build or a single-platform cross build (e.g. PLATFORMS=linux/arm64
+# on an amd64 host) - regardless of whether the buildx builder already exists (a
+# pre-existing builder would otherwise skip emulation setup and the foreign-arch
+# build would fail with "exec format error"). The registration is idempotent, so
+# it is safe to re-run. It is skipped only when PLATFORMS is exactly the native
+# platform, which never needs emulation.
 #
 # On some systems the emulation setup might not work at all (e.g., macOS on Apple
 # Silicon -> Rosetta 2 will be used by Docker Desktop as the default emulation
@@ -331,14 +333,15 @@ crd-verify: ## Verify the chart CRD directories cover every CRD in config/crd/ba
 setup-qemu: ## Register QEMU emulation for multi-architecture image builds
 	$(info Auto-detected system architecture: $(TARGET_ARCH))
 	@case "$(PLATFORMS)" in \
-		*,*) \
-			echo "Multi-platform build ($(PLATFORMS)); registering QEMU emulation"; \
+		"$(TARGET_OS)/$(TARGET_ARCH)") \
+			echo "Native single-platform build ($(PLATFORMS)); skipping QEMU setup" ;; \
+		*) \
+			echo "Build targets non-native platforms ($(PLATFORMS)); registering QEMU emulation"; \
 			if [ "$(TARGET_ARCH)" = "amd64" ] ; then \
 				docker run --rm --privileged $(QEMU_IMAGE) --reset -p yes; \
 			else \
 				docker run --rm --privileged $(BINFMT_IMAGE) --install all; \
 			fi ;; \
-		*) echo "Single-platform build ($(PLATFORMS)); skipping QEMU setup" ;; \
 	esac
 
 # By default, docker buildx create will pull image moby/buildkit:buildx-stable-1 and hit the too many requests error

--- a/Makefile
+++ b/Makefile
@@ -246,8 +246,17 @@ run-memberagent: manifests generate fmt vet ## Run member-agent from your host
 
 OUTPUT_TYPE ?= type=registry
 BUILDX_BUILDER_NAME ?= img-builder
-QEMU_VERSION ?= 7.2.0-1
 BUILDKIT_VERSION ?= v0.18.1
+
+# QEMU binfmt registration images (see setup-qemu). Both run --privileged, so
+# they come from the Microsoft-vetted MCR mirrors (no direct third-party pulls)
+# and are pinned by digest as well as tag: a floating reference on a privileged
+# release-path container is a supply-chain risk. The binfmt mirror digest is
+# byte-identical to the upstream docker.io/tonistiigi/binfmt tag it mirrors.
+QEMU_VERSION ?= 7.2.0-1
+QEMU_IMAGE ?= mcr.microsoft.com/mirror/docker/multiarch/qemu-user-static:$(QEMU_VERSION)@sha256:cb0dff994856c640b6080bfbd5983352e7856221a989625ea3e232cb7eff4507
+BINFMT_VERSION ?= qemu-v9.2.2-52
+BINFMT_IMAGE ?= mcr.microsoft.com/mirror/docker/tonistiigi/binfmt:$(BINFMT_VERSION)@sha256:1b804311fe87047a4c96d38b4b3ef6f62fca8cd125265917a9e3dc3c996c39e6
 
 # Platforms to build container images for. Defaults to the host/target platform
 # so local single-arch builds (e.g. loading into kind, which cannot load a
@@ -325,20 +334,25 @@ setup-qemu: ## Register QEMU emulation for multi-architecture image builds
 		*,*) \
 			echo "Multi-platform build ($(PLATFORMS)); registering QEMU emulation"; \
 			if [ "$(TARGET_ARCH)" = "amd64" ] ; then \
-				docker run --rm --privileged mcr.microsoft.com/mirror/docker/multiarch/qemu-user-static:$(QEMU_VERSION) --reset -p yes; \
+				docker run --rm --privileged $(QEMU_IMAGE) --reset -p yes; \
 			else \
-				docker run --rm --privileged tonistiigi/binfmt --install all; \
+				docker run --rm --privileged $(BINFMT_IMAGE) --install all; \
 			fi ;; \
 		*) echo "Single-platform build ($(PLATFORMS)); skipping QEMU setup" ;; \
 	esac
 
 # By default, docker buildx create will pull image moby/buildkit:buildx-stable-1 and hit the too many requests error
+# Always select and bootstrap the named builder, not only on creation: if the
+# builder already exists but another builder is current, the subsequent
+# `docker buildx build` would silently run on the wrong builder (potentially a
+# docker-driver one with no multi-platform support).
 .PHONY: docker-buildx-builder
 docker-buildx-builder: setup-qemu
-	@if ! docker buildx ls | grep $(BUILDX_BUILDER_NAME); then \
-		docker buildx create --driver-opt image=mcr.microsoft.com/oss/v2/moby/buildkit:$(BUILDKIT_VERSION) --name $(BUILDX_BUILDER_NAME) --use; \
-		docker buildx inspect $(BUILDX_BUILDER_NAME) --bootstrap; \
+	@if ! docker buildx ls | grep -q "$(BUILDX_BUILDER_NAME)"; then \
+		docker buildx create --driver-opt image=mcr.microsoft.com/oss/v2/moby/buildkit:$(BUILDKIT_VERSION) --name $(BUILDX_BUILDER_NAME); \
 	fi
+	docker buildx use $(BUILDX_BUILDER_NAME)
+	docker buildx inspect $(BUILDX_BUILDER_NAME) --bootstrap
 
 .PHONY: docker-build-hub-agent
 docker-build-hub-agent: docker-buildx-builder ## Build hub-agent image

--- a/docker/hub-agent.Dockerfile
+++ b/docker/hub-agent.Dockerfile
@@ -1,8 +1,12 @@
+# syntax=docker/dockerfile:1
 # Build the hubagent binary
 FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.5-1 AS builder
 
-ARG GOOS=linux
-ARG GOARCH=amd64
+# TARGETOS and TARGETARCH are populated automatically by BuildKit for each
+# platform being built, so a single multi-platform `docker buildx build`
+# produces a correctly built binary per architecture.
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -13,19 +17,23 @@ COPY go.sum go.sum
 RUN go mod download
 
 # Copy the go source
-COPY cmd/hubagent/  cmd/hubagent/
+COPY cmd/hubagent/ cmd/hubagent/
 COPY apis/ apis/
 COPY pkg/ pkg/
 
-# Build
-RUN echo "Building images with GOOS=$GOOS GOARCH=$GOARCH"
-RUN CGO_ENABLED=1 GOOS=$GOOS GOARCH=$GOARCH GOEXPERIMENT=systemcrypto GO111MODULE=on go build -o hubagent  cmd/hubagent/main.go
+# Build. CGO + systemcrypto compiles against the target architecture's OpenSSL,
+# which is why the builder runs per-target under emulation (see the Makefile's
+# docker-buildx-builder / setup-qemu targets) rather than cross-compiling.
+RUN echo "Building hubagent with GOOS=${TARGETOS} GOARCH=${TARGETARCH}" && \
+    CGO_ENABLED=1 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOEXPERIMENT=systemcrypto go build -o hubagent ./cmd/hubagent/
 
-# Use distroless as minimal base image to package the hubagent binary
+# Use distroless as minimal base image to package the hubagent binary.
+# The pinned digest must reference a multi-arch image index so BuildKit can
+# resolve the matching base layer for each target architecture.
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/base:nonroot@sha256:97b9d04bed1c754b756c3c4b6a04915c22fb0b5d96a59944eb3bf78c26e6e157
 WORKDIR /
-COPY --from=builder /workspace/hubagent .
+COPY --link --from=builder /workspace/hubagent .
 USER 65532:65532
 
 ENTRYPOINT ["/hubagent"]

--- a/docker/member-agent.Dockerfile
+++ b/docker/member-agent.Dockerfile
@@ -1,8 +1,12 @@
+# syntax=docker/dockerfile:1
 # Build the memberagent binary
 FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.5-1 AS builder
 
-ARG GOOS=linux
-ARG GOARCH=amd64
+# TARGETOS and TARGETARCH are populated automatically by BuildKit for each
+# platform being built, so a single multi-platform `docker buildx build`
+# produces a correctly built binary per architecture.
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -17,15 +21,19 @@ COPY cmd/memberagent cmd/memberagent/
 COPY apis/ apis/
 COPY pkg/ pkg/
 
-# Build
-RUN echo "Building images with GOOS=$GOOS GOARCH=$GOARCH"
-RUN CGO_ENABLED=1 GOOS=$GOOS GOARCH=$GOARCH GOEXPERIMENT=systemcrypto GO111MODULE=on go build -o memberagent cmd/memberagent/main.go
+# Build. CGO + systemcrypto compiles against the target architecture's OpenSSL,
+# which is why the builder runs per-target under emulation (see the Makefile's
+# docker-buildx-builder / setup-qemu targets) rather than cross-compiling.
+RUN echo "Building memberagent with GOOS=${TARGETOS} GOARCH=${TARGETARCH}" && \
+    CGO_ENABLED=1 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOEXPERIMENT=systemcrypto go build -o memberagent ./cmd/memberagent/
 
-# Use distroless as minimal base image to package the memberagent binary
+# Use distroless as minimal base image to package the memberagent binary.
+# The pinned digest must reference a multi-arch image index so BuildKit can
+# resolve the matching base layer for each target architecture.
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/base:nonroot@sha256:97b9d04bed1c754b756c3c4b6a04915c22fb0b5d96a59944eb3bf78c26e6e157
 WORKDIR /
-COPY --from=builder /workspace/memberagent .
+COPY --link --from=builder /workspace/memberagent .
 USER 65532:65532
 
 ENTRYPOINT ["/memberagent"]

--- a/docker/refresh-token.Dockerfile
+++ b/docker/refresh-token.Dockerfile
@@ -1,8 +1,12 @@
+# syntax=docker/dockerfile:1
 # Build the refreshtoken binary
 FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.5-1 AS builder
 
-ARG GOOS="linux"
-ARG GOARCH="amd64"
+# TARGETOS and TARGETARCH are populated automatically by BuildKit for each
+# platform being built, so a single multi-platform `docker buildx build`
+# produces a correctly built binary per architecture.
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -18,17 +22,19 @@ COPY pkg/authtoken pkg/authtoken
 # writefile is a dependency of pkg/authtoken for secure file creation (0600 permissions)
 COPY pkg/utils/writefile pkg/utils/writefile
 
-ARG TARGETARCH
+# Build. CGO + systemcrypto compiles against the target architecture's OpenSSL,
+# which is why the builder runs per-target under emulation (see the Makefile's
+# docker-buildx-builder / setup-qemu targets) rather than cross-compiling.
+RUN echo "Building refreshtoken with GOOS=${TARGETOS} GOARCH=${TARGETARCH}" && \
+    CGO_ENABLED=1 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOEXPERIMENT=systemcrypto go build -o refreshtoken .
 
-# Build
-RUN echo "Building images with GOOS=${GOOS} GOARCH=${GOARCH}"
-RUN CGO_ENABLED=1 GOOS=$GOOS GOARCH=$GOARCH GOEXPERIMENT=systemcrypto GO111MODULE=on go build -o refreshtoken main.go
-
-# Use distroless as minimal base image to package the refreshtoken binary
+# Use distroless as minimal base image to package the refreshtoken binary.
+# The pinned digest must reference a multi-arch image index so BuildKit can
+# resolve the matching base layer for each target architecture.
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/base:nonroot@sha256:97b9d04bed1c754b756c3c4b6a04915c22fb0b5d96a59944eb3bf78c26e6e157
 WORKDIR /
-COPY --from=builder /workspace/refreshtoken .
+COPY --link --from=builder /workspace/refreshtoken .
 USER 65532:65532
 
 ENTRYPOINT ["/refreshtoken"]


### PR DESCRIPTION
## What

Make the `hub-agent`, `member-agent`, and `refresh-token` images multi-arch (`linux/amd64` + `linux/arm64`) and collapse the image publish path into a single dual-tag `docker buildx build`, removing the separate `docker buildx imagetools create` retag step.

Addresses two Phase 1 items from #693:
- Add `linux/arm64` to `make push`.
- Replace the `imagetools create` retag with a single dual-tag `buildx` invocation.

## Changes

**Makefile**
- Add `PLATFORMS` (defaults to the host platform so local single-arch builds — e.g. loading into kind — keep working) and `RELEASE_PLATFORMS` (`linux/amd64,linux/arm64`); `make push` now builds a multi-arch manifest.
- New `setup-qemu` target registers QEMU emulation for any multi-platform build **regardless of whether the buildx builder already exists**. The previous recipe registered QEMU only inside the builder-creation branch, so on a runner where the builder already existed emulation was skipped and the foreign-arch build failed with `exec format error`. Single-platform builds skip QEMU (native, not needed).
- `IMAGE_EXTRA_TAG` adds an additional tag within the same `buildx` invocation, so a stable release publishes both the full and short tags from one build.

**Dockerfiles (`docker/*.Dockerfile`)**
- Use BuildKit-provided `TARGETOS`/`TARGETARCH` for per-arch native builds. `CGO_ENABLED=1` + `GOEXPERIMENT=systemcrypto` links against the target architecture's OpenSSL, so pure cross-compilation isn't possible — each arch is built natively under emulation.
- Add `# syntax=docker/dockerfile:1` and `COPY --link`.
- Use package-path `go build` (e.g. `./cmd/hubagent/`) so a future second source file in a package isn't silently dropped.
- The pinned distroless base digest is a multi-arch image index, so BuildKit resolves the matching base layer per target arch.

**release.yml**
- A single dual-tag `make push` replaces the old `make push` + `imagetools create` retag. Stable releases publish both `vX.Y.Z` and the short `X.Y.Z`; RC tags publish only the full form (the short-tag namespace stays reserved for stable releases consumers pin to).
- The verify step now asserts each published tag is a real multi-arch manifest (via `imagetools inspect`) instead of only echoing tag strings.

## Testing

- Dry-runs confirm `make push IMAGE_EXTRA_TAG=<v>` forwards through the recursive make and emits two `--tag` flags per image; single-platform default emits one.
- End-to-end build of `refresh-token` to a local registry: one `buildx` push produced both tags at the **same digest**, each a manifest list containing `linux/amd64` + `linux/arm64`; the verify-step logic passed.
- All three `cmd` main packages compile via the package-path form.
- Confirmed the distroless base digest resolves to a multi-arch index.