### PR TITLE
ci: add actionlint + shellcheck workflow linting

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - oracle-vm-16cpu-64gb-x86-64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,9 +50,9 @@ jobs:
       
       - name: Prepare necessary environment variables
         run: |
-          echo "CGO_ENABLED=1" >> $GITHUB_ENV
+          echo "CGO_ENABLED=1" >> "$GITHUB_ENV"
           KUBEBUILDER_ASSETS=$(make --silent kubebuilder-assets-path)
-          echo "KUBEBUILDER_ASSETS="$KUBEBUILDER_ASSETS"" >> $GITHUB_ENV
+          echo "KUBEBUILDER_ASSETS=$KUBEBUILDER_ASSETS" >> "$GITHUB_ENV"
 
       # Certain tests that require special setup (e.g., those that should be run with Ginkgo CLI only) will
       # be skipped in this step.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
           echo "✅ Published images:"
           for IMAGE in ${{ env.HUB_AGENT_IMAGE_NAME }} ${{ env.MEMBER_AGENT_IMAGE_NAME }} ${{ env.REFRESH_TOKEN_IMAGE_NAME }}; do
             echo "  - ${{ env.REGISTRY }}/${IMAGE}:${{ env.TAG }}"
-            if [[ "${{ env.TAG }}" != *-rc.* ]]; then
+            if [[ "${TAG}" != *-rc.* ]]; then
               echo "  - ${{ env.REGISTRY }}/${IMAGE}:${VERSION}"
             fi
           done

--- a/.github/workflows/setup-release.yml
+++ b/.github/workflows/setup-release.yml
@@ -38,7 +38,9 @@ jobs:
                   fi
 
                   # registry must be in lowercase
-                  echo "registry=$(echo "${{ env.REGISTRY }}/${{ github.repository }}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
-                  echo "tag=${TAG}" >> $GITHUB_OUTPUT
-                  echo "version=${TAG#v}" >> $GITHUB_OUTPUT
+                  {
+                    echo "registry=$(echo "${{ env.REGISTRY }}/${{ github.repository }}" | tr '[:upper:]' '[:lower:]')"
+                    echo "tag=${TAG}"
+                    echo "version=${TAG#v}"
+                  } >> "$GITHUB_OUTPUT"
                   echo "Release tag: ${TAG}, version: ${TAG#v}"

--- a/.github/workflows/squad-heartbeat.yml
+++ b/.github/workflows/squad-heartbeat.yml
@@ -31,9 +31,9 @@ jobs:
         id: check-script
         run: |
           if [ -f ".squad/templates/ralph-triage.js" ]; then
-            echo "has_script=true" >> $GITHUB_OUTPUT
+            echo "has_script=true" >> "$GITHUB_OUTPUT"
           else
-            echo "has_script=false" >> $GITHUB_OUTPUT
+            echo "has_script=false" >> "$GITHUB_OUTPUT"
             echo "⚠️ ralph-triage.js not found — run 'squad upgrade' to install"
           fi
 

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -3,9 +3,9 @@ on:
   push:
     branches:
       - main
-  create:
     # Publish semver tags as releases.
-    tags: [ 'v*.*.*' ]
+    tags:
+      - 'v*.*.*'
   workflow_dispatch: {}
 
 permissions:
@@ -31,7 +31,7 @@ jobs:
           # registry must be in lowercase
           # store the images under dev
           # TODO: need to cleanup dev images periodically 
-          echo "registry=$(echo "${{ env.REGISTRY }}/${{ github.repository }}" | tr [:upper:] [:lower:])"  >> $GITHUB_OUTPUT
+          echo "registry=$(echo "${{ env.REGISTRY }}/${{ github.repository }}" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
   scan-images:
     needs: export-registry
     env:
@@ -54,7 +54,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: generate image version
-        run: echo IMAGE_VERSION=$(git rev-parse --short=7 HEAD) >> $GITHUB_ENV
+        run: echo "IMAGE_VERSION=$(git rev-parse --short=7 HEAD)" >> "$GITHUB_ENV"
 
       - name: Build and push images to registry with tag ${{ env.IMAGE_VERSION }}
         run: |

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -69,7 +69,7 @@ jobs:
               echo "Fetch all tags..."
 
               git fetch --all
