### PR TITLE
test: add coverage for pod and replicaset validating webhooks

### DIFF
--- a/pkg/webhook/pod/pod_validating_webhook_test.go
+++ b/pkg/webhook/pod/pod_validating_webhook_test.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2026 The KubeFleet Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pod
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	admissionv1 "k8s.io/api/admission/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+func TestHandle(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("corev1.AddToScheme() = %v, want nil", err)
+	}
+	decoder := admission.NewDecoder(scheme)
+
+	podInDefaultNS := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+		},
+	}
+	podInFleetNS := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "fleet-system",
+		},
+	}
+	podInKubeNS := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "kube-system",
+		},
+	}
+
+	podInDefaultNSBytes, err := json.Marshal(podInDefaultNS)
+	if err != nil {
+		t.Fatalf("json.Marshal() = %v, want nil", err)
+	}
+	podInFleetNSBytes, err := json.Marshal(podInFleetNS)
+	if err != nil {
+		t.Fatalf("json.Marshal() = %v, want nil", err)
+	}
+	podInKubeNSBytes, err := json.Marshal(podInKubeNS)
+	if err != nil {
+		t.Fatalf("json.Marshal() = %v, want nil", err)
+	}
+
+	userInfo := authenticationv1.UserInfo{
+		Username: "test-user",
+		Groups:   []string{"system:authenticated"},
+	}
+
+	testCases := map[string]struct {
+		req          admission.Request
+		wantResponse admission.Response
+		cmpOpts      []cmp.Option
+	}{
+		"deny CREATE in non-reserved namespace": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name:      "test-pod",
+					Namespace: "default",
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw:    podInDefaultNSBytes,
+						Object: podInDefaultNS,
+					},
+					UserInfo: userInfo,
+				},
+			},
+			wantResponse: admission.Denied(fmt.Sprintf(podDeniedFormat, "default", "test-pod")),
+		},
+		"allow CREATE in fleet- reserved namespace": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name:      "test-pod",
+					Namespace: "fleet-system",
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw:    podInFleetNSBytes,
+						Object: podInFleetNS,
+					},
+					UserInfo: userInfo,
+				},
+			},
+			wantResponse: admission.Allowed(""),
+		},
+		"allow CREATE in kube- reserved namespace": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name:      "test-pod",
+					Namespace: "kube-system",
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw:    podInKubeNSBytes,
+						Object: podInKubeNS,
+					},
+					UserInfo: userInfo,
+				},
+			},
+			wantResponse: admission.Allowed(""),
+		},
+		"allow UPDATE (non-CREATE operation)": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name:      "test-pod",
+					Namespace: "default",
+					Operation: admissionv1.Update,
+					UserInfo:  userInfo,
+				},
+			},
+			wantResponse: admission.Allowed(""),
+		},
+		"allow DELETE (non-CREATE operation)": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name:      "test-pod",
+					Namespace: "default",
+					Operation: admissionv1.Delete,
+					UserInfo:  userInfo,
+				},
+			},
+			wantResponse: admission.Allowed(""),
+		},
+		"error on malformed request object": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name:      "test-pod",
+					Namespace: "default",
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw: []byte("not valid json"),
+					},
+					UserInfo: userInfo,
+				},
+			},
+			// The exact error message from the decoder is implementation-defined,
+			// so it is excluded from the comparison; the status code and
+			// allowed=false still are not.
+			wantResponse: admission.Errored(http.StatusBadRequest, errors.New("")),
+			cmpOpts:      []cmp.Option{cmpopts.IgnoreFields(metav1.Status{}, "Message")},
+		},
+	}
+
+	for testName, testCase := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			v := podValidator{decoder: decoder}
+			gotResponse := v.Handle(context.Background(), testCase.req)
+			if diff := cmp.Diff(gotResponse, testCase.wantResponse, testCase.cmpOpts...); diff != "" {
+				t.Errorf("Handle() mismatch (-got +want):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/webhook/replicaset/replicaset_validating_webhook_test.go
+++ b/pkg/webhook/replicaset/replicaset_validating_webhook_test.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2026 The KubeFleet Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package replicaset
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	admissionv1 "k8s.io/api/admission/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+func TestHandle(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("appsv1.AddToScheme() = %v, want nil", err)
+	}
+	decoder := admission.NewDecoder(scheme)
+
+	rsInDefaultNS := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-replicaset",
+			Namespace: "default",
+		},
+	}
+	rsInFleetNS := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-replicaset",
+			Namespace: "fleet-system",
+		},
+	}
+	rsInKubeNS := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-replicaset",
+			Namespace: "kube-system",
+		},
+	}
+
+	rsInDefaultNSBytes, err := json.Marshal(rsInDefaultNS)
+	if err != nil {
+		t.Fatalf("json.Marshal() = %v, want nil", err)
+	}
+	rsInFleetNSBytes, err := json.Marshal(rsInFleetNS)
+	if err != nil {
+		t.Fatalf("json.Marshal() = %v, want nil", err)
+	}
+	rsInKubeNSBytes, err := json.Marshal(rsInKubeNS)
+	if err != nil {
+		t.Fatalf("json.Marshal() = %v, want nil", err)
+	}
+
+	userInfo := authenticationv1.UserInfo{
+		Username: "test-user",
+		Groups:   []string{"system:authenticated"},
+	}
+
+	testCases := map[string]struct {
+		req          admission.Request
+		wantResponse admission.Response
+		cmpOpts      []cmp.Option
+	}{
+		"deny CREATE in non-reserved namespace": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name:      "test-replicaset",
+					Namespace: "default",
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw:    rsInDefaultNSBytes,
+						Object: rsInDefaultNS,
+					},
+					UserInfo: userInfo,
+				},
+			},
+			wantResponse: admission.Denied(fmt.Sprintf(replicaSetDeniedFormat, "default", "test-replicaset")),
+		},
+		"allow CREATE in fleet- reserved namespace": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name:      "test-replicaset",
+					Namespace: "fleet-system",
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw:    rsInFleetNSBytes,
+						Object: rsInFleetNS,
+					},
+					UserInfo: userInfo,
+				},
+			},
+			wantResponse: admission.Allowed(""),
+		},
+		"allow CREATE in kube- reserved namespace": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name:      "test-replicaset",
+					Namespace: "kube-system",
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw:    rsInKubeNSBytes,
+						Object: rsInKubeNS,
+					},
+					UserInfo: userInfo,
+				},
+			},
+			wantResponse: admission.Allowed(""),
+		},
+		"allow UPDATE (non-CREATE operation)": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name:      "test-replicaset",
+					Namespace: "default",
+					Operation: admissionv1.Update,
+					UserInfo:  userInfo,
+				},
+			},
+			wantResponse: admission.Allowed(""),
+		},
+		"allow DELETE (non-CREATE operation)": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name:      "test-replicaset",
+					Namespace: "default",
+					Operation: admissionv1.Delete,
+					UserInfo:  userInfo,
+				},
+			},
+			wantResponse: admission.Allowed(""),
+		},
+		"error on malformed request object": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name:      "test-replicaset",
+					Namespace: "default",
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw: []byte("not valid json"),
+					},
+					UserInfo: userInfo,
+				},
+			},
+			// The exact error message from the decoder is implementation-defined,
+			// so it is excluded from the comparison; the status code and
+			// allowed=false still are not.
+			wantResponse: admission.Errored(http.StatusBadRequest, errors.New("")),
+			cmpOpts:      []cmp.Option{cmpopts.IgnoreFields(metav1.Status{}, "Message")},
+		},
+	}
+
+	for testName, testCase := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			v := replicaSetValidator{decoder: decoder}
+			gotResponse := v.Handle(context.Background(), testCase.req)
+			if diff := cmp.Diff(gotResponse, testCase.wantResponse, testCase.cmpOpts...); diff != "" {
+				t.Errorf("Handle() mismatch (-got +want):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/webhook/replicaset/replicaset_validating_webhook_test.go
+++ b/pkg/webhook/replicaset/replicaset_validating_webhook_test.go
@@ -164,7 +164,7 @@ func TestHandle(t *testing.T) {
 			},
 			// The exact error message from the decoder is implementation-defined,
 			// so it is excluded from the comparison; the status code and
-			// allowed=false still are not.
+			// allowed=false are still compared.
 			wantResponse: admission.Errored(http.StatusBadRequest, errors.New("")),
 			cmpOpts:      []cmp.Option{cmpopts.IgnoreFields(metav1.Status{}, "Message")},
 		},


### PR DESCRIPTION
## Description

`pkg/webhook/pod` and `pkg/webhook/replicaset` were the only two webhook packages with no unit tests. Both validators deny creation of their resource outside the reserved `fleet-` and `kube-` namespaces, and neither branch of `Handle` was covered.

This adds table-driven tests for both, following the existing `pkg/webhook/pdb` test.

## Coverage

Each handler is now tested for all four paths through `Handle`:

| Case | Expected |
| --- | --- |
| CREATE in a non-reserved namespace (`default`) | Denied, with the resource-specific denial message |
| CREATE in `fleet-system` | Allowed |
| CREATE in `kube-system` | Allowed |
| UPDATE / DELETE (non-CREATE) | Allowed without decoding |
| CREATE with an undecodable object | `Errored(http.StatusBadRequest, ...)` |

## One deliberate difference from the pdb test

The pdb test passes `cmpopts.IgnoreFields(metav1.Status{}, "Message")` to every comparison. That also discards the denial message, which is the main thing these webhooks produce, so the denial text goes unasserted.

Here the ignore is scoped to the decode-failure case only — the decoder's wording is implementation-defined, but the code and `allowed=false` are still compared. Every other case compares the full response, including the message. Happy to align with the pdb style instead if you'd prefer consistency across the webhook tests.

## Testing

- `go test ./pkg/webhook/pod/... ./pkg/webhook/replicaset/...` — all 12 subtests pass.
- `go vet` and `staticcheck` clean on both packages.
- Sanity-checked that the tests are not vacuous: inverting `!utils.IsReservedNamespace(...)` to `utils.IsReservedNamespace(...)` in the pod handler fails both the deny and the allow cases.
