### PR TITLE
feat: update trivy scan workflow and add CVE remediation agent

### DIFF
--- a/.github/agents/cve-scanner.agent.md
+++ b/.github/agents/cve-scanner.agent.md
@@ -1,0 +1,114 @@
+---
+name: CVE Scanner
+description: "Scan KubeFleet container images for vulnerabilities and create PRs to remediate CVEs by upgrading Go dependencies."
+---
+
+You are the **CVE Scanner** agent for the KubeFleet project. Your job is to scan
+container images for vulnerabilities using Trivy, analyze the findings, and open
+pull requests that upgrade Go dependencies to fix the CVEs.
+
+## Images to Scan
+
+KubeFleet ships three container images, all built from Dockerfiles in `docker/`:
+
+| Image | Dockerfile | Binary |
+|-------|-----------|--------|
+| `hub-agent` | `docker/hub-agent.Dockerfile` | `cmd/hubagent/main.go` |
+| `member-agent` | `docker/member-agent.Dockerfile` | `cmd/memberagent/main.go` |
+| `refresh-token` | `docker/refresh-token.Dockerfile` | `cmd/refreshtoken/main.go` |
+
+All images share the same `go.mod` / `go.sum` in the repo root, so a single set
+of dependency upgrades fixes all three.
+
+## Workflow
+
+### 1. Scan
+
+Run Trivy against each image to get JSON vulnerability reports:
+
+```bash
+# Install Trivy if needed
+# See https://aquasecurity.github.io/trivy/latest/getting-started/installation/
+
+# Build images locally first
+make docker-build-hub-agent docker-build-member-agent docker-build-refresh-token
+
+# Scan each image
+for IMAGE in hub-agent member-agent refresh-token; do
+  trivy image --format json --ignore-unfixed \
+    --severity CRITICAL,HIGH \
+    --vuln-type os,library \
+    --output "trivy-${IMAGE}.json" \
+    "fleet-${IMAGE}:latest"
+done
+```
+
+### 2. Analyze
+
+Parse the JSON reports to extract fixable Go library vulnerabilities:
+
+```bash
+jq -r '[.Results[]?
+  | select(.Class == "lang-pkgs" and .Type == "gomod")
+  | .Vulnerabilities[]?
+  | select(.FixedVersion != null)
+  | {id: .VulnerabilityID, pkg: .PkgName, installed: .InstalledVersion, fixed: .FixedVersion, severity: .Severity}
+] | unique_by(.pkg) | sort_by(.severity)' trivy-*.json
+```
+
+### 3. Remediate
+
+For each vulnerable Go package with a fix version:
+
+```bash
+go get <package>@v<fixed_version>
+go mod tidy
+```
+
+After upgrading, verify the build still works:
+
+```bash
+make build
+make local-unit-test
+```
+
+### 4. Create PR
+
+Create a pull request with:
+- **Title**: `fix: remediate CVEs in container images`
+- **Branch**: `trivy-cve-fix/<date>`
+- **Labels**: `security`, `dependencies`
+- **Body**: List each CVE fixed, the package upgraded, and old→new versions
+
+### PR body template
+
+```markdown
+## CVE Remediation
+
+Trivy scan detected fixable Go dependency vulnerabilities in our container images.
+This PR upgrades the affected packages.
+
+### Upgraded dependencies
+
+| Severity | CVE | Package | Old Version | New Version |
+|----------|-----|---------|------------|-------------|
+| CRITICAL | CVE-XXXX-XXXXX | example.com/pkg | v1.0.0 | v1.0.1 |
+
+### Verification
+
+- [ ] `make build` passes
+- [ ] `make local-unit-test` passes
+- [ ] `make reviewable` passes
+```
+
+## Guidelines
+
+- Always pin to exact fix versions from Trivy output; do not speculatively upgrade
+  to the latest version unless the fix version IS the latest.
+- If a `go get` upgrade fails (e.g., breaking API change), note it in the PR body
+  and skip that package — do not leave the build broken.
+- Group all fixable CVEs into a single PR when they share the same `go.mod`.
+- Run `make reviewable` before finalizing to ensure code quality checks pass.
+- Follow the project's PR title convention: use the `fix:` prefix.
+- OS-level vulnerabilities (from the base image) cannot be fixed via Go upgrades.
+  Note them in the PR body and recommend a base image update if applicable.