-              GIT_TAG=$(git describe --tags --exclude='*-rc.*' $(git rev-list --tags --exclude='*-rc.*' --max-count=1))
+              GIT_TAG=$(git describe --tags --exclude='*-rc.*' "$(git rev-list --tags --exclude='*-rc.*' --max-count=1)")
           else
               echo "A tag is specified; go back to the state tracked by the specified tag."
               echo "Fetch all tags..."
@@ -77,7 +77,7 @@ jobs:
               git fetch --all
           fi
 
-          git checkout $GIT_TAG
+          git checkout "$GIT_TAG"
           echo "Checked out source code at $GIT_TAG."
 
       - name: Prepare the fleet using the before upgrade version
@@ -86,7 +86,7 @@ jobs:
         # Note that the `git checkout` command below only checks out the `test/upgrade` directory (at
         # the current commit); the rest of the source code is still at the before-upgrade version.
         run: |
-          git checkout $CURRENT_BRANCH -- test/upgrade
+          git checkout "$CURRENT_BRANCH" -- test/upgrade
           cd test/upgrade && chmod +x setup.sh && cd -
           ./test/upgrade/setup.sh 3
         env:
@@ -96,7 +96,7 @@ jobs:
       - name: Travel to the current state
         # Run the test suite from the current version, i.e., the commit that triggered the workflow.
         run: |
-          git checkout $CURRENT_BRANCH
+          git checkout "$CURRENT_BRANCH"
           echo "Checked out source code at $CURRENT_BRANCH."
 
       - name: Run the Before suite
@@ -152,7 +152,7 @@ jobs:
               echo "Fetch all tags..."
 
               git fetch --all
-              GIT_TAG=$(git describe --tags --exclude='*-rc.*' $(git rev-list --tags --exclude='*-rc.*' --max-count=1)) 
+              GIT_TAG=$(git describe --tags --exclude='*-rc.*' "$(git rev-list --tags --exclude='*-rc.*' --max-count=1)") 
           else
               echo "A tag is specified; go back to the state tracked by the specified tag."
               echo "Fetch all tags..."
@@ -160,7 +160,7 @@ jobs:
               git fetch --all
           fi
 
-          git checkout $GIT_TAG
+          git checkout "$GIT_TAG"
           echo "Checked out source code at $GIT_TAG."
 
       - name: Prepare the fleet using the before upgrade version
@@ -169,7 +169,7 @@ jobs:
         # Note that the `git checkout` command below only checks out the `test/upgrade` directory (at
         # the current commit); the rest of the source code is still at the before-upgrade version.
         run: |
-          git checkout $CURRENT_BRANCH -- test/upgrade
+          git checkout "$CURRENT_BRANCH" -- test/upgrade
           cd test/upgrade && chmod +x setup.sh && cd -
           ./test/upgrade/setup.sh 3
         env:
@@ -179,7 +179,7 @@ jobs:
       - name: Travel to the current state
         # Run the test suite from the current version, i.e., the commit that triggered the workflow.
         run: |
-          git checkout $CURRENT_BRANCH
+          git checkout "$CURRENT_BRANCH"
           echo "Checked out source code at $CURRENT_BRANCH."
 
       - name: Run the Before suite
@@ -235,7 +235,7 @@ jobs:
               echo "Fetch all tags..."
 
               git fetch --all
-              GIT_TAG=$(git describe --tags --exclude='*-rc.*' $(git rev-list --tags --exclude='*-rc.*' --max-count=1)) 
+              GIT_TAG=$(git describe --tags --exclude='*-rc.*' "$(git rev-list --tags --exclude='*-rc.*' --max-count=1)") 
           else
               echo "A tag is specified; go back to the state tracked by the specified tag."
               echo "Fetch all tags..."
@@ -243,7 +243,7 @@ jobs:
               git fetch --all
           fi
 
-          git checkout $GIT_TAG
+          git checkout "$GIT_TAG"
           echo "Checked out source code at $GIT_TAG."
 
       - name: Prepare the fleet using the before upgrade version
@@ -252,7 +252,7 @@ jobs:
         # Note that the `git checkout` command below only checks out the `test/upgrade` directory (at
         # the current commit); the rest of the source code is still at the before-upgrade version.
         run: |
