### PR TITLE
chore: bump Go versions to address security concerns

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
     paths-ignore: [docs/**, "**.md", "**.mdx", "**.png", "**.jpg"]
 
 env:
-  GO_VERSION: '1.25.11'
+  GO_VERSION: '1.25.12'
   CERT_MANAGER_VERSION: 'v1.16.2'
 
 jobs:

--- a/.github/workflows/code-lint.yml
+++ b/.github/workflows/code-lint.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: "1.25.11"
+  GO_VERSION: "1.25.12"
 
 jobs:
   detect-noop:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ env:
   HUB_AGENT_IMAGE_NAME: hub-agent
   MEMBER_AGENT_IMAGE_NAME: member-agent
   REFRESH_TOKEN_IMAGE_NAME: refresh-token
-  GO_VERSION: "1.25.11"
+  GO_VERSION: "1.25.12"
 
 jobs:
   export-registry:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -18,7 +18,7 @@ env:
   MEMBER_AGENT_IMAGE_NAME: member-agent
   REFRESH_TOKEN_IMAGE_NAME: refresh-token
 
-  GO_VERSION: '1.25.11'
+  GO_VERSION: '1.25.12'
 
 jobs:
   export-registry:

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -17,7 +17,7 @@ on:
     paths-ignore: [docs/**, "**.md", "**.mdx", "**.png", "**.jpg"]
 
 env:
-  GO_VERSION: '1.25.11'
+  GO_VERSION: '1.25.12'
 
 jobs:
   detect-noop:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 run:
   timeout: 15m
-  go: '1.25.11'
+  go: '1.25.12'
 
 linters-settings:
   stylecheck:

--- a/docker/hub-agent.Dockerfile
+++ b/docker/hub-agent.Dockerfile
@@ -1,5 +1,5 @@
 # Build the hubagent binary
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.4 AS builder
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.5 AS builder
 
 ARG GOOS=linux
 ARG GOARCH=amd64

--- a/docker/member-agent.Dockerfile
+++ b/docker/member-agent.Dockerfile
@@ -1,5 +1,5 @@
 # Build the memberagent binary
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.4 AS builder
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.5 AS builder
 
 ARG GOOS=linux
 ARG GOARCH=amd64

--- a/docker/refresh-token.Dockerfile
+++ b/docker/refresh-token.Dockerfile
@@ -1,5 +1,5 @@
 # Build the refreshtoken binary
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.4 AS builder
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.5 AS builder
 
 ARG GOOS="linux"
 ARG GOARCH="amd64"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubefleet-dev/kubefleet
 
-go 1.25.11
+go 1.25.12
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.0


### PR DESCRIPTION
### Description of your changes

This PR uses Go 1.26.5 to build images and Go 1.25.12 in `go.mod`.

I have:

- [NA] Associated this change with a known KubeFleet Issue (Bug, Feature, etc).
- [NA] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

N/A

### Special notes for your reviewer

N/A