--- a/.github/agents/cve-scanner.agent.md
+++ b/.github/agents/cve-scanner.agent.md
@@ -107,7 +107,9 @@ This PR upgrades the affected packages.
   to the latest version unless the fix version IS the latest.
 - If a `go get` upgrade fails (e.g., breaking API change), note it in the PR body
   and skip that package — do not leave the build broken.
-- Group all fixable CVEs into a single PR when they share the same `go.mod`.
+- When running interactively, group all fixable CVEs into a single PR when they
+  share the same `go.mod`. The automated workflow may still create per-image PRs
+  for scan traceability.
 - Run `make reviewable` before finalizing to ensure code quality checks pass.
 - Follow the project's PR title convention: use the `fix:` prefix.
 - OS-level vulnerabilities (from the base image) cannot be fixed via Go upgrades.

--- a/.github/agents/cve-scanner.agent.md
+++ b/.github/agents/cve-scanner.agent.md
@@ -30,7 +30,10 @@ Run Trivy against each image to get JSON vulnerability reports:
 # Install Trivy if needed
 # See https://aquasecurity.github.io/trivy/latest/getting-started/installation/
 
-# Build images locally first
+# Build images locally first (load into Docker instead of pushing)
+export OUTPUT_TYPE="type=docker"
+export REGISTRY="localhost"
+export TAG="trivy-scan"
 make docker-build-hub-agent docker-build-member-agent docker-build-refresh-token
 
 # Scan each image
@@ -39,7 +42,7 @@ for IMAGE in hub-agent member-agent refresh-token; do
     --severity CRITICAL,HIGH \
     --vuln-type os,library \
     --output "trivy-${IMAGE}.json" \
-    "fleet-${IMAGE}:latest"
+    "localhost/${IMAGE}:trivy-scan"
 done
 ```
 

--- a/.github/agents/cve-scanner.agent.md
+++ b/.github/agents/cve-scanner.agent.md
@@ -64,7 +64,9 @@ jq -r '[.Results[]?
 For each vulnerable Go package with a fix version:
 
 ```bash
-go get <package>@v<fixed_version>
+# Strip leading 'v' if present, then prefix with v
+FIXED="${FIXED_VERSION#v}"
+go get <package>@v${FIXED}
 go mod tidy
 ```
 

--- a/.github/agents/cve-scanner.agent.md
+++ b/.github/agents/cve-scanner.agent.md
@@ -51,12 +51,12 @@ done
 Parse the JSON reports to extract fixable Go library vulnerabilities:
 
 ```bash
-jq -r '[.Results[]?
+jq -s '[.[].Results[]?
   | select(.Class == "lang-pkgs" and .Type == "gomod")
   | .Vulnerabilities[]?
   | select(.FixedVersion != null)
   | {id: .VulnerabilityID, pkg: .PkgName, installed: .InstalledVersion, fixed: .FixedVersion, severity: .Severity}