-          git checkout $CURRENT_BRANCH -- test/upgrade
+          git checkout "$CURRENT_BRANCH" -- test/upgrade
           cd test/upgrade && chmod +x setup.sh && cd -
           ./test/upgrade/setup.sh 3
         env:
@@ -262,7 +262,7 @@ jobs:
       - name: Travel to the current state
         # Run the test suite from the current version, i.e., the commit that triggered the workflow.
         run: |
-          git checkout $CURRENT_BRANCH
+          git checkout "$CURRENT_BRANCH"
           echo "Checked out source code at $CURRENT_BRANCH."
 
       - name: Run the Before suite

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -1,0 +1,45 @@
+name: Workflow Lint
+
+on:
+  push:
+    branches: [main, "release-*"]
+    paths:
+      - ".github/workflows/**"
+      - ".github/release.yml"
+  pull_request:
+    branches: [main, "release-*"]
+    paths:
+      - ".github/workflows/**"
+      - ".github/release.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    name: actionlint + shellcheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9ca718d3bf646d6534007c269a635b3e54cadf99 # v2.19.2
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Verify shellcheck is available
+        run: shellcheck --version
+
+      - name: Install actionlint
+        env:
+          ACTIONLINT_VERSION: "1.7.12"
+        run: |
+          curl -sSfL "https://raw.githubusercontent.com/rhysd/actionlint/v${ACTIONLINT_VERSION}/scripts/download-actionlint.bash" -o download-actionlint.bash
+          bash download-actionlint.bash "${ACTIONLINT_VERSION}"
+          rm -f download-actionlint.bash
+          echo "${PWD}" >> "${GITHUB_PATH}"
+
+      - name: Run actionlint
+        run: actionlint -color


### PR DESCRIPTION
### Description of your changes

Adds a lightweight Workflow Lint workflow to catch GitHub Actions issues during review instead of mid-release.

- A new `Workflow Lint` workflow that runs `[actionlint](https://github.com/rhysd/actionlint)` whenever a PR or push touches `.github/workflows/**` or `.github/release.yml`. actionlint validates workflow syntax, expression references, and event triggers, and automatically runs `shellcheck` (already on the `ubuntu-latest` image) over every `run:` block.

- `.github/actionlint.yaml` registers our self-hosted runner label (`oracle-vm-16cpu-64gb-x86-64`) so actionlint doesn't false-fail on `ci.yml`. This is the only config the linter needs.
<!--

Briefly describe what this pull request does. We love pull requests that have a clear purpose. If yours fix an issue,
please uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Refs:  #714

I have:

- [x] Associated this change with a known KubeFleet Issue (Bug, Feature, etc).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- Ran `actionlint` v1.7.12 with `shellcheck` 0.11.0 locally against the whole `.github/workflows/` tree — it now exits cleanly with zero findings.
- Ran `make reviewable`.
<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

Two of the fixes were more than mechanical, so I want to call them out explicitly. please push back if you'd prefer a different approach:

1. `release.yml` (SC2193): The `[[ "${{ env.TAG }}" != *-rc.* ]]` comparison tripped shellcheck because actionlint expands `${{ env.TAG }}` before shellcheck sees it. `TAG` is already a job-level `env:` var, so I switched it to reference the shell variable directly, same runtime behavior, and it also matches GitHub's guidance on not inlining `${{ }}` into scripts:
 ```
   [[ "${TAG}" != *-rc.* ]]
```

2. trivy.yml: this one changes trigger behavior, please review. The tags: ['v*.*.*'] filter was placed under the create event, where GitHub silently ignores it, so the scanner was firing on every branch and tag creation, not just version tags. I moved the filter under push, which matches the file's own "publish semver tags as releases" comment:
```
 on:
   push:
     branches:
       - main
     tags:
       - 'v*.*.*'
   workflow_dispatch: {}
```

Before: ran on push to main + any create event.

After: runs on push to main + push of a v*.*.* tag.

If you'd rather keep the create event (e.g. guard the job with if: startsWith(github.ref, 'refs/tags/v')) or split this trigger fix into its own PR, just say so and I'll adjust.