-] | unique_by(.pkg) | sort_by(.severity)' trivy-*.json
+] | group_by(.pkg) | map(sort_by(.fixed | ltrimstr("v") | split(".") | map(tonumber)) | last)' trivy-*.json
 ```
 
 ### 3. Remediate
@@ -79,11 +79,14 @@ make local-unit-test
 
 ### 4. Create PR
 
-Create a pull request with:
+Create a single pull request covering all images (they share the same `go.mod`):
 - **Title**: `fix: remediate CVEs in container images`
 - **Branch**: `trivy-cve-fix/<date>`
 - **Labels**: `security`, `dependencies`
-- **Body**: List each CVE fixed, the package upgraded, and old→new versions
+- **Body**: List each CVE fixed, the package upgraded, and old->new versions
+
+> Note: The automated `trivy-remediate.yml` workflow creates per-image PRs for
+> scan traceability. When running interactively, prefer a single consolidated PR.
 
 ### PR body template
 

--- a/.github/workflows/trivy-remediate.yml
+++ b/.github/workflows/trivy-remediate.yml
@@ -45,10 +45,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Login to ${{ env.REGISTRY }}
+      - name: Login to GHCR
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
         with:
-          registry: ${{ env.REGISTRY }}
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
@@ -139,7 +139,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.changes.outputs.has_changes == 'true'
-        uses: peter-evans/create-pull-request@5f6978f # v8.1.1
+        uses: peter-evans/create-pull-request@5f6978feb637d0d40460b08e3626d77b938b046f # v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "fix: remediate CVEs in ${{ matrix.image }} image"

--- a/.github/workflows/trivy-remediate.yml
+++ b/.github/workflows/trivy-remediate.yml
@@ -95,9 +95,9 @@ jobs:
           echo "$VULNS" | jq -r '.[] | "  \(.severity) \(.id): \(.pkg) \(.installed) -> \(.fixed)"'
 
           COUNT=$(echo "$VULNS" | jq 'length')
-          echo "vuln_count=$COUNT" >> "$GITHUB_OUTPUT"
 
           if [ "$COUNT" -eq 0 ]; then
+            echo "vuln_count=0" >> "$GITHUB_OUTPUT"
             echo "No fixable Go library vulnerabilities found for ${{ matrix.image }}."
             exit 0
           fi
@@ -117,9 +117,12 @@ jobs:
 
           go mod tidy
 
-          echo "upgraded_list<<EOF" >> "$GITHUB_OUTPUT"
-          echo -e "$UPGRADED" >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
+          {
+            echo "vuln_count=$COUNT"
+            echo "upgraded_list<<EOF"
+            echo -e "$UPGRADED"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Check for changes
         id: changes

--- a/.github/workflows/trivy-remediate.yml
+++ b/.github/workflows/trivy-remediate.yml
@@ -108,11 +108,15 @@ jobs:
             _jq() { echo "$row" | base64 --decode | jq -r "$1"; }
             PKG=$(_jq '.pkg')
             FIXED=$(_jq '.fixed')
+            FIXED="${FIXED#v}"
             ID=$(_jq '.id')
             SEVERITY=$(_jq '.severity')
-            echo "Upgrading $PKG to $FIXED (fixes $ID)"
-            go get "$PKG@v$FIXED" || echo "Warning: failed to upgrade $PKG"
-            UPGRADED="$UPGRADED- **$SEVERITY**: \`$ID\` — upgraded \`$PKG\` to v$FIXED\n"
+            echo "Upgrading $PKG to v$FIXED (fixes $ID)"
+            if go get "$PKG@v$FIXED"; then
+              UPGRADED="$UPGRADED- **$SEVERITY**: \`$ID\` — upgraded \`$PKG\` to v$FIXED\n"
+            else
+              echo "Warning: failed to upgrade $PKG to v$FIXED"
+            fi
           done
 
           go mod tidy

--- a/.github/workflows/trivy-remediate.yml
+++ b/.github/workflows/trivy-remediate.yml
@@ -89,7 +89,7 @@ jobs:
               | .Vulnerabilities[]?
               | select(.FixedVersion != null and .FixedVersion != "")
               | {id: .VulnerabilityID, pkg: .PkgName, installed: .InstalledVersion, fixed: .FixedVersion, severity: .Severity}
-            ] | unique_by(.pkg)' trivy-results.json 2>/dev/null || echo '[]')
+            ] | group_by(.pkg) | map(sort_by(.fixed | ltrimstr("v") | split(".") | map(tonumber)) | last)' trivy-results.json 2>/dev/null || echo '[]')
 
           echo "Found Go library vulnerabilities:"
           echo "$VULNS" | jq -r '.[] | "  \(.severity) \(.id): \(.pkg) \(.installed) -> \(.fixed)"'

--- a/.github/workflows/trivy-remediate.yml
+++ b/.github/workflows/trivy-remediate.yml
@@ -1,0 +1,164 @@
+name: Trivy CVE Remediation
+on:
+  schedule:
+    # Run weekly on Wednesday at 09:00 UTC
+    - cron: '0 9 * * 3'
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  packages: write
+  pull-requests: write
+
+env:
+  REGISTRY: ghcr.io
+  GO_VERSION: '1.25.12'
+
+jobs:
+  export-registry:
+    runs-on: ubuntu-latest
+    outputs:
+      registry: ${{ steps.export.outputs.registry }}
+    steps:
+      - id: export
+        run: |
+          echo "registry=$(echo "${{ env.REGISTRY }}/${{ github.repository }}" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
+  scan-and-remediate:
+    needs: export-registry
+    runs-on: ubuntu-latest
+    env:
+      REGISTRY: ${{ needs.export-registry.outputs.registry }}
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - hub-agent
+          - member-agent
+          - refresh-token
+    steps:
+      - name: Set up Go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Login to ${{ env.REGISTRY }}
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate image version
+        run: echo "IMAGE_VERSION=$(git rev-parse --short=7 HEAD)" >> "$GITHUB_ENV"
+
+      - name: Build and push ${{ matrix.image }}
+        run: make docker-build-${{ matrix.image }}
+        env:
+          REGISTRY: ${{ env.REGISTRY }}
+          TAG: ${{ env.IMAGE_VERSION }}
+          OUTPUT_TYPE: type=registry
+
+      - name: Scan ${{ matrix.image }} (JSON)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ matrix.image }}:${{ env.IMAGE_VERSION }}
+          format: 'json'
+          output: 'trivy-results.json'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
+          timeout: '5m0s'
+        env:
+          TRIVY_USERNAME: ${{ github.actor }}
+          TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          TRIVY_DB_REPOSITORY: mcr.microsoft.com/mirror/ghcr/aquasecurity/trivy-db
+
+      - name: Parse vulnerabilities and upgrade Go dependencies
+        id: remediate
+        run: |
+          set -euo pipefail
+
+          # Extract Go library CVEs with fix versions from Trivy JSON
+          VULNS=$(jq -r '
+            [.Results[]?
+              | select(.Class == "lang-pkgs" and .Type == "gomod")
+              | .Vulnerabilities[]?
+              | select(.FixedVersion != null and .FixedVersion != "")
+              | {id: .VulnerabilityID, pkg: .PkgName, installed: .InstalledVersion, fixed: .FixedVersion, severity: .Severity}
+            ] | unique_by(.pkg)' trivy-results.json 2>/dev/null || echo '[]')
+
+          echo "Found Go library vulnerabilities:"
+          echo "$VULNS" | jq -r '.[] | "  \(.severity) \(.id): \(.pkg) \(.installed) -> \(.fixed)"'
+
+          COUNT=$(echo "$VULNS" | jq 'length')
+          echo "vuln_count=$COUNT" >> "$GITHUB_OUTPUT"
+
+          if [ "$COUNT" -eq 0 ]; then
+            echo "No fixable Go library vulnerabilities found for ${{ matrix.image }}."
+            exit 0
+          fi
+
+          # Upgrade each vulnerable package to its fix version
+          UPGRADED=""
+          for row in $(echo "$VULNS" | jq -r '.[] | @base64'); do
+            _jq() { echo "$row" | base64 --decode | jq -r "$1"; }
+            PKG=$(_jq '.pkg')
+            FIXED=$(_jq '.fixed')
+            ID=$(_jq '.id')
+            SEVERITY=$(_jq '.severity')
+            echo "Upgrading $PKG to $FIXED (fixes $ID)"
+            go get "$PKG@v$FIXED" || echo "Warning: failed to upgrade $PKG"
+            UPGRADED="$UPGRADED- **$SEVERITY**: \`$ID\` — upgraded \`$PKG\` to v$FIXED\n"
+          done
+
+          go mod tidy
+
+          echo "upgraded_list<<EOF" >> "$GITHUB_OUTPUT"
+          echo -e "$UPGRADED" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if git diff --quiet go.mod go.sum; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create Pull Request
+        if: steps.changes.outputs.has_changes == 'true'
+        uses: peter-evans/create-pull-request@5f6978f # v8.1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "fix: remediate CVEs in ${{ matrix.image }} image"
+          branch: "trivy-cve-fix/${{ matrix.image }}"
+          delete-branch: true
+          title: "fix: remediate CVEs found in ${{ matrix.image }}"
+          body: |
+            ## Automated CVE Remediation — `${{ matrix.image }}`
+
+            Trivy scan detected fixable Go dependency vulnerabilities. This PR upgrades the affected packages.
+
+            ### Upgraded dependencies
+
+            ${{ steps.remediate.outputs.upgraded_list }}
+
+            ---
+            _Generated by the [Trivy CVE Remediation](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) workflow._
+          labels: |
+            security
+            dependencies
+            automated
+
+      - name: Upload scan results
+        if: always()
+        uses: actions/upload-artifact@043fb46e7a57af58e954e936061a1f93f05906ca # v7.0.1
+        with:
+          name: trivy-${{ matrix.image }}-results
+          path: trivy-results.json
+          retention-days: 30

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -6,37 +6,36 @@ on:
     # Publish semver tags as releases.
     tags:
       - 'v*.*.*'
+  schedule:
+    # Run weekly on Monday at 09:00 UTC
+    - cron: '0 9 * * 1'
   workflow_dispatch: {}
 
 permissions:
   contents: read
   packages: write
+  security-events: write
 
 env:
   REGISTRY: ghcr.io
-  HUB_AGENT_IMAGE_NAME: hub-agent
-  MEMBER_AGENT_IMAGE_NAME: member-agent
-  REFRESH_TOKEN_IMAGE_NAME: refresh-token
-
   GO_VERSION: '1.25.12'
 
 jobs:
   export-registry:
-    runs-on: ubuntu-latest #Latest tag points to the latest LTS release of Ubuntu per docker hub
+    runs-on: ubuntu-latest
     outputs:
       registry: ${{ steps.export.outputs.registry }}
     steps:
       - id: export
         run: |
           # registry must be in lowercase
-          # store the images under dev
-          # TODO: need to cleanup dev images periodically 
           echo "registry=$(echo "${{ env.REGISTRY }}/${{ github.repository }}" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
-  scan-images:
+
+  build-images:
     needs: export-registry
+    runs-on: ubuntu-latest
     env:
       REGISTRY: ${{ needs.export-registry.outputs.registry }}
-    runs-on: ubuntu-latest #Latest tag points to the latest LTS release of Ubuntu per docker hub
     steps:
       - name: Set up Go ${{ env.GO_VERSION }}
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
@@ -53,20 +52,36 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: generate image version
+      - name: Generate image version
         run: echo "IMAGE_VERSION=$(git rev-parse --short=7 HEAD)" >> "$GITHUB_ENV"
 
       - name: Build and push images to registry with tag ${{ env.IMAGE_VERSION }}
-        run: |
-          make push
+        run: make push
         env:
-          REGISTRY: ${{ env.REGISTRY}}
+          REGISTRY: ${{ env.REGISTRY }}
           TAG: ${{ env.IMAGE_VERSION }}
 
-      - name: Scan ${{ env.REGISTRY }}/${{ env.HUB_AGENT_IMAGE_NAME }}:${{ env.IMAGE_VERSION }}
+    outputs:
+      image_version: ${{ env.IMAGE_VERSION }}
+
+  scan-image:
+    needs: [export-registry, build-images]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - hub-agent
+          - member-agent
+          - refresh-token
+    env:
+      REGISTRY: ${{ needs.export-registry.outputs.registry }}
+      IMAGE_VERSION: ${{ needs.build-images.outputs.image_version }}
+    steps:
+      - name: Scan ${{ matrix.image }} (table)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
-          image-ref: ${{ env.REGISTRY }}/${{ env.HUB_AGENT_IMAGE_NAME }}:${{ env.IMAGE_VERSION }}
+          image-ref: ${{ env.REGISTRY }}/${{ matrix.image }}:${{ env.IMAGE_VERSION }}
           format: 'table'
           exit-code: '1'
           ignore-unfixed: true
@@ -76,15 +91,15 @@ jobs:
         env:
           TRIVY_USERNAME: ${{ github.actor }}
           TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-          TRIVY_DB_REPOSITORY: mcr.microsoft.com/mirror/ghcr/aquasecurity/trivy-db 
+          TRIVY_DB_REPOSITORY: mcr.microsoft.com/mirror/ghcr/aquasecurity/trivy-db
 
-
-      - name: Scan ${{ env.REGISTRY }}/${{ env.MEMBER_AGENT_IMAGE_NAME }}:${{ env.IMAGE_VERSION }}
+      - name: Scan ${{ matrix.image }} (SARIF)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        if: always()
         with:
-          image-ref: ${{ env.REGISTRY }}/${{ env.MEMBER_AGENT_IMAGE_NAME }}:${{ env.IMAGE_VERSION }}
-          format: 'table'
-          exit-code: '1'
+          image-ref: ${{ env.REGISTRY }}/${{ matrix.image }}:${{ env.IMAGE_VERSION }}
+          format: 'sarif'
+          output: '${{ matrix.image }}-trivy-results.sarif'
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'
@@ -92,19 +107,11 @@ jobs:
         env:
           TRIVY_USERNAME: ${{ github.actor }}
           TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-          TRIVY_DB_REPOSITORY: mcr.microsoft.com/mirror/ghcr/aquasecurity/trivy-db 
+          TRIVY_DB_REPOSITORY: mcr.microsoft.com/mirror/ghcr/aquasecurity/trivy-db
 
-      - name: Scan ${{ env.REGISTRY }}/${{ env.REFRESH_TOKEN_IMAGE_NAME }}:${{ env.IMAGE_VERSION }}
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+      - name: Upload SARIF results for ${{ matrix.image }}
+        uses: github/codeql-action/upload-sarif@f0489ab # v4
+        if: always()
         with:
-          image-ref: ${{ env.REGISTRY }}/${{ env.REFRESH_TOKEN_IMAGE_NAME }}:${{ env.IMAGE_VERSION }}
-          format: 'table'
-          exit-code: '1'
-          ignore-unfixed: true
-          vuln-type: 'os,library'
-          severity: 'CRITICAL,HIGH'
-          timeout: '5m0s'
-        env:
-          TRIVY_USERNAME: ${{ github.actor }}
-          TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-          TRIVY_DB_REPOSITORY: mcr.microsoft.com/mirror/ghcr/aquasecurity/trivy-db 
+          sarif_file: '${{ matrix.image }}-trivy-results.sarif'
+          category: 'trivy-${{ matrix.image }}'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -45,10 +45,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Login to ${{ env.REGISTRY }}
+      - name: Login to GHCR
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
         with:
-          registry: ${{ env.REGISTRY }}
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
@@ -114,7 +114,7 @@ jobs:
           TRIVY_DB_REPOSITORY: mcr.microsoft.com/mirror/ghcr/aquasecurity/trivy-db
 
       - name: Upload SARIF results for ${{ matrix.image }}
-        uses: github/codeql-action/upload-sarif@f0489ab # v4
+        uses: github/codeql-action/upload-sarif@f0489ab2491a550e4f630e9e22e15062d8e4d227 # v4
         if: always()
         with:
           sarif_file: '${{ matrix.image }}-trivy-results.sarif'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -53,7 +53,11 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate image version
-        run: echo "IMAGE_VERSION=$(git rev-parse --short=7 HEAD)" >> "$GITHUB_ENV"
+        id: generate-image-version
+        run: |
+          image_version="$(git rev-parse --short=7 HEAD)"
+          echo "IMAGE_VERSION=${image_version}" >> "$GITHUB_ENV"
+          echo "image_version=${image_version}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push images to registry with tag ${{ env.IMAGE_VERSION }}
         run: make push
@@ -62,7 +66,7 @@ jobs:
           TAG: ${{ env.IMAGE_VERSION }}
 
     outputs:
-      image_version: ${{ env.IMAGE_VERSION }}
+      image_version: ${{ steps.generate-image-version.outputs.image_version }}
 
   scan-image:
     needs: [export-registry, build-images]


### PR DESCRIPTION
## Summary

Updates the Trivy vulnerability scanning workflow and adds an automated CVE remediation pipeline with a Copilot coding agent.

### Changes

#### 1. `trivy.yml` — Modernized scan workflow
- **Matrix strategy** — scans `hub-agent`, `member-agent`, and `refresh-token` in parallel instead of sequential steps
- **Weekly cron schedule** — runs every Monday at 09:00 UTC in addition to push/tag triggers
- **SARIF upload** — uploads scan results to GitHub Security tab via `codeql-action/upload-sarif`
- **Separate build job** — builds images once, scans in parallel

#### 2. `trivy-remediate.yml` — Automated CVE fix workflow (new)
- Runs weekly (Wednesday) or on-demand via `workflow_dispatch`
- Scans each image with Trivy JSON output
- Parses results to find fixable Go library CVEs
- Runs `go get <pkg>@v<fixed>` + `go mod tidy` for each
- Opens a PR per image with the dependency upgrades
- Uploads scan results as artifacts

#### 3. `cve-scanner.agent.md` — Copilot coding agent (new)
- Available at `.github/agents/cve-scanner.agent.md`
- Provides instructions for scanning all three images, analyzing results, upgrading deps, and creating fix PRs
- Can be invoked interactively for on-demand CVE remediation