### PR TITLE
fix: apply overrides to resources inside envelope objects

### DIFF
--- a/examples/envelopes/override-inside-envelope.yaml
+++ b/examples/envelopes/override-inside-envelope.yaml
@@ -1,0 +1,132 @@
+# This example shows overrides targeting resources inside envelope objects.
+# Fleet places the unpacked inner manifests on member clusters, not the envelope wrappers.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: app
+---
+apiVersion: placement.kubernetes-fleet.io/v1beta1
+kind: ResourceEnvelope
+metadata:
+  name: ingress
+  namespace: app
+data:
+  "deploy.yaml":
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: ingress
+      namespace: app
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: nginx
+      template:
+        metadata:
+          labels:
+            app: nginx
+        spec:
+          containers:
+          - name: web
+            image: nginx
+---
+apiVersion: placement.kubernetes-fleet.io/v1beta1
+kind: ResourcePlacement
+metadata:
+  name: ingress
+  namespace: app
+spec:
+  resourceSelectors:
+  - group: placement.kubernetes-fleet.io
+    kind: ResourceEnvelope
+    name: ingress
+    version: v1beta1
+  policy:
+    placementType: PickAll
+  strategy:
+    type: RollingUpdate
+---
+apiVersion: placement.kubernetes-fleet.io/v1beta1
+kind: ResourceOverride
+metadata:
+  name: ingress-replicas
+  namespace: app
+spec:
+  placement:
+    name: ingress
+    scope: Namespaced
+  # This selector matches the inner Deployment in the ResourceEnvelope above.
+  # It does not target the ResourceEnvelope wrapper or a /data/... path.
+  resourceSelectors:
+  - group: apps
+    kind: Deployment
+    name: ingress
+    version: v1
+  policy:
+    overrideRules:
+    - clusterSelector:
+        clusterSelectorTerms:
+        - labelSelector:
+            matchLabels:
+              env: canary
+      jsonPatchOverrides:
+      - op: replace
+        path: /spec/replicas
+        value: 3
+---
+apiVersion: placement.kubernetes-fleet.io/v1beta1
+kind: ClusterResourceEnvelope
+metadata:
+  name: reader-role
+data:
+  "clusterrole.yaml":
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: pod-reader
+    rules:
+    - apiGroups: [""]
+      resources: ["pods"]
+      verbs: ["get", "list"]
+---
+apiVersion: placement.kubernetes-fleet.io/v1beta1
+kind: ClusterResourcePlacement
+metadata:
+  name: reader-role
+spec:
+  resourceSelectors:
+  - group: placement.kubernetes-fleet.io
+    kind: ClusterResourceEnvelope
+    name: reader-role
+    version: v1beta1
+  policy:
+    placementType: PickAll
+  strategy:
+    type: RollingUpdate
+---
+apiVersion: placement.kubernetes-fleet.io/v1beta1
+kind: ClusterResourceOverride
+metadata:
+  name: pod-reader-extra-verb
+spec:
+  placement:
+    name: reader-role
+  # This selector matches the inner ClusterRole, not the ClusterResourceEnvelope wrapper.
+  clusterResourceSelectors:
+  - group: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: pod-reader
+    version: v1
+  policy:
+    overrideRules:
+    - clusterSelector:
+        clusterSelectorTerms:
+        - labelSelector:
+            matchLabels:
+              env: canary
+      jsonPatchOverrides:
+      - op: add
+        path: /rules/0/verbs/-
+        value: watch

--- a/pkg/controllers/workgenerator/controller.go
+++ b/pkg/controllers/workgenerator/controller.go
@@ -150,13 +150,16 @@ func (r *Reconciler) Reconcile(ctx context.Context, req controllerruntime.Reques
 		}
 	}
 
-	workUpdated := false
-	overrideSucceeded := false
+	// result must be allocated before listing the works so that if listing fails (and syncAllWork
+	// is never called), the existing status outcome is preserved: the list failure is reported on
+	// the Overridden condition and no Work is reported as changed.
+	result := &syncResult{overrideFailed: true}
 	// list all the corresponding works
 	works, syncErr := r.listAllWorksAssociated(ctx, resourceBinding)
 	if syncErr == nil {
-		// generate and apply the workUpdated works if we have all the works
-		overrideSucceeded, workUpdated, syncErr = r.syncAllWork(ctx, resourceBinding, works, &cluster)
+		// generate and apply the works if we have all the works.
+		// syncAllWork always returns a non-nil result, even on error.
+		result, syncErr = r.syncAllWork(ctx, resourceBinding, works, &cluster)
 	}
 	// Reset the conditions and failed/drifted/diffed placements.
 	for i := condition.OverriddenCondition; i < condition.TotalCondition; i++ {
@@ -165,7 +168,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req controllerruntime.Reques
 	resourceBinding.GetBindingStatus().FailedPlacements = nil
 	resourceBinding.GetBindingStatus().DriftedPlacements = nil
 	resourceBinding.GetBindingStatus().DiffedPlacements = nil
-	if overrideSucceeded {
+	if !result.overrideFailed {
 		overrideReason := condition.OverriddenSucceededReason
 		overrideMessage := "Successfully applied the override rules on the resources"
 		if len(resourceBinding.GetBindingSpec().ClusterResourceOverrideSnapshots) == 0 &&
@@ -191,7 +194,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req controllerruntime.Reques
 		if err := errors.Unwrap(syncErr); err != nil && len(err.Error()) > 2 {
 			errorMessage = errorMessage[len(err.Error())+2:]
 		}
-		if !overrideSucceeded {
+		if result.overrideFailed {
 			resourceBinding.SetConditions(metav1.Condition{
 				Status:             metav1.ConditionFalse,
 				Type:               string(fleetv1beta1.ResourceBindingOverridden),
@@ -217,7 +220,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req controllerruntime.Reques
 			Message:            "All of the works are synchronized to the latest",
 		})
 		switch {
-		case !workUpdated:
+		case !result.workUpdated:
 			// The Work object itself is unchanged; refresh the cluster resource binding status
 			// based on the status information reported on the Work object(s).
 			setBindingStatus(works, resourceBinding)
@@ -411,11 +414,20 @@ func (r *Reconciler) listAllWorksAssociated(ctx context.Context, resourceBinding
 	return currentWork, nil
 }
 
-// syncAllWork generates all the work for the resourceSnapshot and apply them to the corresponding target cluster.
-// it returns
-// 1: if we apply the overrides successfully
-// 2: if we actually made any changes on the hub cluster
-func (r *Reconciler) syncAllWork(ctx context.Context, resourceBinding fleetv1beta1.BindingObj, existingWorks map[string]*fleetv1beta1.Work, cluster *clusterv1beta1.MemberCluster) (bool, bool, error) {
+// syncResult captures the outcome of a syncAllWork call.
+type syncResult struct {
+	// overrideFailed reports whether a sync error should fail the binding's Overridden condition.
+	// It is false when syncAllWork succeeds.
+	overrideFailed bool
+	// workUpdated reports whether any Work object was actually changed on the hub cluster.
+	workUpdated bool
+}
+
+// syncAllWork generates all the work for the resourceSnapshot and applies them to the corresponding target cluster.
+//
+// The returned syncResult is always non-nil, including on error paths, so the caller can safely
+// inspect its fields regardless of the returned error. See syncResult for the meaning of each field.
+func (r *Reconciler) syncAllWork(ctx context.Context, resourceBinding fleetv1beta1.BindingObj, existingWorks map[string]*fleetv1beta1.Work, cluster *clusterv1beta1.MemberCluster) (*syncResult, error) {
 	updateAny := atomic.NewBool(false)
 	resourceBindingRef := klog.KObj(resourceBinding)
 
@@ -441,17 +453,17 @@ func (r *Reconciler) syncAllWork(ctx context.Context, resourceBinding fleetv1bet
 		})
 	}
 	if updateErr := errs.Wait(); updateErr != nil {
-		return false, false, updateErr
+		return &syncResult{overrideFailed: true}, updateErr
 	}
 
 	// the hash256 function can handle empty list https://go.dev/play/p/_4HW17fooXM
 	resourceOverrideSnapshotHash, err := resource.HashOf(resourceBinding.GetBindingSpec().ResourceOverrideSnapshots)
 	if err != nil {
-		return false, false, controller.NewUnexpectedBehaviorError(err)
+		return &syncResult{overrideFailed: true}, controller.NewUnexpectedBehaviorError(err)
 	}
 	clusterResourceOverrideSnapshotHash, err := resource.HashOf(resourceBinding.GetBindingSpec().ClusterResourceOverrideSnapshots)
 	if err != nil {
-		return false, false, controller.NewUnexpectedBehaviorError(err)
+		return &syncResult{overrideFailed: true}, controller.NewUnexpectedBehaviorError(err)
 	}
 	// TODO: check all work synced first before fetching the snapshots after we put ParentResourceOverrideSnapshotHashAnnotation and ParentClusterResourceOverrideSnapshotHashAnnotation in all the work objects
 
@@ -462,22 +474,30 @@ func (r *Reconciler) syncAllWork(ctx context.Context, resourceBinding fleetv1bet
 			// the resourceIndex is deleted but the works might still be up to date with the binding.
 			if areAllWorkSynced(existingWorks, resourceBinding, resourceOverrideSnapshotHash, clusterResourceOverrideSnapshotHash) {
 				klog.V(2).InfoS("All the works are synced with the resourceBinding even if the resource snapshot index is removed", "resourceBinding", resourceBindingRef)
-				return true, updateAny.Load(), nil
+				return &syncResult{workUpdated: updateAny.Load()}, nil
 			}
-			return false, false, controller.NewUserError(err)
+			return &syncResult{overrideFailed: true}, controller.NewUserError(err)
 		}
 		// TODO(RZ): handle errResourceNotFullyCreated error so we don't need to wait for all the snapshots to be created
-		return false, false, err
+		return &syncResult{overrideFailed: true}, err
 	}
 
 	croMap, err := r.fetchClusterResourceOverrideSnapshots(ctx, resourceBinding)
 	if err != nil {
-		return false, false, err
+		return &syncResult{overrideFailed: true}, err
 	}
 
 	roMap, err := r.fetchResourceOverrideSnapshots(ctx, resourceBinding)
 	if err != nil {
-		return false, false, err
+		return &syncResult{overrideFailed: true}, err
+	}
+
+	// Assemble the override inputs once so the snapshots are fetched a single time per sync
+	// and threaded down as one value rather than as three separate parameters.
+	overrideCtx := &overrideContext{
+		cluster: cluster,
+		croMap:  croMap,
+		roMap:   roMap,
 	}
 
 	// issue all the create/update requests for the corresponding works for each snapshot in parallel
@@ -489,39 +509,31 @@ func (r *Reconciler) syncAllWork(ctx context.Context, resourceBinding fleetv1bet
 		workNamePrefix, err := getWorkNamePrefixFromSnapshotName(snapshot)
 		if err != nil {
 			klog.ErrorS(err, "Encountered a mal-formatted resource snapshot", "resourceSnapshot", klog.KObj(snapshot))
-			return false, false, err
+			return &syncResult{overrideFailed: true}, err
 		}
 		var simpleManifests []fleetv1beta1.Manifest
 		var newWork []*fleetv1beta1.Work
 		selectedRes := snapshot.GetResourceSnapshotSpec().SelectedResources
 		for j := range selectedRes {
 			selectedResource := selectedRes[j].DeepCopy()
-			// TODO: apply the override rules on the envelope resources by applying them on the work instead of the selected resource
-			resourceDeleted, overrideErr := r.applyOverrides(selectedResource, cluster, croMap, roMap)
-			if overrideErr != nil {
-				return false, false, overrideErr
-			}
-			if resourceDeleted {
-				klog.V(2).InfoS("The resource is deleted by the override rules", "snapshot", klog.KObj(snapshot), "selectedResource", selectedRes[j])
-				continue
-			}
 
 			// Process the selected resource.
 			//
 			// Specifically,
-			// a) if the selected resource is an envelope (configMap-based or envelope-based; the former will soon
-			//    become obsolete), we will create a work object dedicated for the envelope;
-			// b) otherwise (the selected resource is a regular resource), the resource will be appended to the list of
-			//    simple manifests.
+			// a) if the selected resource is an envelope CR, we will create a work object dedicated for the
+			//    envelope and apply overrides to its extracted manifests;
+			// b) otherwise (the selected resource is a regular resource), overrides are applied directly and the
+			//    resource will be appended to the list of simple manifests unless deleted by override.
 			//
 			// Note (chenyu1): this method is added to reduce the cyclomatic complexity of the syncAllWork method.
-			newWork, simpleManifests, err = r.processOneSelectedResource(
-				ctx, selectedResource, resourceBinding, snapshot,
+			var overrideFailed bool
+			newWork, simpleManifests, overrideFailed, err = r.processOneSelectedResource(
+				ctx, selectedResource, overrideCtx, resourceBinding, snapshot,
 				workNamePrefix, resourceOverrideSnapshotHash, clusterResourceOverrideSnapshotHash,
 				activeWork, newWork, simpleManifests)
 			if err != nil {
 				klog.ErrorS(err, "Failed to process the selected resource", "snapshot", klog.KObj(snapshot), "selectedResourceIdx", j)
-				return true, false, err
+				return &syncResult{overrideFailed: overrideFailed}, err
 			}
 		}
 		if len(simpleManifests) == 0 {
@@ -571,31 +583,45 @@ func (r *Reconciler) syncAllWork(ctx context.Context, resourceBinding fleetv1bet
 
 	// wait for all the create/update/delete requests to finish
 	if updateErr := errs.Wait(); updateErr != nil {
-		return true, false, updateErr
+		return &syncResult{}, updateErr
 	}
 	klog.V(2).InfoS("Successfully synced all the work associated with the resourceBinding", "updateAny", updateAny.Load(), "resourceBinding", resourceBindingRef)
-	return true, updateAny.Load(), nil
+	return &syncResult{workUpdated: updateAny.Load()}, nil
+}
+
+// overrideContext carries the inputs needed to apply overrides to a resource: the target
+// cluster and the override snapshots that apply to the binding, keyed by the resource each
+// selector targets. It is assembled once per sync so the snapshots are fetched only once and
+// threaded down the call stack as a single value.
+type overrideContext struct {
+	cluster *clusterv1beta1.MemberCluster
+	croMap  map[fleetv1beta1.ResourceIdentifier][]*fleetv1beta1.ClusterResourceOverrideSnapshot
+	roMap   map[fleetv1beta1.ResourceIdentifier][]*fleetv1beta1.ResourceOverrideSnapshot
 }
 
 // processOneSelectedResource processes a single selected resource from the resource snapshot.
 //
 // If the selected resource is an envelope (either configMap-based or envelope-based), create a new dedicated
 // work object for the envelope. Otherwise, append the selected resource to the list of simple manifests.
+//
+// The returned bool reports an override failure (used to fail the binding's Overridden condition);
+// it is only meaningful when the returned error is non-nil and is always false on success.
 func (r *Reconciler) processOneSelectedResource(
 	ctx context.Context,
 	selectedResource *fleetv1beta1.ResourceContent,
+	overrideCtx *overrideContext,
 	resourceBinding fleetv1beta1.BindingObj,
 	snapshot fleetv1beta1.ResourceSnapshotObj,
 	workNamePrefix, resourceOverrideSnapshotHash, clusterResourceOverrideSnapshotHash string,
 	activeWork map[string]*fleetv1beta1.Work,
 	newWork []*fleetv1beta1.Work,
 	simpleManifests []fleetv1beta1.Manifest,
-) ([]*fleetv1beta1.Work, []fleetv1beta1.Manifest, error) {
+) ([]*fleetv1beta1.Work, []fleetv1beta1.Manifest, bool, error) {
 	// Unmarshal the YAML content into an unstructured object.
 	var uResource unstructured.Unstructured
 	if unMarshallErr := uResource.UnmarshalJSON(selectedResource.Raw); unMarshallErr != nil {
 		klog.ErrorS(unMarshallErr, "work has invalid content", "snapshot", klog.KObj(snapshot), "selectedResource", selectedResource.Raw)
-		return nil, nil, controller.NewUnexpectedBehaviorError(unMarshallErr)
+		return nil, nil, false, controller.NewUnexpectedBehaviorError(unMarshallErr)
 	}
 
 	uGVK := uResource.GetObjectKind().GroupVersionKind().GroupKind()
@@ -608,15 +634,15 @@ func (r *Reconciler) processOneSelectedResource(
 				"clusterResourceBinding", klog.KObj(resourceBinding),
 				"clusterResourceSnapshot", klog.KObj(snapshot),
 				"selectedResource", klog.KObj(&uResource))
-			return nil, nil, controller.NewUnexpectedBehaviorError(err)
+			return nil, nil, false, controller.NewUnexpectedBehaviorError(err)
 		}
-		work, err := r.createOrUpdateEnvelopeCRWorkObj(ctx, &clusterResourceEnvelope, workNamePrefix, resourceBinding, snapshot, resourceOverrideSnapshotHash, clusterResourceOverrideSnapshotHash)
+		work, overrideFailed, err := r.createOrUpdateEnvelopeCRWorkObj(ctx, &clusterResourceEnvelope, workNamePrefix, resourceBinding, snapshot, overrideCtx, resourceOverrideSnapshotHash, clusterResourceOverrideSnapshotHash)
 		if err != nil {
 			klog.ErrorS(err, "Failed to create or get the work object for the ClusterResourceEnvelope",
 				"clusterResourceEnvelope", klog.KObj(&clusterResourceEnvelope),
 				"clusterResourceBinding", klog.KObj(resourceBinding),
 				"clusterResourceSnapshot", klog.KObj(snapshot))
-			return nil, nil, err
+			return nil, nil, overrideFailed, err
 		}
 		activeWork[work.Name] = work
 		newWork = append(newWork, work)
@@ -628,25 +654,34 @@ func (r *Reconciler) processOneSelectedResource(
 				"clusterResourceBinding", klog.KObj(resourceBinding),
 				"clusterResourceSnapshot", klog.KObj(snapshot),
 				"selectedResource", klog.KObj(&uResource))
-			return nil, nil, controller.NewUnexpectedBehaviorError(err)
+			return nil, nil, false, controller.NewUnexpectedBehaviorError(err)
 		}
-		work, err := r.createOrUpdateEnvelopeCRWorkObj(ctx, &resourceEnvelope, workNamePrefix, resourceBinding, snapshot, resourceOverrideSnapshotHash, clusterResourceOverrideSnapshotHash)
+		work, overrideFailed, err := r.createOrUpdateEnvelopeCRWorkObj(ctx, &resourceEnvelope, workNamePrefix, resourceBinding, snapshot, overrideCtx, resourceOverrideSnapshotHash, clusterResourceOverrideSnapshotHash)
 		if err != nil {
 			klog.ErrorS(err, "Failed to create or get the work object for the ResourceEnvelope",
 				"resourceEnvelope", klog.KObj(&resourceEnvelope),
 				"clusterResourceBinding", klog.KObj(resourceBinding),
 				"clusterResourceSnapshot", klog.KObj(snapshot))
-			return nil, nil, err
+			return nil, nil, overrideFailed, err
 		}
 		activeWork[work.Name] = work
 		newWork = append(newWork, work)
 
 	default:
+		resourceDeleted, overrideErr := r.applyOverrides(selectedResource, overrideCtx.cluster, overrideCtx.croMap, overrideCtx.roMap)
+		if overrideErr != nil {
+			return nil, nil, true, overrideErr
+		}
+		if resourceDeleted {
+			klog.V(2).InfoS("The resource is deleted by the override rules", "snapshot", klog.KObj(snapshot), "selectedResource", selectedResource)
+			return newWork, simpleManifests, false, nil
+		}
+
 		// The resource is not an envelope; add it to the list of simple manifests.
 		simpleManifests = append(simpleManifests, fleetv1beta1.Manifest(*selectedResource))
 	}
 
-	return newWork, simpleManifests, nil
+	return newWork, simpleManifests, false, nil
 }
 
 // syncApplyStrategy syncs the apply strategy specified on a binding object

--- a/pkg/controllers/workgenerator/controller_integration_test.go
+++ b/pkg/controllers/workgenerator/controller_integration_test.go
@@ -29,10 +29,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -42,6 +45,8 @@ import (
 	"github.com/kubefleet-dev/kubefleet/pkg/controllers/workapplier"
 	"github.com/kubefleet-dev/kubefleet/pkg/utils"
 	"github.com/kubefleet-dev/kubefleet/pkg/utils/condition"
+	"github.com/kubefleet-dev/kubefleet/pkg/utils/overrider"
+	testutilsinformer "github.com/kubefleet-dev/kubefleet/test/utils/informer"
 )
 
 var (
@@ -111,6 +116,8 @@ const (
 	timeout  = time.Second * 20
 	duration = time.Second * 10
 	interval = time.Millisecond * 250
+
+	insideDeploymentName = "inside-deployment"
 )
 
 var _ = Describe("Test Work Generator Controller for clusterResourcePlacement", func() {
@@ -980,6 +987,277 @@ var _ = Describe("Test Work Generator Controller for clusterResourcePlacement", 
 					}
 					return nil
 				}, timeout, interval).Should(Succeed(), "Failed to delete the expected enveloped work in hub cluster")
+			})
+		})
+
+		Context("Test Bound ClusterResourceBinding with envelope override snapshots", func() {
+			var objectsToDelete []client.Object
+
+			createObject := func(obj client.Object) {
+				Expect(k8sClient.Create(ctx, obj)).Should(Succeed())
+				objectsToDelete = append(objectsToDelete, obj)
+			}
+
+			AfterEach(func() {
+				for i := len(objectsToDelete) - 1; i >= 0; i-- {
+					Expect(k8sClient.Delete(ctx, objectsToDelete[i])).Should(SatisfyAny(Succeed(), utils.NotFoundMatcher{}))
+				}
+				objectsToDelete = nil
+			})
+
+			It("Should patch a ResourceEnvelope inner Deployment with a matching ResourceOverride", func() {
+				envelopeNamespace := "envelope-ns-" + utils.RandStr()
+				envelopeName := "resource-envelope-" + utils.RandStr()
+				deploymentName := insideDeploymentName
+				createObject(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: envelopeNamespace}})
+
+				masterSnapshot := generateClusterResourceSnapshot(1, 1, 0, [][]byte{
+					resourceEnvelopeRaw(envelopeName, envelopeNamespace, map[string][]byte{
+						"deployment.json": deploymentManifestRaw(envelopeNamespace, deploymentName, map[string]string{"app": "demo"}),
+					}),
+				})
+				createObject(masterSnapshot)
+				createObject(envelopeResourceOverrideSnapshot("ro-"+utils.RandStr(), envelopeNamespace, []placementv1beta1.ResourceSelector{
+					{
+						Group:   "apps",
+						Version: "v1",
+						Kind:    "Deployment",
+						Name:    deploymentName,
+					},
+				}, []placementv1beta1.JSONPatchOverride{
+					{
+						Operator: placementv1beta1.JSONPatchOverrideOpAdd,
+						Path:     "/metadata/labels/patched",
+						Value:    apiextensionsv1.JSON{Raw: []byte(`"true"`)},
+					},
+				}))
+				croNames, roNames := matchingOverrideSnapshotRefs(masterSnapshot)
+				spec := placementv1beta1.ResourceBindingSpec{
+					State:                     placementv1beta1.BindingStateBound,
+					ResourceSnapshotName:      masterSnapshot.Name,
+					TargetCluster:             memberClusterName,
+					ResourceOverrideSnapshots: roNames,
+				}
+				createClusterResourceBinding(&binding, spec)
+
+				var workList placementv1beta1.WorkList
+				fetchEnvelopedWork(&workList, binding, string(placementv1beta1.ResourceEnvelopeType), envelopeName, envelopeNamespace)
+				got := findManifestObject(workList.Items[0].Spec.Workload.Manifests, "apps", "v1", "Deployment", envelopeNamespace, deploymentName)
+				want := manifestObject(deploymentManifestRaw(envelopeNamespace, deploymentName, map[string]string{"app": "demo", "patched": "true"}))
+				diff := cmp.Diff(want.Object, got.Object)
+				Expect(diff).Should(BeEmpty(), fmt.Sprintf("inner deployment mismatch (-want +got):\n%s", diff))
+				Expect(croNames).Should(BeEmpty(), "ResourceOverride test should not select ClusterResourceOverrideSnapshots")
+				verifyBindingStatusSyncedNotApplied(binding, true, true)
+			})
+
+			It("Should patch a ClusterResourceEnvelope inner ClusterRole with a matching ClusterResourceOverride", func() {
+				envelopeName := "cluster-resource-envelope-" + utils.RandStr()
+				clusterRoleName := "inside-clusterrole"
+				masterSnapshot := generateClusterResourceSnapshot(1, 1, 0, [][]byte{
+					clusterResourceEnvelopeRaw(envelopeName, map[string][]byte{
+						"clusterrole.json": clusterRoleManifestRaw(clusterRoleName, nil),
+					}),
+				})
+				createObject(masterSnapshot)
+				createObject(envelopeClusterResourceOverrideSnapshot("cro-"+utils.RandStr(), []placementv1beta1.ResourceSelectorTerm{
+					{
+						Group:   "rbac.authorization.k8s.io",
+						Version: "v1",
+						Kind:    "ClusterRole",
+						Name:    clusterRoleName,
+					},
+				}, []placementv1beta1.JSONPatchOverride{
+					{
+						Operator: placementv1beta1.JSONPatchOverrideOpAdd,
+						Path:     "/metadata/labels",
+						Value:    apiextensionsv1.JSON{Raw: []byte(`{"patched":"true"}`)},
+					},
+				}))
+				croNames, roNames := matchingOverrideSnapshotRefs(masterSnapshot)
+				spec := placementv1beta1.ResourceBindingSpec{
+					State:                            placementv1beta1.BindingStateBound,
+					ResourceSnapshotName:             masterSnapshot.Name,
+					TargetCluster:                    memberClusterName,
+					ClusterResourceOverrideSnapshots: croNames,
+				}
+				createClusterResourceBinding(&binding, spec)
+
+				var workList placementv1beta1.WorkList
+				fetchEnvelopedWork(&workList, binding, string(placementv1beta1.ClusterResourceEnvelopeType), envelopeName, "")
+				got := findManifestObject(workList.Items[0].Spec.Workload.Manifests, "rbac.authorization.k8s.io", "v1", "ClusterRole", "", clusterRoleName)
+				want := manifestObject(clusterRoleManifestRaw(clusterRoleName, map[string]string{"patched": "true"}))
+				diff := cmp.Diff(want.Object, got.Object)
+				Expect(diff).Should(BeEmpty(), fmt.Sprintf("inner clusterRole mismatch (-want +got):\n%s", diff))
+				Expect(roNames).Should(BeEmpty(), "ClusterResourceOverride test should not select ResourceOverrideSnapshots")
+				verifyBindingStatusSyncedNotApplied(binding, true, true)
+			})
+
+			It("Should not apply a ResourceOverride targeting the ResourceEnvelope wrapper", func() {
+				envelopeNamespace := "envelope-ns-" + utils.RandStr()
+				envelopeName := "resource-envelope-" + utils.RandStr()
+				deploymentName := insideDeploymentName
+				createObject(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: envelopeNamespace}})
+
+				masterSnapshot := generateClusterResourceSnapshot(1, 1, 0, [][]byte{
+					resourceEnvelopeRaw(envelopeName, envelopeNamespace, map[string][]byte{
+						"deployment.json": deploymentManifestRaw(envelopeNamespace, deploymentName, map[string]string{"app": "demo"}),
+					}),
+				})
+				createObject(masterSnapshot)
+				createObject(envelopeResourceOverrideSnapshot("ro-"+utils.RandStr(), envelopeNamespace, []placementv1beta1.ResourceSelector{
+					{
+						Group:   placementv1beta1.GroupVersion.Group,
+						Version: placementv1beta1.GroupVersion.Version,
+						Kind:    string(placementv1beta1.ResourceEnvelopeType),
+						Name:    envelopeName,
+					},
+				}, []placementv1beta1.JSONPatchOverride{
+					{
+						Operator: placementv1beta1.JSONPatchOverrideOpReplace,
+						Path:     "/metadata/name",
+						Value:    apiextensionsv1.JSON{Raw: []byte(`"unexpected-envelope-name"`)},
+					},
+				}))
+				croNames, roNames := matchingOverrideSnapshotRefs(masterSnapshot)
+				spec := placementv1beta1.ResourceBindingSpec{
+					State:                            placementv1beta1.BindingStateBound,
+					ResourceSnapshotName:             masterSnapshot.Name,
+					TargetCluster:                    memberClusterName,
+					ClusterResourceOverrideSnapshots: croNames,
+					ResourceOverrideSnapshots:        roNames,
+				}
+				createClusterResourceBinding(&binding, spec)
+
+				var workList placementv1beta1.WorkList
+				fetchEnvelopedWork(&workList, binding, string(placementv1beta1.ResourceEnvelopeType), envelopeName, envelopeNamespace)
+				got := findManifestObject(workList.Items[0].Spec.Workload.Manifests, "apps", "v1", "Deployment", envelopeNamespace, deploymentName)
+				want := manifestObject(deploymentManifestRaw(envelopeNamespace, deploymentName, map[string]string{"app": "demo"}))
+				diff := cmp.Diff(want.Object, got.Object)
+				Expect(diff).Should(BeEmpty(), fmt.Sprintf("inner deployment mismatch (-want +got):\n%s", diff))
+				Expect(croNames).Should(BeEmpty(), "wrapper-targeting ResourceOverride should not select ClusterResourceOverrideSnapshots")
+				Expect(roNames).Should(BeEmpty(), "wrapper-targeting ResourceOverride should not be selected")
+				verifyBindingStatusSyncedNotApplied(binding, false, true)
+			})
+
+			It("Should patch only the selected inner resource from a ResourceEnvelope", func() {
+				envelopeNamespace := "envelope-ns-" + utils.RandStr()
+				envelopeName := "resource-envelope-" + utils.RandStr()
+				deploymentName := insideDeploymentName
+				configMapName := "inside-configmap"
+				createObject(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: envelopeNamespace}})
+
+				masterSnapshot := generateClusterResourceSnapshot(1, 1, 0, [][]byte{
+					resourceEnvelopeRaw(envelopeName, envelopeNamespace, map[string][]byte{
+						"configmap.json":  configMapManifestRaw(envelopeNamespace, configMapName),
+						"deployment.json": deploymentManifestRaw(envelopeNamespace, deploymentName, map[string]string{"app": "demo"}),
+					}),
+				})
+				createObject(masterSnapshot)
+				createObject(envelopeResourceOverrideSnapshot("ro-"+utils.RandStr(), envelopeNamespace, []placementv1beta1.ResourceSelector{
+					{
+						Group:   "apps",
+						Version: "v1",
+						Kind:    "Deployment",
+						Name:    deploymentName,
+					},
+				}, []placementv1beta1.JSONPatchOverride{
+					{
+						Operator: placementv1beta1.JSONPatchOverrideOpAdd,
+						Path:     "/metadata/labels/patched",
+						Value:    apiextensionsv1.JSON{Raw: []byte(`"true"`)},
+					},
+				}))
+				croNames, roNames := matchingOverrideSnapshotRefs(masterSnapshot)
+				spec := placementv1beta1.ResourceBindingSpec{
+					State:                     placementv1beta1.BindingStateBound,
+					ResourceSnapshotName:      masterSnapshot.Name,
+					TargetCluster:             memberClusterName,
+					ResourceOverrideSnapshots: roNames,
+				}
+				createClusterResourceBinding(&binding, spec)
+
+				var workList placementv1beta1.WorkList
+				fetchEnvelopedWork(&workList, binding, string(placementv1beta1.ResourceEnvelopeType), envelopeName, envelopeNamespace)
+				gotDeployment := findManifestObject(workList.Items[0].Spec.Workload.Manifests, "apps", "v1", "Deployment", envelopeNamespace, deploymentName)
+				wantDeployment := manifestObject(deploymentManifestRaw(envelopeNamespace, deploymentName, map[string]string{"app": "demo", "patched": "true"}))
+				diff := cmp.Diff(wantDeployment.Object, gotDeployment.Object)
+				Expect(diff).Should(BeEmpty(), fmt.Sprintf("inner deployment mismatch (-want +got):\n%s", diff))
+				gotConfigMap := findManifestObject(workList.Items[0].Spec.Workload.Manifests, "", "v1", "ConfigMap", envelopeNamespace, configMapName)
+				wantConfigMap := manifestObject(configMapManifestRaw(envelopeNamespace, configMapName))
+				diff = cmp.Diff(wantConfigMap.Object, gotConfigMap.Object)
+				Expect(diff).Should(BeEmpty(), fmt.Sprintf("inner configMap mismatch (-want +got):\n%s", diff))
+				Expect(croNames).Should(BeEmpty(), "ResourceOverride test should not select ClusterResourceOverrideSnapshots")
+				verifyBindingStatusSyncedNotApplied(binding, true, true)
+			})
+
+			It("Should report ResourceOverride failures inside a ResourceEnvelope on the Overridden condition", func() {
+				envelopeNamespace := "envelope-ns-" + utils.RandStr()
+				envelopeName := "resource-envelope-" + utils.RandStr()
+				deploymentName := insideDeploymentName
+				createObject(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: envelopeNamespace}})
+
+				masterSnapshot := generateClusterResourceSnapshot(1, 1, 0, [][]byte{
+					resourceEnvelopeRaw(envelopeName, envelopeNamespace, map[string][]byte{
+						"deployment.json": deploymentManifestRaw(envelopeNamespace, deploymentName, map[string]string{"app": "demo"}),
+					}),
+				})
+				createObject(masterSnapshot)
+				invalidRO := envelopeResourceOverrideSnapshot("ro-"+utils.RandStr(), envelopeNamespace, []placementv1beta1.ResourceSelector{
+					{
+						Group:   "apps",
+						Version: "v1",
+						Kind:    "Deployment",
+						Name:    deploymentName,
+					},
+				}, []placementv1beta1.JSONPatchOverride{
+					{
+						Operator: placementv1beta1.JSONPatchOverrideOpAdd,
+						Path:     "/spec/template/spec/containers/0/resources/limits/cpu",
+						Value:    apiextensionsv1.JSON{Raw: []byte(`"100m"`)},
+					},
+				})
+				createObject(invalidRO)
+				croNames, roNames := matchingOverrideSnapshotRefs(masterSnapshot)
+				spec := placementv1beta1.ResourceBindingSpec{
+					State:                     placementv1beta1.BindingStateBound,
+					ResourceSnapshotName:      masterSnapshot.Name,
+					TargetCluster:             memberClusterName,
+					ResourceOverrideSnapshots: roNames,
+				}
+				createClusterResourceBinding(&binding, spec)
+
+				Consistently(func() int {
+					workList := placementv1beta1.WorkList{}
+					Expect(k8sClient.List(ctx, &workList, client.MatchingLabels{
+						placementv1beta1.ParentBindingLabel:     binding.Name,
+						placementv1beta1.PlacementTrackingLabel: testCRPName,
+					})).Should(Succeed())
+					return len(workList.Items)
+				}, duration, interval).Should(Equal(0), "controller should not create work when an inner envelope override fails")
+
+				Eventually(func() string {
+					Expect(k8sClient.Get(ctx, types.NamespacedName{Name: binding.Name}, binding)).Should(Succeed())
+					wantStatus := placementv1beta1.ResourceBindingStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:               string(placementv1beta1.ResourceBindingRolloutStarted),
+								Status:             metav1.ConditionTrue,
+								Reason:             condition.RolloutStartedReason,
+								ObservedGeneration: binding.GetGeneration(),
+							},
+							{
+								Type:               string(placementv1beta1.ResourceBindingOverridden),
+								Status:             metav1.ConditionFalse,
+								Reason:             condition.OverriddenFailedReason,
+								ObservedGeneration: binding.GetGeneration(),
+							},
+						},
+					}
+					return cmp.Diff(wantStatus, binding.Status, cmpConditionOption)
+				}, timeout, interval).Should(BeEmpty(), fmt.Sprintf("binding(%s) mismatch (-want +got)", binding.Name))
+				message := binding.GetCondition(string(placementv1beta1.ResourceBindingOverridden)).Message
+				Expect(message).Should(ContainSubstring("add operation does not apply"))
+				Expect(croNames).Should(BeEmpty(), "ResourceOverride failure test should not select ClusterResourceOverrideSnapshots")
 			})
 		})
 
@@ -4259,6 +4537,240 @@ func fetchEnvelopedWork(workList *placementv1beta1.WorkList, binding *placementv
 		}
 		return nil
 	}, timeout, interval).Should(Succeed(), "Failed to get the expected enveloped work in hub cluster")
+}
+
+func matchingOverrideSnapshotRefs(masterSnapshot *placementv1beta1.ClusterResourceSnapshot) ([]string, []placementv1beta1.NamespacedName) {
+	fakeInformer := envelopeOverrideInformerManager()
+	directClient, err := client.New(cfg, client.Options{Scheme: mgr.GetScheme()})
+	Expect(err).Should(Succeed())
+	croSnapshots, roSnapshots, err := overrider.FetchAllMatchingOverridesForResourceSnapshot(ctx, directClient, fakeInformer, testCRPName, masterSnapshot)
+	Expect(err).Should(Succeed())
+
+	croNames := make([]string, 0, len(croSnapshots))
+	for _, snapshot := range croSnapshots {
+		croNames = append(croNames, snapshot.Name)
+	}
+	roNames := make([]placementv1beta1.NamespacedName, 0, len(roSnapshots))
+	for _, snapshot := range roSnapshots {
+		roNames = append(roNames, placementv1beta1.NamespacedName{
+			Name:      snapshot.Name,
+			Namespace: snapshot.Namespace,
+		})
+	}
+	return croNames, roNames
+}
+
+func envelopeOverrideInformerManager() *testutilsinformer.FakeManager {
+	return &testutilsinformer.FakeManager{
+		APIResources: map[schema.GroupVersionKind]bool{
+			utils.NamespaceGVK: true,
+			placementv1beta1.GroupVersion.WithKind(string(placementv1beta1.ClusterResourceEnvelopeType)): true,
+			{
+				Group:   "admissionregistration.k8s.io",
+				Version: "v1",
+				Kind:    "ValidatingWebhookConfiguration",
+			}: true,
+			{
+				Group:   "apiextensions.k8s.io",
+				Version: "v1",
+				Kind:    "CustomResourceDefinition",
+			}: true,
+			{
+				Group:   "rbac.authorization.k8s.io",
+				Version: "v1",
+				Kind:    "ClusterRole",
+			}: true,
+		},
+		IsClusterScopedResource: true,
+	}
+}
+
+func envelopeResourceOverrideSnapshot(name, namespace string, selectors []placementv1beta1.ResourceSelector, patches []placementv1beta1.JSONPatchOverride) *placementv1beta1.ResourceOverrideSnapshot {
+	return &placementv1beta1.ResourceOverrideSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				placementv1beta1.IsLatestSnapshotLabel: "true",
+			},
+		},
+		Spec: placementv1beta1.ResourceOverrideSnapshotSpec{
+			OverrideSpec: placementv1beta1.ResourceOverrideSpec{
+				Placement: &placementv1beta1.PlacementRef{
+					Name:  testCRPName,
+					Scope: placementv1beta1.ClusterScoped,
+				},
+				ResourceSelectors: selectors,
+				Policy: &placementv1beta1.OverridePolicy{
+					OverrideRules: []placementv1beta1.OverrideRule{
+						{
+							ClusterSelector: &placementv1beta1.ClusterSelector{
+								ClusterSelectorTerms: []placementv1beta1.ClusterSelectorTerm{},
+							},
+							OverrideType:       placementv1beta1.JSONPatchOverrideType,
+							JSONPatchOverrides: patches,
+						},
+					},
+				},
+			},
+			OverrideHash: []byte(name),
+		},
+	}
+}
+
+func envelopeClusterResourceOverrideSnapshot(name string, selectors []placementv1beta1.ResourceSelectorTerm, patches []placementv1beta1.JSONPatchOverride) *placementv1beta1.ClusterResourceOverrideSnapshot {
+	return &placementv1beta1.ClusterResourceOverrideSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				placementv1beta1.IsLatestSnapshotLabel: "true",
+			},
+		},
+		Spec: placementv1beta1.ClusterResourceOverrideSnapshotSpec{
+			OverrideSpec: placementv1beta1.ClusterResourceOverrideSpec{
+				Placement: &placementv1beta1.PlacementRef{
+					Name:  testCRPName,
+					Scope: placementv1beta1.ClusterScoped,
+				},
+				ClusterResourceSelectors: selectors,
+				Policy: &placementv1beta1.OverridePolicy{
+					OverrideRules: []placementv1beta1.OverrideRule{
+						{
+							ClusterSelector: &placementv1beta1.ClusterSelector{
+								ClusterSelectorTerms: []placementv1beta1.ClusterSelectorTerm{},
+							},
+							OverrideType:       placementv1beta1.JSONPatchOverrideType,
+							JSONPatchOverrides: patches,
+						},
+					},
+				},
+			},
+			OverrideHash: []byte(name),
+		},
+	}
+}
+
+func resourceEnvelopeRaw(name, namespace string, data map[string][]byte) []byte {
+	rawData := make(map[string]runtime.RawExtension, len(data))
+	for key, raw := range data {
+		rawData[key] = runtime.RawExtension{Raw: raw}
+	}
+	return mustMarshalJSON(&placementv1beta1.ResourceEnvelope{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: placementv1beta1.GroupVersion.String(),
+			Kind:       string(placementv1beta1.ResourceEnvelopeType),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Data: rawData,
+	})
+}
+
+func clusterResourceEnvelopeRaw(name string, data map[string][]byte) []byte {
+	rawData := make(map[string]runtime.RawExtension, len(data))
+	for key, raw := range data {
+		rawData[key] = runtime.RawExtension{Raw: raw}
+	}
+	return mustMarshalJSON(&placementv1beta1.ClusterResourceEnvelope{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: placementv1beta1.GroupVersion.String(),
+			Kind:       string(placementv1beta1.ClusterResourceEnvelopeType),
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Data:       rawData,
+	})
+}
+
+func deploymentManifestRaw(namespace, name string, labels map[string]string) []byte {
+	return mustMarshalJSON(map[string]interface{}{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": namespace,
+			"labels":    labels,
+		},
+		"spec": map[string]interface{}{
+			"replicas": int64(1),
+			"selector": map[string]interface{}{
+				"matchLabels": map[string]string{"app": "demo"},
+			},
+			"template": map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"labels": map[string]string{"app": "demo"},
+				},
+				"spec": map[string]interface{}{
+					"containers": []map[string]string{
+						{
+							"name":  "nginx",
+							"image": "nginx:1.14.2",
+						},
+					},
+				},
+			},
+		},
+	})
+}
+
+func configMapManifestRaw(namespace, name string) []byte {
+	return mustMarshalJSON(map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": namespace,
+		},
+		"data": map[string]string{
+			"field": "untouched",
+		},
+	})
+}
+
+func clusterRoleManifestRaw(name string, labels map[string]string) []byte {
+	metadata := map[string]interface{}{
+		"name": name,
+	}
+	if labels != nil {
+		metadata["labels"] = labels
+	}
+	return mustMarshalJSON(map[string]interface{}{
+		"apiVersion": "rbac.authorization.k8s.io/v1",
+		"kind":       "ClusterRole",
+		"metadata":   metadata,
+		"rules": []map[string]interface{}{
+			{
+				"apiGroups": []string{""},
+				"resources": []string{"pods"},
+				"verbs":     []string{"get", "list", "watch"},
+			},
+		},
+	})
+}
+
+func findManifestObject(manifests []placementv1beta1.Manifest, group, version, kind, namespace, name string) unstructured.Unstructured {
+	for _, manifest := range manifests {
+		got := manifestObject(manifest.Raw)
+		gvk := got.GroupVersionKind()
+		if gvk.Group == group && gvk.Version == version && gvk.Kind == kind && got.GetNamespace() == namespace && got.GetName() == name {
+			return got
+		}
+	}
+	Fail(fmt.Sprintf("manifest %s/%s, Kind=%s, namespace=%s, name=%s not found", group, version, kind, namespace, name))
+	return unstructured.Unstructured{}
+}
+
+func manifestObject(raw []byte) unstructured.Unstructured {
+	var obj unstructured.Unstructured
+	Expect(obj.UnmarshalJSON(raw)).Should(Succeed())
+	return obj
+}
+
+func mustMarshalJSON(obj interface{}) []byte {
+	raw, err := json.Marshal(obj)
+	Expect(err).Should(Succeed())
+	return raw
 }
 
 func generateClusterResourceBinding(spec placementv1beta1.ResourceBindingSpec) *placementv1beta1.ClusterResourceBinding {

--- a/pkg/controllers/workgenerator/envelope.go
+++ b/pkg/controllers/workgenerator/envelope.go
@@ -36,27 +36,41 @@ import (
 )
 
 // createOrUpdateEnvelopeCRWorkObj creates or updates a work object for a given envelope CR.
+//
+// The returned bool reports an override failure (used to fail the binding's Overridden condition);
+// it is only meaningful when the returned error is non-nil and is always false on success.
 func (r *Reconciler) createOrUpdateEnvelopeCRWorkObj(
 	ctx context.Context,
 	envelopeReader fleetv1beta1.EnvelopeReader,
 	workNamePrefix string,
 	binding fleetv1beta1.BindingObj,
 	resourceSnapshot fleetv1beta1.ResourceSnapshotObj,
+	overrideCtx *overrideContext,
 	resourceOverrideSnapshotHash, clusterResourceOverrideSnapshotHash string,
-) (*fleetv1beta1.Work, error) {
+) (*fleetv1beta1.Work, bool, error) {
 	manifests, err := extractManifestsFromEnvelopeCR(envelopeReader)
 	if err != nil {
 		klog.ErrorS(err, "Failed to extract manifests from the envelope spec",
 			"resourceBinding", klog.KObj(binding),
 			"resourceSnapshot", klog.KObj(resourceSnapshot),
 			"envelope", envelopeReader.GetEnvelopeObjRef())
-		return nil, err
+		return nil, false, err
 	}
 	klog.V(2).InfoS("Successfully extracted wrapped manifests from the envelope",
 		"numOfResources", len(manifests),
 		"resourceBinding", klog.KObj(binding),
 		"resourceSnapshot", klog.KObj(resourceSnapshot),
 		"envelope", envelopeReader.GetEnvelopeObjRef())
+
+	var overrideFailed bool
+	manifests, overrideFailed, err = r.applyOverridesToEnvelopeManifests(manifests, overrideCtx, envelopeReader)
+	if err != nil {
+		klog.ErrorS(err, "Failed to apply override rules to the manifests extracted from the envelope",
+			"resourceBinding", klog.KObj(binding),
+			"resourceSnapshot", klog.KObj(resourceSnapshot),
+			"envelope", envelopeReader.GetEnvelopeObjRef())
+		return nil, overrideFailed, err
+	}
 
 	// Check to see if a corresponding work object has been created for the envelope.
 	labelMatcher := client.MatchingLabels{
@@ -83,7 +97,7 @@ func (r *Reconciler) createOrUpdateEnvelopeCRWorkObj(
 			"resourceSnapshot", klog.KObj(resourceSnapshot),
 			"envelope", envelopeReader.GetEnvelopeObjRef())
 		wrappedErr := fmt.Errorf("failed to list work objects when finding the work object for an envelope %v: %w", envelopeReader.GetEnvelopeObjRef(), err)
-		return nil, controller.NewAPIServerError(true, wrappedErr)
+		return nil, false, controller.NewAPIServerError(true, wrappedErr)
 	}
 
 	var work *fleetv1beta1.Work
@@ -110,7 +124,7 @@ func (r *Reconciler) createOrUpdateEnvelopeCRWorkObj(
 		r.recorder.Eventf(binding, corev1.EventTypeWarning, "DuplicateEnvelopeWorks",
 			"Multiple Work objects (%v) found for envelope %v in namespace %s; delete all but the oldest to recover",
 			workNames, envelopeReader.GetEnvelopeObjRef(), fmt.Sprintf(utils.NamespaceNameFormat, binding.GetBindingSpec().TargetCluster))
-		return nil, controller.NewUnexpectedBehaviorError(wrappedErr)
+		return nil, false, controller.NewUnexpectedBehaviorError(wrappedErr)
 	case len(workList.Items) == 1:
 		klog.V(2).InfoS("Found existing work object for the envelope; updating it",
 			"work", klog.KObj(&workList.Items[0]),
@@ -128,7 +142,54 @@ func (r *Reconciler) createOrUpdateEnvelopeCRWorkObj(
 		work = buildNewWorkForEnvelopeCR(workNamePrefix, binding, resourceSnapshot, envelopeReader, manifests, resourceOverrideSnapshotHash, clusterResourceOverrideSnapshotHash)
 	}
 
-	return work, nil
+	return work, false, nil
+}
+
+// applyOverridesToEnvelopeManifests applies the override rules to each manifest extracted from an
+// envelope, dropping any manifest that a Delete override removes, and returns the surviving,
+// overridden manifests.
+//
+// The returned bool reports whether applying the override rules failed, as opposed to a manifest
+// parse failure; it is only meaningful when the returned error is non-nil, and lets the caller fail
+// the binding's Overridden condition. On success it is always false, so false alone does not mean
+// "overrides succeeded".
+func (r *Reconciler) applyOverridesToEnvelopeManifests(
+	manifests []fleetv1beta1.Manifest,
+	overrideCtx *overrideContext,
+	envelopeReader fleetv1beta1.EnvelopeReader,
+) ([]fleetv1beta1.Manifest, bool, error) {
+	overriddenManifests := make([]fleetv1beta1.Manifest, 0, len(manifests))
+	for i := range manifests {
+		manifest := manifests[i]
+		resourceContent := &fleetv1beta1.ResourceContent{
+			RawExtension: manifest.RawExtension,
+		}
+		if manifest.Raw != nil {
+			resourceContent.Raw = append([]byte(nil), manifest.Raw...)
+		}
+
+		var target unstructured.Unstructured
+		if err := target.UnmarshalJSON(resourceContent.Raw); err != nil {
+			wrappedErr := fmt.Errorf("failed to parse manifest from envelope %v: %w", envelopeReader.GetEnvelopeObjRef(), err)
+			return nil, false, controller.NewUnexpectedBehaviorError(wrappedErr)
+		}
+
+		deleted, err := r.applyOverrides(resourceContent, overrideCtx.cluster, overrideCtx.croMap, overrideCtx.roMap)
+		if err != nil {
+			return nil, true, fmt.Errorf("failed to apply overrides to %s from envelope %v: %w", formatOverrideTarget(&target), envelopeReader.GetEnvelopeObjRef(), err)
+		}
+		if deleted {
+			klog.V(2).InfoS("The envelope manifest is deleted by the override rules",
+				"envelope", envelopeReader.GetEnvelopeObjRef(),
+				"resource", klog.KObj(&target))
+			continue
+		}
+
+		overriddenManifests = append(overriddenManifests, fleetv1beta1.Manifest{
+			RawExtension: resourceContent.RawExtension,
+		})
+	}
+	return overriddenManifests, false, nil
 }
 
 func extractManifestsFromEnvelopeCR(envelopeReader fleetv1beta1.EnvelopeReader) ([]fleetv1beta1.Manifest, error) {

--- a/pkg/controllers/workgenerator/envelope_test.go
+++ b/pkg/controllers/workgenerator/envelope_test.go
@@ -27,12 +27,16 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	clusterv1beta1 "github.com/kubefleet-dev/kubefleet/apis/cluster/v1beta1"
 	fleetv1beta1 "github.com/kubefleet-dev/kubefleet/apis/placement/v1beta1"
 	"github.com/kubefleet-dev/kubefleet/pkg/utils"
 	"github.com/kubefleet-dev/kubefleet/pkg/utils/controller"
@@ -254,6 +258,365 @@ func TestExtractManifestsFromEnvelopeCR(t *testing.T) {
 				t.Errorf("extractManifestsFromEnvelopeCR() mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestApplyOverridesToEnvelopeManifests(t *testing.T) {
+	cluster := &clusterv1beta1.MemberCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster-1"},
+	}
+	fakeInformer := informer.FakeManager{
+		APIResources: map[schema.GroupVersionKind]bool{
+			utils.ConfigMapGVK:  true,
+			utils.DeploymentGVK: true,
+		},
+		IsClusterScopedResource: false,
+	}
+
+	deploymentRaw := `{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"web","namespace":"app"},"spec":{"replicas":1,"selector":{"matchLabels":{"app":"web"}},"template":{"metadata":{"labels":{"app":"web"}},"spec":{"containers":[{"name":"web","image":"nginx","env":[]}]}}}}`
+	configMapRaw := `{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"settings","namespace":"app"},"data":{"key":"value"}}`
+	clusterRoleRaw := `{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"ClusterRole","metadata":{"name":"reader"},"rules":[{"apiGroups":[""],"resources":["pods"],"verbs":["get"]}]}`
+	otherDeploymentRaw := `{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"api","namespace":"app"},"spec":{"replicas":1,"selector":{"matchLabels":{"app":"api"}},"template":{"metadata":{"labels":{"app":"api"}},"spec":{"containers":[{"name":"api","image":"nginx"}]}}}}`
+
+	tests := []struct {
+		name                 string
+		envelopeReader       fleetv1beta1.EnvelopeReader
+		croMap               map[fleetv1beta1.ResourceIdentifier][]*fleetv1beta1.ClusterResourceOverrideSnapshot
+		roMap                map[fleetv1beta1.ResourceIdentifier][]*fleetv1beta1.ResourceOverrideSnapshot
+		wantByResourceKey    map[string]string
+		wantRawByResourceKey map[string]string
+		wantErrSubstrings    []string
+	}{
+		{
+			name: "ResourceEnvelope applies ResourceOverride to inner Deployment replicas",
+			envelopeReader: &fleetv1beta1.ResourceEnvelope{
+				ObjectMeta: metav1.ObjectMeta{Name: "app-envelope", Namespace: "app"},
+				Data: map[string]runtime.RawExtension{
+					"deployment": {Raw: []byte(deploymentRaw)},
+				},
+			},
+			roMap: map[fleetv1beta1.ResourceIdentifier][]*fleetv1beta1.ResourceOverrideSnapshot{
+				deploymentResourceIdentifier("app", "web"): {resourceOverrideSnapshot("replicas-ro", "app", placementPatchRule("/spec/replicas", []byte(`5`)))},
+			},
+			wantByResourceKey: map[string]string{
+				"Deployment/app/web": `{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"web","namespace":"app"},"spec":{"replicas":5,"selector":{"matchLabels":{"app":"web"}},"template":{"metadata":{"labels":{"app":"web"}},"spec":{"containers":[{"name":"web","image":"nginx","env":[]}]}}}}`,
+			},
+		},
+		{
+			name: "ClusterResourceEnvelope applies ClusterResourceOverride to inner ClusterRole",
+			envelopeReader: &fleetv1beta1.ClusterResourceEnvelope{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster-envelope"},
+				Data: map[string]runtime.RawExtension{
+					"clusterrole": {Raw: []byte(clusterRoleRaw)},
+				},
+			},
+			croMap: map[fleetv1beta1.ResourceIdentifier][]*fleetv1beta1.ClusterResourceOverrideSnapshot{
+				clusterRoleResourceIdentifier("reader"): {clusterResourceOverrideSnapshot("clusterrole-cro", addPatchRule("/metadata/labels", []byte(`{"patched":"true"}`)))},
+			},
+			wantByResourceKey: map[string]string{
+				"ClusterRole//reader": `{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"ClusterRole","metadata":{"labels":{"patched":"true"},"name":"reader"},"rules":[{"apiGroups":[""],"resources":["pods"],"verbs":["get"]}]}`,
+			},
+		},
+		{
+			name: "override matching only one inner resource leaves siblings byte-identical",
+			envelopeReader: &fleetv1beta1.ResourceEnvelope{
+				ObjectMeta: metav1.ObjectMeta{Name: "mixed-envelope", Namespace: "app"},
+				Data: map[string]runtime.RawExtension{
+					"configmap":  {Raw: []byte(configMapRaw)},
+					"deployment": {Raw: []byte(deploymentRaw)},
+				},
+			},
+			roMap: map[fleetv1beta1.ResourceIdentifier][]*fleetv1beta1.ResourceOverrideSnapshot{
+				deploymentResourceIdentifier("app", "web"): {resourceOverrideSnapshot("label-ro", "app", addPatchRule("/metadata/labels", []byte(`{"patched":"true"}`)))},
+			},
+			wantByResourceKey: map[string]string{
+				"ConfigMap/app/settings": configMapRaw,
+				"Deployment/app/web":     `{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"labels":{"patched":"true"},"name":"web","namespace":"app"},"spec":{"replicas":1,"selector":{"matchLabels":{"app":"web"}},"template":{"metadata":{"labels":{"app":"web"}},"spec":{"containers":[{"name":"web","image":"nginx","env":[]}]}}}}`,
+			},
+			wantRawByResourceKey: map[string]string{
+				"ConfigMap/app/settings": configMapRaw,
+			},
+		},
+		{
+			name: "Delete override omits only the matching inner manifest",
+			envelopeReader: &fleetv1beta1.ResourceEnvelope{
+				ObjectMeta: metav1.ObjectMeta{Name: "delete-one-envelope", Namespace: "app"},
+				Data: map[string]runtime.RawExtension{
+					"configmap":  {Raw: []byte(configMapRaw)},
+					"deployment": {Raw: []byte(deploymentRaw)},
+				},
+			},
+			roMap: map[fleetv1beta1.ResourceIdentifier][]*fleetv1beta1.ResourceOverrideSnapshot{
+				deploymentResourceIdentifier("app", "web"): {resourceOverrideSnapshot("delete-ro", "app", deleteOverrideRule())},
+			},
+			wantByResourceKey: map[string]string{
+				"ConfigMap/app/settings": configMapRaw,
+			},
+		},
+		{
+			name: "Delete overrides can produce an empty manifest list",
+			envelopeReader: &fleetv1beta1.ResourceEnvelope{
+				ObjectMeta: metav1.ObjectMeta{Name: "delete-all-envelope", Namespace: "app"},
+				Data: map[string]runtime.RawExtension{
+					"api": {Raw: []byte(otherDeploymentRaw)},
+					"web": {Raw: []byte(deploymentRaw)},
+				},
+			},
+			roMap: map[fleetv1beta1.ResourceIdentifier][]*fleetv1beta1.ResourceOverrideSnapshot{
+				deploymentResourceIdentifier("app", "api"): {resourceOverrideSnapshot("delete-api-ro", "app", deleteOverrideRule())},
+				deploymentResourceIdentifier("app", "web"): {resourceOverrideSnapshot("delete-web-ro", "app", deleteOverrideRule())},
+			},
+			wantByResourceKey: map[string]string{},
+		},
+		{
+			name: "JSONPatch error identifies inner target and containing envelope",
+			envelopeReader: &fleetv1beta1.ResourceEnvelope{
+				ObjectMeta: metav1.ObjectMeta{Name: "bad-patch-envelope", Namespace: "app"},
+				Data: map[string]runtime.RawExtension{
+					"deployment": {Raw: []byte(deploymentRaw)},
+				},
+			},
+			roMap: map[fleetv1beta1.ResourceIdentifier][]*fleetv1beta1.ResourceOverrideSnapshot{
+				deploymentResourceIdentifier("app", "web"): {resourceOverrideSnapshot("bad-ro", "app", placementPatchRule("/spec/missing/value", []byte(`1`)))},
+			},
+			wantErrSubstrings: []string{
+				`Deployment "web" in namespace "app"`,
+				"bad-patch-envelope",
+				`ResourceOverrideSnapshot "bad-ro"`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Reconciler{InformerManager: &fakeInformer}
+			manifests, err := extractManifestsFromEnvelopeCR(tt.envelopeReader)
+			if err != nil {
+				t.Fatalf("extractManifestsFromEnvelopeCR() error = %v, want nil", err)
+			}
+
+			got, overrideFailed, err := r.applyOverridesToEnvelopeManifests(manifests, &overrideContext{cluster: cluster, croMap: tt.croMap, roMap: tt.roMap}, tt.envelopeReader)
+			if len(tt.wantErrSubstrings) > 0 {
+				if err == nil {
+					t.Fatalf("applyOverridesToEnvelopeManifests() error = nil, want non-nil")
+				}
+				if !overrideFailed {
+					t.Errorf("applyOverridesToEnvelopeManifests() overrideFailed = false, want true")
+				}
+				for _, want := range tt.wantErrSubstrings {
+					if !strings.Contains(err.Error(), want) {
+						t.Errorf("applyOverridesToEnvelopeManifests() error = %q, want to contain %q", err.Error(), want)
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("applyOverridesToEnvelopeManifests() error = %v, want nil", err)
+			}
+			if overrideFailed {
+				t.Errorf("applyOverridesToEnvelopeManifests() overrideFailed = true, want false")
+			}
+
+			gotByResourceKey := manifestObjectByResourceKey(t, got)
+			wantByResourceKey := manifestObjectByResourceKeyFromRaw(t, tt.wantByResourceKey)
+			if diff := cmp.Diff(wantByResourceKey, gotByResourceKey); diff != "" {
+				t.Errorf("applyOverridesToEnvelopeManifests() mismatch (-want +got):\n%s", diff)
+			}
+			gotRawByResourceKey := manifestRawByResourceKey(t, got)
+			for key, want := range tt.wantRawByResourceKey {
+				if got := gotRawByResourceKey[key]; got != want {
+					t.Errorf("applyOverridesToEnvelopeManifests() raw manifest %q = %s, want %s", key, got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestCreateOrUpdateEnvelopeCRWorkObj_EmptyManifestListRetained(t *testing.T) {
+	scheme := serviceScheme(t)
+	ctx := context.Background()
+	deploymentRaw := `{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"web","namespace":"app"},"spec":{"replicas":1,"selector":{"matchLabels":{"app":"web"}},"template":{"metadata":{"labels":{"app":"web"}},"spec":{"containers":[{"name":"web","image":"nginx"}]}}}}`
+	resourceEnvelope := &fleetv1beta1.ResourceEnvelope{
+		ObjectMeta: metav1.ObjectMeta{Name: "empty-envelope", Namespace: "app"},
+		Data: map[string]runtime.RawExtension{
+			"deployment": {Raw: []byte(deploymentRaw)},
+		},
+	}
+	resourceSnapshot := &fleetv1beta1.ClusterResourceSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "snapshot",
+			Labels: map[string]string{
+				fleetv1beta1.ResourceIndexLabel:     "0",
+				fleetv1beta1.PlacementTrackingLabel: "crp",
+			},
+		},
+	}
+	resourceBinding := &fleetv1beta1.ClusterResourceBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "binding",
+			Labels: map[string]string{
+				fleetv1beta1.PlacementTrackingLabel: "crp",
+			},
+		},
+		Spec: fleetv1beta1.ResourceBindingSpec{
+			TargetCluster:        "cluster-1",
+			ResourceSnapshotName: "snapshot",
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &Reconciler{
+		Client: fakeClient,
+		InformerManager: &informer.FakeManager{
+			APIResources:            map[schema.GroupVersionKind]bool{utils.DeploymentGVK: true},
+			IsClusterScopedResource: false,
+		},
+		recorder: record.NewFakeRecorder(10),
+	}
+	roMap := map[fleetv1beta1.ResourceIdentifier][]*fleetv1beta1.ResourceOverrideSnapshot{
+		deploymentResourceIdentifier("app", "web"): {resourceOverrideSnapshot("delete-ro", "app", deleteOverrideRule())},
+	}
+
+	got, overrideFailed, err := r.createOrUpdateEnvelopeCRWorkObj(ctx, resourceEnvelope, testWorkNamePrefix, resourceBinding, resourceSnapshot, &overrideContext{cluster: &clusterv1beta1.MemberCluster{ObjectMeta: metav1.ObjectMeta{Name: "cluster-1"}}, roMap: roMap}, "ro-hash", "cro-hash")
+	if err != nil {
+		t.Fatalf("createOrUpdateEnvelopeCRWorkObj() error = %v, want nil", err)
+	}
+	if overrideFailed {
+		t.Errorf("createOrUpdateEnvelopeCRWorkObj() overrideFailed = true, want false")
+	}
+	if got == nil {
+		t.Fatalf("createOrUpdateEnvelopeCRWorkObj() = nil, want Work")
+	}
+	if len(got.Spec.Workload.Manifests) != 0 {
+		t.Errorf("createOrUpdateEnvelopeCRWorkObj() manifests len = %d, want 0", len(got.Spec.Workload.Manifests))
+	}
+	if got.Annotations[fleetv1beta1.ParentResourceOverrideSnapshotHashAnnotation] != "ro-hash" {
+		t.Errorf("resource override hash annotation = %q, want %q", got.Annotations[fleetv1beta1.ParentResourceOverrideSnapshotHashAnnotation], "ro-hash")
+	}
+}
+
+func manifestObjectByResourceKey(t *testing.T, manifests []fleetv1beta1.Manifest) map[string]map[string]interface{} {
+	t.Helper()
+	byKey := make(map[string]map[string]interface{}, len(manifests))
+	for i := range manifests {
+		key, obj := manifestKeyAndObject(t, manifests[i].Raw)
+		byKey[key] = obj
+	}
+	return byKey
+}
+
+func manifestObjectByResourceKeyFromRaw(t *testing.T, manifests map[string]string) map[string]map[string]interface{} {
+	t.Helper()
+	byKey := make(map[string]map[string]interface{}, len(manifests))
+	for key, raw := range manifests {
+		gotKey, obj := manifestKeyAndObject(t, []byte(raw))
+		if gotKey != key {
+			t.Fatalf("manifest key from raw = %q, want %q", gotKey, key)
+		}
+		byKey[key] = obj
+	}
+	return byKey
+}
+
+func manifestRawByResourceKey(t *testing.T, manifests []fleetv1beta1.Manifest) map[string]string {
+	t.Helper()
+	byKey := make(map[string]string, len(manifests))
+	for i := range manifests {
+		key, _ := manifestKeyAndObject(t, manifests[i].Raw)
+		byKey[key] = string(manifests[i].Raw)
+	}
+	return byKey
+}
+
+func manifestKeyAndObject(t *testing.T, raw []byte) (string, map[string]interface{}) {
+	t.Helper()
+	var u unstructured.Unstructured
+	if err := u.UnmarshalJSON(raw); err != nil {
+		t.Fatalf("UnmarshalJSON(%q) error = %v, want nil", string(raw), err)
+	}
+	key := fmt.Sprintf("%s/%s/%s", u.GetKind(), u.GetNamespace(), u.GetName())
+	return key, u.Object
+}
+
+func deploymentResourceIdentifier(namespace, name string) fleetv1beta1.ResourceIdentifier {
+	return fleetv1beta1.ResourceIdentifier{
+		Group:     utils.DeploymentGVK.Group,
+		Version:   utils.DeploymentGVK.Version,
+		Kind:      utils.DeploymentGVK.Kind,
+		Namespace: namespace,
+		Name:      name,
+	}
+}
+
+func clusterRoleResourceIdentifier(name string) fleetv1beta1.ResourceIdentifier {
+	return fleetv1beta1.ResourceIdentifier{
+		Group:   utils.ClusterRoleGVK.Group,
+		Version: utils.ClusterRoleGVK.Version,
+		Kind:    utils.ClusterRoleGVK.Kind,
+		Name:    name,
+	}
+}
+
+func resourceOverrideSnapshot(name, namespace string, rule fleetv1beta1.OverrideRule) *fleetv1beta1.ResourceOverrideSnapshot {
+	return &fleetv1beta1.ResourceOverrideSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: fleetv1beta1.ResourceOverrideSnapshotSpec{
+			OverrideSpec: fleetv1beta1.ResourceOverrideSpec{
+				Policy: &fleetv1beta1.OverridePolicy{
+					OverrideRules: []fleetv1beta1.OverrideRule{rule},
+				},
+			},
+		},
+	}
+}
+
+func clusterResourceOverrideSnapshot(name string, rule fleetv1beta1.OverrideRule) *fleetv1beta1.ClusterResourceOverrideSnapshot {
+	return &fleetv1beta1.ClusterResourceOverrideSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: fleetv1beta1.ClusterResourceOverrideSnapshotSpec{
+			OverrideSpec: fleetv1beta1.ClusterResourceOverrideSpec{
+				Policy: &fleetv1beta1.OverridePolicy{
+					OverrideRules: []fleetv1beta1.OverrideRule{rule},
+				},
+			},
+		},
+	}
+}
+
+func placementPatchRule(path string, value []byte) fleetv1beta1.OverrideRule {
+	return fleetv1beta1.OverrideRule{
+		ClusterSelector: &fleetv1beta1.ClusterSelector{},
+		JSONPatchOverrides: []fleetv1beta1.JSONPatchOverride{
+			{
+				Operator: fleetv1beta1.JSONPatchOverrideOpReplace,
+				Path:     path,
+				Value:    apiextensionsv1.JSON{Raw: value},
+			},
+		},
+	}
+}
+
+func addPatchRule(path string, value []byte) fleetv1beta1.OverrideRule {
+	return fleetv1beta1.OverrideRule{
+		ClusterSelector: &fleetv1beta1.ClusterSelector{},
+		JSONPatchOverrides: []fleetv1beta1.JSONPatchOverride{
+			{
+				Operator: fleetv1beta1.JSONPatchOverrideOpAdd,
+				Path:     path,
+				Value:    apiextensionsv1.JSON{Raw: value},
+			},
+		},
+	}
+}
+
+func deleteOverrideRule() fleetv1beta1.OverrideRule {
+	return fleetv1beta1.OverrideRule{
+		ClusterSelector: &fleetv1beta1.ClusterSelector{},
+		OverrideType:    fleetv1beta1.DeleteOverrideType,
 	}
 }
 
@@ -522,8 +885,8 @@ func TestCreateOrUpdateEnvelopeCRWorkObj(t *testing.T) {
 			}
 
 			// Call the function under test
-			got, err := r.createOrUpdateEnvelopeCRWorkObj(ctx, tt.envelopeReader, testWorkNamePrefix,
-				resourceBinding, resourceSnapshot, tt.resourceOverrideSnapshotHash, tt.clusterResourceOverrideSnapshotHash)
+			got, overrideFailed, err := r.createOrUpdateEnvelopeCRWorkObj(ctx, tt.envelopeReader, testWorkNamePrefix,
+				resourceBinding, resourceSnapshot, &overrideContext{cluster: &clusterv1beta1.MemberCluster{}}, tt.resourceOverrideSnapshotHash, tt.clusterResourceOverrideSnapshotHash)
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("createOrUpdateEnvelopeCRWorkObj() error = %v, wantErr %v", err, tt.wantErr)
@@ -533,6 +896,9 @@ func TestCreateOrUpdateEnvelopeCRWorkObj(t *testing.T) {
 			// Use cmp.Diff for comparison
 			if diff := cmp.Diff(got, tt.want, ignoreWorkOption, ignoreWorkMeta, ignoreTypeMeta); diff != "" {
 				t.Errorf("createOrUpdateEnvelopeCRWorkObj() mismatch (-got +want):\n%s", diff)
+			}
+			if overrideFailed {
+				t.Errorf("createOrUpdateEnvelopeCRWorkObj() overrideFailed = true, want false")
 			}
 		})
 	}
@@ -689,9 +1055,10 @@ func TestProcessOneSelectedResource(t *testing.T) {
 			newWork := make([]*fleetv1beta1.Work, 0)
 			simpleManifests := make([]fleetv1beta1.Manifest, 0)
 
-			gotNewWork, gotSimpleManifests, err := r.processOneSelectedResource(
+			gotNewWork, gotSimpleManifests, overrideFailed, err := r.processOneSelectedResource(
 				ctx,
 				tt.selectedResource,
+				&overrideContext{cluster: &clusterv1beta1.MemberCluster{}},
 				resourceBinding,
 				snapshot,
 				testWorkNamePrefix,
@@ -705,6 +1072,9 @@ func TestProcessOneSelectedResource(t *testing.T) {
 			if (err != nil) != tt.wantErr {
 				t.Errorf("processOneSelectedResource() error = %v, wantErr %v", err, tt.wantErr)
 				return
+			}
+			if overrideFailed {
+				t.Errorf("processOneSelectedResource() overrideFailed = true, want false")
 			}
 
 			if len(gotNewWork) != tt.wantNewWorkLen {
@@ -720,6 +1090,250 @@ func TestProcessOneSelectedResource(t *testing.T) {
 				t.Errorf("processOneSelectedResource() populated %d active works, want %d", len(activeWork), tt.wantNewWorkLen)
 			}
 		})
+	}
+}
+
+func TestProcessOneSelectedResource_OverrideBehavior(t *testing.T) {
+	scheme := serviceScheme(t)
+	ctx := context.Background()
+	resourceBinding := &fleetv1beta1.ClusterResourceBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-binding",
+			Labels: map[string]string{
+				fleetv1beta1.PlacementTrackingLabel: "test-crp",
+			},
+		},
+		Spec: fleetv1beta1.ResourceBindingSpec{
+			TargetCluster:        "test-cluster",
+			ResourceSnapshotName: "test-snapshot",
+		},
+	}
+	snapshot := &fleetv1beta1.ClusterResourceSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-snapshot",
+			Labels: map[string]string{
+				fleetv1beta1.ResourceIndexLabel:     "0",
+				fleetv1beta1.PlacementTrackingLabel: "test-crp",
+			},
+		},
+	}
+	cluster := &clusterv1beta1.MemberCluster{ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"}}
+	deploymentRaw := `{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"web","namespace":"app"},"spec":{"replicas":1,"selector":{"matchLabels":{"app":"web"}},"template":{"metadata":{"labels":{"app":"web"}},"spec":{"containers":[{"name":"web","image":"nginx","env":[]}]}}}}`
+
+	resourceEnvelope := &fleetv1beta1.ResourceEnvelope{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: fleetv1beta1.GroupVersion.String(),
+			Kind:       fleetv1beta1.ResourceEnvelopeKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: "wrapper", Namespace: "app"},
+		Data: map[string]runtime.RawExtension{
+			"deployment": {Raw: []byte(deploymentRaw)},
+		},
+	}
+	resourceEnvelopeContent := createResourceContent(t, resourceEnvelope)
+	originalEnvelopeRaw := append([]byte(nil), resourceEnvelopeContent.Raw...)
+
+	regularDeployment := &unstructured.Unstructured{}
+	if err := regularDeployment.UnmarshalJSON([]byte(deploymentRaw)); err != nil {
+		t.Fatalf("UnmarshalJSON(%q) error = %v, want nil", deploymentRaw, err)
+	}
+	regularDeploymentContent := createResourceContent(t, regularDeployment)
+
+	tests := []struct {
+		name             string
+		selectedResource *fleetv1beta1.ResourceContent
+		roMap            map[fleetv1beta1.ResourceIdentifier][]*fleetv1beta1.ResourceOverrideSnapshot
+		validate         func(t *testing.T, gotNewWork []*fleetv1beta1.Work, gotSimpleManifests []fleetv1beta1.Manifest)
+	}{
+		{
+			name:             "wrapper-targeting override is ignored for ResourceEnvelope",
+			selectedResource: resourceEnvelopeContent,
+			roMap: map[fleetv1beta1.ResourceIdentifier][]*fleetv1beta1.ResourceOverrideSnapshot{
+				{
+					Group:     fleetv1beta1.GroupVersion.Group,
+					Version:   fleetv1beta1.GroupVersion.Version,
+					Kind:      fleetv1beta1.ResourceEnvelopeKind,
+					Namespace: "app",
+					Name:      "wrapper",
+				}: {resourceOverrideSnapshot("wrapper-ro", "app", addPatchRule("/data/injected", []byte(`{"raw":{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"bad","namespace":"app"}}}`)))},
+			},
+			validate: func(t *testing.T, gotNewWork []*fleetv1beta1.Work, gotSimpleManifests []fleetv1beta1.Manifest) {
+				t.Helper()
+				if len(gotSimpleManifests) != 0 {
+					t.Fatalf("processOneSelectedResource() simple manifests len = %d, want 0", len(gotSimpleManifests))
+				}
+				if len(gotNewWork) != 1 {
+					t.Fatalf("processOneSelectedResource() new works len = %d, want 1", len(gotNewWork))
+				}
+				gotByResourceKey := manifestObjectByResourceKey(t, gotNewWork[0].Spec.Workload.Manifests)
+				wantByResourceKey := map[string]string{"Deployment/app/web": deploymentRaw}
+				wantObjectByResourceKey := manifestObjectByResourceKeyFromRaw(t, wantByResourceKey)
+				if diff := cmp.Diff(wantObjectByResourceKey, gotByResourceKey); diff != "" {
+					t.Errorf("processOneSelectedResource() envelope manifests mismatch (-want +got):\n%s", diff)
+				}
+				if string(resourceEnvelopeContent.Raw) != string(originalEnvelopeRaw) {
+					t.Errorf("processOneSelectedResource() mutated envelope wrapper raw = %s, want %s", string(resourceEnvelopeContent.Raw), string(originalEnvelopeRaw))
+				}
+			},
+		},
+		{
+			name:             "non-envelope override is applied exactly once",
+			selectedResource: regularDeploymentContent,
+			roMap: map[fleetv1beta1.ResourceIdentifier][]*fleetv1beta1.ResourceOverrideSnapshot{
+				deploymentResourceIdentifier("app", "web"): {resourceOverrideSnapshot("env-ro", "app", addPatchRule("/spec/template/spec/containers/0/env/-", []byte(`{"name":"ADDED","value":"true"}`)))},
+			},
+			validate: func(t *testing.T, gotNewWork []*fleetv1beta1.Work, gotSimpleManifests []fleetv1beta1.Manifest) {
+				t.Helper()
+				if len(gotNewWork) != 0 {
+					t.Fatalf("processOneSelectedResource() new works len = %d, want 0", len(gotNewWork))
+				}
+				if len(gotSimpleManifests) != 1 {
+					t.Fatalf("processOneSelectedResource() simple manifests len = %d, want 1", len(gotSimpleManifests))
+				}
+				var u unstructured.Unstructured
+				if err := u.UnmarshalJSON(gotSimpleManifests[0].Raw); err != nil {
+					t.Fatalf("UnmarshalJSON() error = %v, want nil", err)
+				}
+				containers, found, err := unstructured.NestedSlice(u.Object, "spec", "template", "spec", "containers")
+				if err != nil || !found || len(containers) != 1 {
+					t.Fatalf("containers lookup error = %v, found = %v, len = %d, want one container", err, found, len(containers))
+				}
+				container, ok := containers[0].(map[string]interface{})
+				if !ok {
+					t.Fatalf("container type = %T, want map[string]interface{}", containers[0])
+				}
+				env, ok := container["env"].([]interface{})
+				if !ok {
+					t.Fatalf("env type = %T, want []interface{}", container["env"])
+				}
+				if len(env) != 1 {
+					t.Fatalf("env entries len = %d, want 1", len(env))
+				}
+				gotEnv, ok := env[0].(map[string]interface{})
+				if !ok {
+					t.Fatalf("env entry type = %T, want map[string]interface{}", env[0])
+				}
+				wantEnv := map[string]interface{}{"name": "ADDED", "value": "true"}
+				if diff := cmp.Diff(wantEnv, gotEnv); diff != "" {
+					t.Errorf("env entry mismatch (-want +got):\n%s", diff)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+			r := &Reconciler{
+				Client: fakeClient,
+				InformerManager: &informer.FakeManager{
+					APIResources: map[schema.GroupVersionKind]bool{
+						utils.DeploymentGVK: true,
+						fleetv1beta1.GroupVersion.WithKind(fleetv1beta1.ResourceEnvelopeKind): true,
+					},
+					IsClusterScopedResource: false,
+				},
+				recorder: record.NewFakeRecorder(10),
+			}
+			activeWork := make(map[string]*fleetv1beta1.Work)
+			gotNewWork, gotSimpleManifests, overrideFailed, err := r.processOneSelectedResource(
+				ctx,
+				tt.selectedResource,
+				&overrideContext{cluster: cluster, roMap: tt.roMap},
+				resourceBinding,
+				snapshot,
+				testWorkNamePrefix,
+				"ro-hash",
+				"cro-hash",
+				activeWork,
+				nil,
+				nil,
+			)
+			if err != nil {
+				t.Fatalf("processOneSelectedResource() error = %v, want nil", err)
+			}
+			if overrideFailed {
+				t.Errorf("processOneSelectedResource() overrideFailed = true, want false")
+			}
+			tt.validate(t, gotNewWork, gotSimpleManifests)
+		})
+	}
+}
+
+func TestProcessOneSelectedResource_EnvelopeInnerOverrideFailureClassifiedAsOverrideFailure(t *testing.T) {
+	scheme := serviceScheme(t)
+	ctx := context.Background()
+	deploymentRaw := `{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"web","namespace":"app"},"spec":{"replicas":1,"selector":{"matchLabels":{"app":"web"}},"template":{"metadata":{"labels":{"app":"web"}},"spec":{"containers":[{"name":"web","image":"nginx"}]}}}}`
+	resourceEnvelopeContent := createResourceContent(t, &fleetv1beta1.ResourceEnvelope{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: fleetv1beta1.GroupVersion.String(),
+			Kind:       fleetv1beta1.ResourceEnvelopeKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: "bad-inner-override", Namespace: "app"},
+		Data: map[string]runtime.RawExtension{
+			"deployment": {Raw: []byte(deploymentRaw)},
+		},
+	})
+	resourceBinding := &fleetv1beta1.ClusterResourceBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-binding",
+			Labels: map[string]string{
+				fleetv1beta1.PlacementTrackingLabel: "test-crp",
+			},
+		},
+		Spec: fleetv1beta1.ResourceBindingSpec{
+			TargetCluster:        "test-cluster",
+			ResourceSnapshotName: "test-snapshot",
+		},
+	}
+	snapshot := &fleetv1beta1.ClusterResourceSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-snapshot",
+			Labels: map[string]string{
+				fleetv1beta1.ResourceIndexLabel:     "0",
+				fleetv1beta1.PlacementTrackingLabel: "test-crp",
+			},
+		},
+	}
+	r := &Reconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).Build(),
+		InformerManager: &informer.FakeManager{
+			APIResources: map[schema.GroupVersionKind]bool{
+				utils.DeploymentGVK: true,
+				fleetv1beta1.GroupVersion.WithKind(fleetv1beta1.ResourceEnvelopeKind): true,
+			},
+			IsClusterScopedResource: false,
+		},
+		recorder: record.NewFakeRecorder(10),
+	}
+	roMap := map[fleetv1beta1.ResourceIdentifier][]*fleetv1beta1.ResourceOverrideSnapshot{
+		deploymentResourceIdentifier("app", "web"): {
+			resourceOverrideSnapshot("bad-ro", "app", placementPatchRule("/spec/missing/value", []byte(`1`))),
+		},
+	}
+
+	_, _, overrideFailed, err := r.processOneSelectedResource(
+		ctx,
+		resourceEnvelopeContent,
+		&overrideContext{cluster: &clusterv1beta1.MemberCluster{ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"}}, roMap: roMap},
+		resourceBinding,
+		snapshot,
+		testWorkNamePrefix,
+		"ro-hash",
+		"cro-hash",
+		make(map[string]*fleetv1beta1.Work),
+		nil,
+		nil,
+	)
+
+	if err == nil {
+		t.Fatalf("processOneSelectedResource() error = nil, want non-nil")
+	}
+	if !overrideFailed {
+		t.Errorf("processOneSelectedResource() overrideFailed = false, want true")
+	}
+	if !errors.Is(err, controller.ErrUserError) {
+		t.Errorf("processOneSelectedResource() error = %v, want wrapping controller.ErrUserError", err)
 	}
 }
 
@@ -862,8 +1476,8 @@ func TestCreateOrUpdateEnvelopeCRWorkObj_DuplicateWorksSurfaceWithoutMutation(t 
 		InformerManager: &informer.FakeManager{},
 	}
 
-	got, err := r.createOrUpdateEnvelopeCRWorkObj(ctx, resourceEnvelope, testWorkNamePrefix,
-		resourceBinding, resourceSnapshot, "", "")
+	got, overrideFailed, err := r.createOrUpdateEnvelopeCRWorkObj(ctx, resourceEnvelope, testWorkNamePrefix,
+		resourceBinding, resourceSnapshot, &overrideContext{cluster: &clusterv1beta1.MemberCluster{}}, "", "")
 
 	if got != nil {
 		t.Errorf("createOrUpdateEnvelopeCRWorkObj() = %v, want nil on duplicate-detected path", got)
@@ -873,6 +1487,9 @@ func TestCreateOrUpdateEnvelopeCRWorkObj_DuplicateWorksSurfaceWithoutMutation(t 
 	}
 	if !errors.Is(err, controller.ErrUnexpectedBehavior) {
 		t.Errorf("createOrUpdateEnvelopeCRWorkObj() error = %v, want wrapping controller.ErrUnexpectedBehavior", err)
+	}
+	if overrideFailed {
+		t.Errorf("createOrUpdateEnvelopeCRWorkObj() overrideFailed = true, want false")
 	}
 
 	// Post-condition: all duplicates remain untouched — no auto-deletion.

--- a/pkg/controllers/workgenerator/suite_test.go
+++ b/pkg/controllers/workgenerator/suite_test.go
@@ -132,6 +132,17 @@ var _ = BeforeSuite(func() {
 				Version: "v1",
 				Kind:    "MutatingWebhookConfiguration",
 			}: true,
+			{
+				Group:   "admissionregistration.k8s.io",
+				Version: "v1",
+				Kind:    "ValidatingWebhookConfiguration",
+			}: true,
+			{
+				Group:   "rbac.authorization.k8s.io",
+				Version: "v1",
+				Kind:    "ClusterRole",
+			}: true,
+			placementv1beta1.GroupVersion.WithKind(string(placementv1beta1.ClusterResourceEnvelopeType)): true,
 		},
 		IsClusterScopedResource: true,
 	}

--- a/pkg/utils/overrider/overrider.go
+++ b/pkg/utils/overrider/overrider.go
@@ -117,7 +117,7 @@ func FetchAllMatchingOverridesForResourceSnapshot(
 			}
 		}
 		if !matched {
-			klog.Warningf("ClusterResourceOverrideSnapshot %s has no selector that matches a selected resource or inner envelope resource in placement %s; selectors=%+v", klog.KObj(&croList.Items[i]), placementKey, croList.Items[i].Spec.OverrideSpec.ClusterResourceSelectors)
+			klog.V(2).InfoS("ClusterResourceOverrideSnapshot has no selector that matches a selected resource or inner envelope resource in this placement", "clusterResourceOverride", klog.KObj(&croList.Items[i]), "placement", placementKey, "selectors", croList.Items[i].Spec.OverrideSpec.ClusterResourceSelectors)
 		}
 	}
 	for i := range roList.Items {
@@ -149,7 +149,7 @@ func FetchAllMatchingOverridesForResourceSnapshot(
 			}
 		}
 		if !matched {
-			klog.Warningf("ResourceOverrideSnapshot %s has no selector that matches a selected resource or inner envelope resource in placement %s; selectors=%+v", klog.KObj(&roList.Items[i]), placementKey, roList.Items[i].Spec.OverrideSpec.ResourceSelectors)
+			klog.V(2).InfoS("ResourceOverrideSnapshot has no selector that matches a selected resource or inner envelope resource in this placement", "resourceOverride", klog.KObj(&roList.Items[i]), "placement", placementKey, "selectors", roList.Items[i].Spec.OverrideSpec.ResourceSelectors)
 		}
 	}
 	return filteredCRO, filteredRO, nil

--- a/pkg/utils/overrider/overrider.go
+++ b/pkg/utils/overrider/overrider.go
@@ -19,6 +19,7 @@ package overrider
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -28,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -77,37 +79,16 @@ func FetchAllMatchingOverridesForResourceSnapshot(
 	// List all the possible CROs and ROs based on the selected resources.
 	for _, snapshot := range resourceSnapshots {
 		for _, res := range snapshot.GetResourceSnapshotSpec().SelectedResources {
-			var uResource unstructured.Unstructured
-			if err := uResource.UnmarshalJSON(res.Raw); err != nil {
-				klog.ErrorS(err, "Resource has invalid content", "snapshot", klog.KObj(snapshot), "selectedResource", res.Raw)
-				return nil, nil, controller.NewUnexpectedBehaviorError(err)
+			croCandidates, roCandidates, err := collectOverrideCandidatesFromSelectedResource(manager, res)
+			if err != nil {
+				klog.ErrorS(err, "Failed to collect override candidates from selected resource", "snapshot", klog.KObj(snapshot), "selectedResource", res.Raw)
+				return nil, nil, err
 			}
-			// If the resource is namespaced scope resource, the resource could be selected by the namespace or selected
-			// by the object itself.
-			if !manager.IsClusterScopedResources(uResource.GroupVersionKind()) {
-				croKey := placementv1beta1.ResourceIdentifier{
-					Group:   utils.NamespaceMetaGVK.Group,
-					Version: utils.NamespaceMetaGVK.Version,
-					Kind:    utils.NamespaceMetaGVK.Kind,
-					Name:    uResource.GetNamespace(),
-				}
-				possibleCROs[croKey] = true // selected by the namespace
-				roKey := placementv1beta1.ResourceIdentifier{
-					Group:     uResource.GetObjectKind().GroupVersionKind().Group,
-					Version:   uResource.GetObjectKind().GroupVersionKind().Version,
-					Kind:      uResource.GetObjectKind().GroupVersionKind().Kind,
-					Namespace: uResource.GetNamespace(),
-					Name:      uResource.GetName(),
-				}
-				possibleROs[roKey] = true // selected by the object itself
-			} else {
-				croKey := placementv1beta1.ResourceIdentifier{
-					Group:   uResource.GetObjectKind().GroupVersionKind().Group,
-					Version: uResource.GetObjectKind().GroupVersionKind().Version,
-					Kind:    uResource.GetObjectKind().GroupVersionKind().Kind,
-					Name:    uResource.GetName(),
-				}
-				possibleCROs[croKey] = true // selected by the object itself
+			for cro := range croCandidates {
+				possibleCROs[cro] = true
+			}
+			for ro := range roCandidates {
+				possibleROs[ro] = true
 			}
 		}
 	}
@@ -121,6 +102,7 @@ func FetchAllMatchingOverridesForResourceSnapshot(
 			continue
 		}
 
+		matched := false
 		for _, selector := range croList.Items[i].Spec.OverrideSpec.ClusterResourceSelectors {
 			croKey := placementv1beta1.ResourceIdentifier{
 				Group:   selector.Group,
@@ -130,8 +112,12 @@ func FetchAllMatchingOverridesForResourceSnapshot(
 			}
 			if possibleCROs[croKey] {
 				filteredCRO = append(filteredCRO, &croList.Items[i])
+				matched = true
 				break
 			}
+		}
+		if !matched {
+			klog.Warningf("ClusterResourceOverrideSnapshot %s has no selector that matches a selected resource or inner envelope resource in placement %s; selectors=%+v", klog.KObj(&croList.Items[i]), placementKey, croList.Items[i].Spec.OverrideSpec.ClusterResourceSelectors)
 		}
 	}
 	for i := range roList.Items {
@@ -147,6 +133,7 @@ func FetchAllMatchingOverridesForResourceSnapshot(
 			}
 		}
 
+		matched := false
 		for _, selector := range roList.Items[i].Spec.OverrideSpec.ResourceSelectors {
 			roKey := placementv1beta1.ResourceIdentifier{
 				Group:     selector.Group,
@@ -157,11 +144,170 @@ func FetchAllMatchingOverridesForResourceSnapshot(
 			}
 			if possibleROs[roKey] {
 				filteredRO = append(filteredRO, &roList.Items[i])
+				matched = true
 				break
 			}
 		}
+		if !matched {
+			klog.Warningf("ResourceOverrideSnapshot %s has no selector that matches a selected resource or inner envelope resource in placement %s; selectors=%+v", klog.KObj(&roList.Items[i]), placementKey, roList.Items[i].Spec.OverrideSpec.ResourceSelectors)
+		}
 	}
 	return filteredCRO, filteredRO, nil
+}
+
+func collectOverrideCandidatesFromSelectedResource(
+	manager informer.Manager,
+	resourceContent placementv1beta1.ResourceContent,
+) (map[placementv1beta1.ResourceIdentifier]bool, map[placementv1beta1.ResourceIdentifier]bool, error) {
+	uResource, err := unmarshalSelectedResource(resourceContent)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	croCandidates := make(map[placementv1beta1.ResourceIdentifier]bool)
+	roCandidates := make(map[placementv1beta1.ResourceIdentifier]bool)
+	switch uResource.GroupVersionKind() {
+	case placementv1beta1.GroupVersion.WithKind(string(placementv1beta1.ClusterResourceEnvelopeType)):
+		var envelope placementv1beta1.ClusterResourceEnvelope
+		if err := json.Unmarshal(resourceContent.Raw, &envelope); err != nil {
+			return nil, nil, controller.NewUnexpectedBehaviorError(err)
+		}
+		collectCandidatesFromClusterResourceEnvelope(manager, &envelope, croCandidates)
+	case placementv1beta1.GroupVersion.WithKind(string(placementv1beta1.ResourceEnvelopeType)):
+		var envelope placementv1beta1.ResourceEnvelope
+		if err := json.Unmarshal(resourceContent.Raw, &envelope); err != nil {
+			return nil, nil, controller.NewUnexpectedBehaviorError(err)
+		}
+		croCandidates[namespaceCROCandidate(envelope.GetNamespace())] = true
+		collectCandidatesFromResourceEnvelope(manager, &envelope, roCandidates)
+	default:
+		addCandidatesFromResource(manager, uResource, croCandidates, roCandidates)
+	}
+	return croCandidates, roCandidates, nil
+}
+
+func unmarshalSelectedResource(resourceContent placementv1beta1.ResourceContent) (*unstructured.Unstructured, error) {
+	var uResource unstructured.Unstructured
+	if err := uResource.UnmarshalJSON(resourceContent.Raw); err != nil {
+		klog.ErrorS(err, "Resource has invalid content", "selectedResource", resourceContent.Raw)
+		return nil, controller.NewUnexpectedBehaviorError(err)
+	}
+	return &uResource, nil
+}
+
+// collectCandidatesFromClusterResourceEnvelope collects override candidates from the inner manifests of a
+// cluster resource envelope. Collecting candidates is a best-effort selection concern and must never block
+// the rollout, so an invalid inner manifest or one that cannot be parsed is logged and skipped rather than returning an
+// error. The authoritative validation of envelope contents lives in the work generator
+// (pkg/controllers/workgenerator/envelope.go), which surfaces the user-facing failure.
+func collectCandidatesFromClusterResourceEnvelope(
+	manager informer.Manager,
+	envelope *placementv1beta1.ClusterResourceEnvelope,
+	croCandidates map[placementv1beta1.ResourceIdentifier]bool,
+) {
+	keys := sortedEnvelopeDataKeys(envelope.Data)
+	for _, key := range keys {
+		uObj, err := unmarshalEnvelopeData(envelope, key)
+		if err != nil {
+			klog.V(2).InfoS("Skipped an inner manifest that could not be parsed while collecting override candidates", "manifestKey", key, "envelope", klog.KObj(envelope), "err", err)
+			continue
+		}
+		if !manager.IsClusterScopedResources(uObj.GroupVersionKind()) {
+			klog.V(2).InfoS("Skipped an inner manifest while collecting override candidates: a namespaced object has been wrapped in a cluster resource envelope", "manifestKey", key, "wrappedObject", klog.KRef(uObj.GetNamespace(), uObj.GetName()), "envelope", klog.KObj(envelope))
+			continue
+		}
+		croCandidates[clusterScopedCROCandidate(uObj)] = true
+	}
+}
+
+// collectCandidatesFromResourceEnvelope collects override candidates from the inner manifests of a resource
+// envelope. Collecting candidates is a best-effort selection concern and must never block the rollout, so an
+// invalid inner manifest or one that cannot be parsed is logged and skipped rather than returning an error. The
+// authoritative validation of envelope contents lives in the work generator
+// (pkg/controllers/workgenerator/envelope.go), which surfaces the user-facing failure.
+func collectCandidatesFromResourceEnvelope(
+	manager informer.Manager,
+	envelope *placementv1beta1.ResourceEnvelope,
+	roCandidates map[placementv1beta1.ResourceIdentifier]bool,
+) {
+	keys := sortedEnvelopeDataKeys(envelope.Data)
+	for _, key := range keys {
+		uObj, err := unmarshalEnvelopeData(envelope, key)
+		if err != nil {
+			klog.V(2).InfoS("Skipped an inner manifest that could not be parsed while collecting override candidates", "manifestKey", key, "envelope", klog.KObj(envelope), "err", err)
+			continue
+		}
+		if manager.IsClusterScopedResources(uObj.GroupVersionKind()) {
+			klog.V(2).InfoS("Skipped an inner manifest while collecting override candidates: a cluster scoped object has been wrapped in a resource envelope", "manifestKey", key, "wrappedObject", klog.KRef(uObj.GetNamespace(), uObj.GetName()), "envelope", klog.KObj(envelope))
+			continue
+		}
+		if envelope.GetNamespace() != uObj.GetNamespace() {
+			klog.V(2).InfoS("Skipped an inner manifest while collecting override candidates: a namespaced object has been wrapped in a resource envelope from another namespace", "manifestKey", key, "wrappedObject", klog.KRef(uObj.GetNamespace(), uObj.GetName()), "envelope", klog.KObj(envelope))
+			continue
+		}
+		roCandidates[namespacedROCandidate(uObj, envelope.GetNamespace())] = true
+	}
+}
+
+func unmarshalEnvelopeData(envelope placementv1beta1.EnvelopeReader, key string) (*unstructured.Unstructured, error) {
+	var uObj unstructured.Unstructured
+	if err := uObj.UnmarshalJSON(envelope.GetData()[key].Raw); err != nil {
+		return nil, fmt.Errorf("failed to parse the wrapped manifest data to a Kubernetes runtime object (manifestKey=%s,envelopeObjRef=%v): %w", key, envelope.GetEnvelopeObjRef(), err)
+	}
+	return &uObj, nil
+}
+
+func sortedEnvelopeDataKeys(data map[string]runtime.RawExtension) []string {
+	keys := make([]string, 0, len(data))
+	for key := range data {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func addCandidatesFromResource(
+	manager informer.Manager,
+	uResource *unstructured.Unstructured,
+	croCandidates map[placementv1beta1.ResourceIdentifier]bool,
+	roCandidates map[placementv1beta1.ResourceIdentifier]bool,
+) {
+	if !manager.IsClusterScopedResources(uResource.GroupVersionKind()) {
+		croCandidates[namespaceCROCandidate(uResource.GetNamespace())] = true           // selected by the namespace
+		roCandidates[namespacedROCandidate(uResource, uResource.GetNamespace())] = true // selected by the object itself
+		return
+	}
+	croCandidates[clusterScopedCROCandidate(uResource)] = true // selected by the object itself
+}
+
+func namespaceCROCandidate(namespace string) placementv1beta1.ResourceIdentifier {
+	return placementv1beta1.ResourceIdentifier{
+		Group:   utils.NamespaceMetaGVK.Group,
+		Version: utils.NamespaceMetaGVK.Version,
+		Kind:    utils.NamespaceMetaGVK.Kind,
+		Name:    namespace,
+	}
+}
+
+func clusterScopedCROCandidate(uObj *unstructured.Unstructured) placementv1beta1.ResourceIdentifier {
+	gvk := uObj.GroupVersionKind()
+	return placementv1beta1.ResourceIdentifier{
+		Group:   gvk.Group,
+		Version: gvk.Version,
+		Kind:    gvk.Kind,
+		Name:    uObj.GetName(),
+	}
+}
+
+func namespacedROCandidate(uObj *unstructured.Unstructured, namespace string) placementv1beta1.ResourceIdentifier {
+	gvk := uObj.GroupVersionKind()
+	return placementv1beta1.ResourceIdentifier{
+		Group:     gvk.Group,
+		Version:   gvk.Version,
+		Kind:      gvk.Kind,
+		Namespace: namespace,
+		Name:      uObj.GetName(),
+	}
 }
 
 // PickFromResourceMatchedOverridesForTargetCluster filter the overrides that are matched with resources to the target cluster.

--- a/pkg/utils/overrider/overrider_test.go
+++ b/pkg/utils/overrider/overrider_test.go
@@ -18,6 +18,7 @@ package overrider
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"testing"
@@ -53,6 +54,110 @@ func serviceScheme(t *testing.T) *runtime.Scheme {
 	return scheme
 }
 
+func clusterResourceSnapshotForTest(resources ...placementv1beta1.ResourceContent) *placementv1beta1.ClusterResourceSnapshot {
+	return &placementv1beta1.ClusterResourceSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf(placementv1beta1.ResourceSnapshotNameFmt, crpName, 0),
+			Labels: map[string]string{
+				placementv1beta1.ResourceIndexLabel:     "0",
+				placementv1beta1.PlacementTrackingLabel: crpName,
+			},
+			Annotations: map[string]string{
+				placementv1beta1.ResourceGroupHashAnnotation:         "abc",
+				placementv1beta1.NumberOfResourceSnapshotsAnnotation: "1",
+			},
+		},
+		Spec: placementv1beta1.ResourceSnapshotSpec{
+			SelectedResources: resources,
+		},
+	}
+}
+
+func resourceEnvelopeContentForTest(t *testing.T, namespace, name string, data map[string]string) placementv1beta1.ResourceContent {
+	t.Helper()
+	return envelopeContentForTest(t, string(placementv1beta1.ResourceEnvelopeType), namespace, name, data)
+}
+
+func clusterResourceEnvelopeContentForTest(t *testing.T, name string, data map[string]string) placementv1beta1.ResourceContent {
+	t.Helper()
+	return envelopeContentForTest(t, string(placementv1beta1.ClusterResourceEnvelopeType), "", name, data)
+}
+
+func envelopeContentForTest(t *testing.T, kind, namespace, name string, data map[string]string) placementv1beta1.ResourceContent {
+	t.Helper()
+	rawData := make(map[string]json.RawMessage, len(data))
+	for key, value := range data {
+		rawData[key] = json.RawMessage(value)
+	}
+	metadata := map[string]string{"name": name}
+	if namespace != "" {
+		metadata["namespace"] = namespace
+	}
+	raw, err := json.Marshal(map[string]interface{}{
+		"apiVersion": placementv1beta1.GroupVersion.String(),
+		"kind":       kind,
+		"metadata":   metadata,
+		"data":       rawData,
+	})
+	if err != nil {
+		t.Fatalf("json.Marshal(%s) = %v, want no error", kind, err)
+	}
+	return placementv1beta1.ResourceContent{RawExtension: runtime.RawExtension{Raw: raw}}
+}
+
+func deploymentRawForTest(namespace, name string) string {
+	return fmt.Sprintf(`{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"namespace":%q,"name":%q}}`, namespace, name)
+}
+
+func secretRawForTest(namespace, name string) string {
+	return fmt.Sprintf(`{"apiVersion":"v1","kind":"Secret","metadata":{"namespace":%q,"name":%q}}`, namespace, name)
+}
+
+func clusterRoleRawForTest(name string) string {
+	return fmt.Sprintf(`{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"ClusterRole","metadata":{"name":%q}}`, name)
+}
+
+func latestCROSnapshotForTest(name string, selectors ...placementv1beta1.ResourceSelectorTerm) placementv1beta1.ClusterResourceOverrideSnapshot {
+	return placementv1beta1.ClusterResourceOverrideSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				placementv1beta1.IsLatestSnapshotLabel: "true",
+			},
+		},
+		Spec: placementv1beta1.ClusterResourceOverrideSnapshotSpec{
+			OverrideSpec: placementv1beta1.ClusterResourceOverrideSpec{
+				ClusterResourceSelectors: selectors,
+			},
+		},
+	}
+}
+
+func latestROSnapshotForTest(namespace, name string, selectors ...placementv1beta1.ResourceSelector) placementv1beta1.ResourceOverrideSnapshot {
+	return placementv1beta1.ResourceOverrideSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				placementv1beta1.IsLatestSnapshotLabel: "true",
+			},
+		},
+		Spec: placementv1beta1.ResourceOverrideSnapshotSpec{
+			OverrideSpec: placementv1beta1.ResourceOverrideSpec{
+				ResourceSelectors: selectors,
+			},
+		},
+	}
+}
+
+func clusterResourceOverrideSnapshotPtrForTest(snapshot placementv1beta1.ClusterResourceOverrideSnapshot) *placementv1beta1.ClusterResourceOverrideSnapshot {
+	return &snapshot
+}
+
+func resourceOverrideSnapshotPtrForTest(snapshot placementv1beta1.ResourceOverrideSnapshot) *placementv1beta1.ResourceOverrideSnapshot {
+	return &snapshot
+}
+
 func TestFetchAllMatchingOverridesForResourceSnapshot(t *testing.T) {
 	fakeInformer := informer.FakeManager{
 		APIResources: map[schema.GroupVersionKind]bool{
@@ -84,6 +189,7 @@ func TestFetchAllMatchingOverridesForResourceSnapshot(t *testing.T) {
 		roList       []placementv1beta1.ResourceOverrideSnapshot
 		wantCRO      []*placementv1beta1.ClusterResourceOverrideSnapshot
 		wantRO       []*placementv1beta1.ResourceOverrideSnapshot
+		wantErr      error
 	}{
 		{
 			name:         "single resource snapshot selecting empty resources",
@@ -1482,6 +1588,385 @@ func TestFetchAllMatchingOverridesForResourceSnapshot(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "resource envelope inner deployment matches resource override",
+			master: clusterResourceSnapshotForTest(resourceEnvelopeContentForTest(t, "ns", "env", map[string]string{
+				"deployment.yaml": deploymentRawForTest("ns", "my-app"),
+			})),
+			roList: []placementv1beta1.ResourceOverrideSnapshot{
+				latestROSnapshotForTest("ns", "ro-deployment", placementv1beta1.ResourceSelector{
+					Group:   "apps",
+					Version: "v1",
+					Kind:    "Deployment",
+					Name:    "my-app",
+				}),
+			},
+			wantCRO: []*placementv1beta1.ClusterResourceOverrideSnapshot{},
+			wantRO: []*placementv1beta1.ResourceOverrideSnapshot{
+				resourceOverrideSnapshotPtrForTest(latestROSnapshotForTest("ns", "ro-deployment", placementv1beta1.ResourceSelector{
+					Group:   "apps",
+					Version: "v1",
+					Kind:    "Deployment",
+					Name:    "my-app",
+				})),
+			},
+		},
+		{
+			name: "cluster resource envelope inner cluster role matches cluster resource override",
+			master: clusterResourceSnapshotForTest(clusterResourceEnvelopeContentForTest(t, "env", map[string]string{
+				"clusterrole.yaml": clusterRoleRawForTest("foo"),
+			})),
+			croList: []placementv1beta1.ClusterResourceOverrideSnapshot{
+				latestCROSnapshotForTest("cro-clusterrole", placementv1beta1.ResourceSelectorTerm{
+					Group:   "rbac.authorization.k8s.io",
+					Version: "v1",
+					Kind:    "ClusterRole",
+					Name:    "foo",
+				}),
+			},
+			wantCRO: []*placementv1beta1.ClusterResourceOverrideSnapshot{
+				clusterResourceOverrideSnapshotPtrForTest(latestCROSnapshotForTest("cro-clusterrole", placementv1beta1.ResourceSelectorTerm{
+					Group:   "rbac.authorization.k8s.io",
+					Version: "v1",
+					Kind:    "ClusterRole",
+					Name:    "foo",
+				})),
+			},
+			wantRO: []*placementv1beta1.ResourceOverrideSnapshot{},
+		},
+		{
+			name: "explicit envelope wrapper selectors are not matched",
+			master: clusterResourceSnapshotForTest(
+				clusterResourceEnvelopeContentForTest(t, "env", map[string]string{
+					"clusterrole.yaml": clusterRoleRawForTest("foo"),
+				}),
+				resourceEnvelopeContentForTest(t, "ns", "env", map[string]string{
+					"deployment.yaml": deploymentRawForTest("ns", "my-app"),
+				}),
+			),
+			croList: []placementv1beta1.ClusterResourceOverrideSnapshot{
+				latestCROSnapshotForTest("cro-wrapper", placementv1beta1.ResourceSelectorTerm{
+					Group:   placementv1beta1.GroupVersion.Group,
+					Version: placementv1beta1.GroupVersion.Version,
+					Kind:    string(placementv1beta1.ClusterResourceEnvelopeType),
+					Name:    "env",
+				}),
+			},
+			roList: []placementv1beta1.ResourceOverrideSnapshot{
+				latestROSnapshotForTest("ns", "ro-wrapper", placementv1beta1.ResourceSelector{
+					Group:   placementv1beta1.GroupVersion.Group,
+					Version: placementv1beta1.GroupVersion.Version,
+					Kind:    string(placementv1beta1.ResourceEnvelopeType),
+					Name:    "env",
+				}),
+			},
+			wantCRO: []*placementv1beta1.ClusterResourceOverrideSnapshot{},
+			wantRO:  []*placementv1beta1.ResourceOverrideSnapshot{},
+		},
+		{
+			name: "resource envelope namespace matches namespace cluster resource override",
+			master: clusterResourceSnapshotForTest(resourceEnvelopeContentForTest(t, "ns", "env", map[string]string{
+				"deployment.yaml": deploymentRawForTest("ns", "my-app"),
+			})),
+			croList: []placementv1beta1.ClusterResourceOverrideSnapshot{
+				latestCROSnapshotForTest("cro-namespace", placementv1beta1.ResourceSelectorTerm{
+					Group:   "",
+					Version: "v1",
+					Kind:    "Namespace",
+					Name:    "ns",
+				}),
+			},
+			wantCRO: []*placementv1beta1.ClusterResourceOverrideSnapshot{
+				clusterResourceOverrideSnapshotPtrForTest(latestCROSnapshotForTest("cro-namespace", placementv1beta1.ResourceSelectorTerm{
+					Group:   "",
+					Version: "v1",
+					Kind:    "Namespace",
+					Name:    "ns",
+				})),
+			},
+			wantRO: []*placementv1beta1.ResourceOverrideSnapshot{},
+		},
+		{
+			// Collecting override candidates is a best-effort selection concern and must never block the
+			// rollout. An inner manifest that cannot be parsed is skipped, and candidates from the remaining valid
+			// manifests in the same envelope are still collected.
+			name: "resource envelope inner manifest that cannot be parsed is skipped and valid inner manifests still collected",
+			master: clusterResourceSnapshotForTest(resourceEnvelopeContentForTest(t, "ns", "env", map[string]string{
+				"bad.yaml":        `"not-an-object"`,
+				"deployment.yaml": deploymentRawForTest("ns", "my-app"),
+			})),
+			roList: []placementv1beta1.ResourceOverrideSnapshot{
+				latestROSnapshotForTest("ns", "ro-deployment", placementv1beta1.ResourceSelector{
+					Group:   "apps",
+					Version: "v1",
+					Kind:    "Deployment",
+					Name:    "my-app",
+				}),
+			},
+			wantCRO: []*placementv1beta1.ClusterResourceOverrideSnapshot{},
+			wantRO: []*placementv1beta1.ResourceOverrideSnapshot{
+				resourceOverrideSnapshotPtrForTest(latestROSnapshotForTest("ns", "ro-deployment", placementv1beta1.ResourceSelector{
+					Group:   "apps",
+					Version: "v1",
+					Kind:    "Deployment",
+					Name:    "my-app",
+				})),
+			},
+		},
+		{
+			// A cluster-scoped object wrapped in a resource envelope is invalid input, but candidate
+			// collection must not hard-fail on it: the offending manifest is skipped while the valid inner
+			// manifest in the same envelope is still collected. The authoritative validation lives in the
+			// work generator.
+			name: "cluster scoped object wrapped in resource envelope is skipped and valid inner manifest still collected",
+			master: clusterResourceSnapshotForTest(resourceEnvelopeContentForTest(t, "ns", "env", map[string]string{
+				"clusterrole.yaml": clusterRoleRawForTest("foo"),
+				"deployment.yaml":  deploymentRawForTest("ns", "my-app"),
+			})),
+			croList: []placementv1beta1.ClusterResourceOverrideSnapshot{
+				latestCROSnapshotForTest("cro-clusterrole", placementv1beta1.ResourceSelectorTerm{
+					Group:   "rbac.authorization.k8s.io",
+					Version: "v1",
+					Kind:    "ClusterRole",
+					Name:    "foo",
+				}),
+			},
+			roList: []placementv1beta1.ResourceOverrideSnapshot{
+				latestROSnapshotForTest("ns", "ro-deployment", placementv1beta1.ResourceSelector{
+					Group:   "apps",
+					Version: "v1",
+					Kind:    "Deployment",
+					Name:    "my-app",
+				}),
+			},
+			wantCRO: []*placementv1beta1.ClusterResourceOverrideSnapshot{},
+			wantRO: []*placementv1beta1.ResourceOverrideSnapshot{
+				resourceOverrideSnapshotPtrForTest(latestROSnapshotForTest("ns", "ro-deployment", placementv1beta1.ResourceSelector{
+					Group:   "apps",
+					Version: "v1",
+					Kind:    "Deployment",
+					Name:    "my-app",
+				})),
+			},
+		},
+		{
+			// A namespaced object wrapped in a cluster resource envelope is invalid input, but candidate
+			// collection must not hard-fail on it: the offending manifest is skipped while the valid inner
+			// manifest in the same envelope is still collected.
+			name: "namespaced object wrapped in cluster resource envelope is skipped and valid inner manifest still collected",
+			master: clusterResourceSnapshotForTest(clusterResourceEnvelopeContentForTest(t, "env", map[string]string{
+				"deployment.yaml":  deploymentRawForTest("ns", "my-app"),
+				"clusterrole.yaml": clusterRoleRawForTest("foo"),
+			})),
+			croList: []placementv1beta1.ClusterResourceOverrideSnapshot{
+				latestCROSnapshotForTest("cro-clusterrole", placementv1beta1.ResourceSelectorTerm{
+					Group:   "rbac.authorization.k8s.io",
+					Version: "v1",
+					Kind:    "ClusterRole",
+					Name:    "foo",
+				}),
+				latestCROSnapshotForTest("cro-deployment", placementv1beta1.ResourceSelectorTerm{
+					Group:   "apps",
+					Version: "v1",
+					Kind:    "Deployment",
+					Name:    "my-app",
+				}),
+			},
+			wantCRO: []*placementv1beta1.ClusterResourceOverrideSnapshot{
+				clusterResourceOverrideSnapshotPtrForTest(latestCROSnapshotForTest("cro-clusterrole", placementv1beta1.ResourceSelectorTerm{
+					Group:   "rbac.authorization.k8s.io",
+					Version: "v1",
+					Kind:    "ClusterRole",
+					Name:    "foo",
+				})),
+			},
+			wantRO: []*placementv1beta1.ResourceOverrideSnapshot{},
+		},
+		{
+			// An inner manifest in a different namespace than the resource envelope is invalid input, but
+			// candidate collection must not hard-fail on it: the offending manifest is skipped while the
+			// valid inner manifest in the same envelope is still collected.
+			name: "inner manifest in a different namespace than the resource envelope is skipped and valid inner manifest still collected",
+			master: clusterResourceSnapshotForTest(resourceEnvelopeContentForTest(t, "ns", "env", map[string]string{
+				"other.yaml":      deploymentRawForTest("other-ns", "other-app"),
+				"deployment.yaml": deploymentRawForTest("ns", "my-app"),
+			})),
+			roList: []placementv1beta1.ResourceOverrideSnapshot{
+				latestROSnapshotForTest("ns", "ro-deployment", placementv1beta1.ResourceSelector{
+					Group:   "apps",
+					Version: "v1",
+					Kind:    "Deployment",
+					Name:    "my-app",
+				}),
+				latestROSnapshotForTest("other-ns", "ro-other", placementv1beta1.ResourceSelector{
+					Group:   "apps",
+					Version: "v1",
+					Kind:    "Deployment",
+					Name:    "other-app",
+				}),
+			},
+			wantCRO: []*placementv1beta1.ClusterResourceOverrideSnapshot{},
+			wantRO: []*placementv1beta1.ResourceOverrideSnapshot{
+				resourceOverrideSnapshotPtrForTest(latestROSnapshotForTest("ns", "ro-deployment", placementv1beta1.ResourceSelector{
+					Group:   "apps",
+					Version: "v1",
+					Kind:    "Deployment",
+					Name:    "my-app",
+				})),
+			},
+		},
+		{
+			name: "resource envelope with multiple inner resources only selects targeted override",
+			master: clusterResourceSnapshotForTest(resourceEnvelopeContentForTest(t, "ns", "env", map[string]string{
+				"deployment.yaml": deploymentRawForTest("ns", "my-app"),
+				"secret.yaml":     secretRawForTest("ns", "secret-name"),
+			})),
+			roList: []placementv1beta1.ResourceOverrideSnapshot{
+				latestROSnapshotForTest("ns", "ro-deployment", placementv1beta1.ResourceSelector{
+					Group:   "apps",
+					Version: "v1",
+					Kind:    "Deployment",
+					Name:    "my-app",
+				}),
+				latestROSnapshotForTest("ns", "ro-service", placementv1beta1.ResourceSelector{
+					Group:   "",
+					Version: "v1",
+					Kind:    "Service",
+					Name:    "svc-name",
+				}),
+			},
+			wantCRO: []*placementv1beta1.ClusterResourceOverrideSnapshot{},
+			wantRO: []*placementv1beta1.ResourceOverrideSnapshot{
+				resourceOverrideSnapshotPtrForTest(latestROSnapshotForTest("ns", "ro-deployment", placementv1beta1.ResourceSelector{
+					Group:   "apps",
+					Version: "v1",
+					Kind:    "Deployment",
+					Name:    "my-app",
+				})),
+			},
+		},
+		{
+			name: "resource envelope does not duplicate snapshot when multiple selectors match",
+			master: clusterResourceSnapshotForTest(resourceEnvelopeContentForTest(t, "ns", "env", map[string]string{
+				"deployment.yaml": deploymentRawForTest("ns", "my-app"),
+				"secret.yaml":     secretRawForTest("ns", "secret-name"),
+			})),
+			roList: []placementv1beta1.ResourceOverrideSnapshot{
+				latestROSnapshotForTest("ns", "ro-multiple-selectors",
+					placementv1beta1.ResourceSelector{
+						Group:   "apps",
+						Version: "v1",
+						Kind:    "Deployment",
+						Name:    "my-app",
+					},
+					placementv1beta1.ResourceSelector{
+						Group:   "",
+						Version: "v1",
+						Kind:    "Secret",
+						Name:    "secret-name",
+					},
+				),
+			},
+			wantCRO: []*placementv1beta1.ClusterResourceOverrideSnapshot{},
+			wantRO: []*placementv1beta1.ResourceOverrideSnapshot{
+				resourceOverrideSnapshotPtrForTest(latestROSnapshotForTest("ns", "ro-multiple-selectors",
+					placementv1beta1.ResourceSelector{
+						Group:   "apps",
+						Version: "v1",
+						Kind:    "Deployment",
+						Name:    "my-app",
+					},
+					placementv1beta1.ResourceSelector{
+						Group:   "",
+						Version: "v1",
+						Kind:    "Secret",
+						Name:    "secret-name",
+					},
+				)),
+			},
+		},
+		{
+			// Only a later selector matches; the snapshot is still selected. This pins the partial-match
+			// behaviour so the no-match warning stays scoped to snapshots where no selector matches at all.
+			name: "resource override with multiple selectors where only a later selector matches is still selected",
+			master: clusterResourceSnapshotForTest(resourceEnvelopeContentForTest(t, "ns", "env", map[string]string{
+				"deployment.yaml": deploymentRawForTest("ns", "my-app"),
+			})),
+			roList: []placementv1beta1.ResourceOverrideSnapshot{
+				latestROSnapshotForTest("ns", "ro-partial-match",
+					placementv1beta1.ResourceSelector{
+						Group:   "",
+						Version: "v1",
+						Kind:    "Service",
+						Name:    "does-not-exist",
+					},
+					placementv1beta1.ResourceSelector{
+						Group:   "apps",
+						Version: "v1",
+						Kind:    "Deployment",
+						Name:    "my-app",
+					},
+				),
+			},
+			wantCRO: []*placementv1beta1.ClusterResourceOverrideSnapshot{},
+			wantRO: []*placementv1beta1.ResourceOverrideSnapshot{
+				resourceOverrideSnapshotPtrForTest(latestROSnapshotForTest("ns", "ro-partial-match",
+					placementv1beta1.ResourceSelector{
+						Group:   "",
+						Version: "v1",
+						Kind:    "Service",
+						Name:    "does-not-exist",
+					},
+					placementv1beta1.ResourceSelector{
+						Group:   "apps",
+						Version: "v1",
+						Kind:    "Deployment",
+						Name:    "my-app",
+					},
+				)),
+			},
+		},
+		{
+			// Only a later selector matches; the snapshot is still selected. This pins the partial-match
+			// behaviour so the no-match warning stays scoped to snapshots where no selector matches at all.
+			name: "cluster resource override with multiple selectors where only a later selector matches is still selected",
+			master: clusterResourceSnapshotForTest(clusterResourceEnvelopeContentForTest(t, "env", map[string]string{
+				"clusterrole.yaml": clusterRoleRawForTest("foo"),
+			})),
+			croList: []placementv1beta1.ClusterResourceOverrideSnapshot{
+				latestCROSnapshotForTest("cro-partial-match",
+					placementv1beta1.ResourceSelectorTerm{
+						Group:   "rbac.authorization.k8s.io",
+						Version: "v1",
+						Kind:    "ClusterRole",
+						Name:    "does-not-exist",
+					},
+					placementv1beta1.ResourceSelectorTerm{
+						Group:   "rbac.authorization.k8s.io",
+						Version: "v1",
+						Kind:    "ClusterRole",
+						Name:    "foo",
+					},
+				),
+			},
+			wantCRO: []*placementv1beta1.ClusterResourceOverrideSnapshot{
+				clusterResourceOverrideSnapshotPtrForTest(latestCROSnapshotForTest("cro-partial-match",
+					placementv1beta1.ResourceSelectorTerm{
+						Group:   "rbac.authorization.k8s.io",
+						Version: "v1",
+						Kind:    "ClusterRole",
+						Name:    "does-not-exist",
+					},
+					placementv1beta1.ResourceSelectorTerm{
+						Group:   "rbac.authorization.k8s.io",
+						Version: "v1",
+						Kind:    "ClusterRole",
+						Name:    "foo",
+					},
+				)),
+			},
+			wantRO: []*placementv1beta1.ResourceOverrideSnapshot{},
+		},
 	}
 
 	for _, tc := range tests {
@@ -1502,8 +1987,11 @@ func TestFetchAllMatchingOverridesForResourceSnapshot(t *testing.T) {
 				WithObjects(objects...).
 				Build()
 			gotCRO, gotRO, err := FetchAllMatchingOverridesForResourceSnapshot(context.Background(), fakeClient, &fakeInformer, tc.placementKey, tc.master)
-			if err != nil {
-				t.Fatalf("fetchAllMatchingOverridesForResourceSnapshot() failed, got err %v, want no err", err)
+			if gotErr, wantErr := err != nil, tc.wantErr != nil; gotErr != wantErr || (err != nil && !errors.Is(err, tc.wantErr)) {
+				t.Fatalf("fetchAllMatchingOverridesForResourceSnapshot() got error %v, want error %v", err, tc.wantErr)
+			}
+			if tc.wantErr != nil {
+				return
 			}
 			options := []cmp.Option{
 				cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion"),


### PR DESCRIPTION
## Summary

Override rules targeting resources wrapped in `ResourceEnvelope` or `ClusterResourceEnvelope` were silently ignored.

Fixes #607

## Root cause

Two coupled defects:

- **Selection** — `FetchAllMatchingOverridesForResourceSnapshot` built override candidates only from the resource snapshot's `SelectedResources`. For an envelope placement that is the wrapper alone; the envelope's `.data` was never opened, so overrides targeting inner resources never reached the binding.
- **Application** — `syncAllWork` applied overrides before envelope detection, so rules were evaluated against the wrapper instead of the resources it carries.

Because selection never produced inner-resource candidates, fixing the work generator alone would not have been sufficient.

## Changes

- Select override snapshots by inspecting the resources inside an envelope rather than the wrapper.
- Apply overrides after envelope extraction, per inner manifest.
- Ignore overrides targeting envelope wrappers.
- A `Delete` override on an inner resource drops only that manifest; the Work is still created when this empties the envelope.
- Override failures inside an envelope are reported on the `Overridden` condition, consistent with non-envelope resources.
- Added `examples/envelopes/override-inside-envelope.yaml`.

## Behavioral change

Overrides no longer apply to envelope wrapper objects, including `/data/...` JSONPatch paths.

Rationale: an override changes resources that land on a member cluster, and the wrapper never lands. A repo-wide search found no existing usage of wrapper-targeting override selectors.

## Override candidate collection is best-effort

Candidate collection skips an inner manifest that is invalid (wrong scope for the envelope type, or a namespace that differs from the envelope's) or whose content cannot be parsed. It logs at V(2) and continues with the remaining manifests instead of returning an error.

This matters because `FetchAllMatchingOverridesForResourceSnapshot` runs in the rollout controller (`pkg/controllers/rollout/controller.go`) and in update run initialization — both upstream of the work generator. Returning an error there aborts the rollout, leaving `RolloutStarted` as `Unknown` so the work generator never runs and never reports the real failure.

`pkg/controllers/workgenerator/envelope.go` already performs these same checks and is the authoritative validator; it returns a user error that surfaces as `SyncWorkFailed`. Duplicating that validation upstream, at fatal severity, masked it. This is also consistent with the existing treatment of override selectors that match nothing, which warn rather than fail.

## Note on the `overrideContext` struct

Applying overrides after envelope extraction meant threading the target cluster and the two override snapshot maps down through `processOneSelectedResource`, `createOrUpdateEnvelopeCRWorkObj`, and `applyOverridesToEnvelopeManifests` — pushing `processOneSelectedResource` from 10 to 13 parameters.

They are bundled into a small `overrideContext` struct, assembled once in `syncAllWork`, so this cost one parameter rather than three and future override inputs will not churn these signatures.

The two alternatives were considered and rejected:

- **Fetching the snapshots deeper in the stack** — the fetches are informer-cache reads, so there is no network I/O, but `processOneSelectedResource` runs inside a nested loop over resource snapshots × selected resources. Fetching there would turn O(overrides) into O(snapshots × resources × overrides) cache reads and deep copies per reconcile, on a path that runs for every binding on every member cluster.
- **Caching the maps on the `Reconciler`** — unsafe, not merely suboptimal. `MaxConcurrentReconciles` is greater than one, so a single `Reconciler` serves concurrent reconciles for different bindings, and these maps are per-binding.

`applyOverrides` and the rest of `override.go` are unchanged.

## Validation

- `go build ./...`, `go vet`, `gofmt`, `staticcheck`, and `golangci-lint` clean.
- Unit tests pass for `pkg/utils/overrider` and `pkg/controllers/workgenerator`.
- Work generator integration suite: 92/92 specs pass (87 pre-existing + 5 new).
- The new override-selection unit tests and 5 new integration specs were each confirmed to **fail on `main` and pass with this change**, so they genuinely cover the reported bug. The same check was applied to the candidate-collection tests: reverting only `overrider.go` makes all of them fail.
- Full CI green, including all four e2e shards (`default`, `custom`, `joinleave`, `resourceplacement`).

## Note on a change that was dropped

An earlier revision of this PR also tightened `upsertWork` to compare desired manifests and apply strategy rather than relying on override snapshot hashes alone, intended as a guard against stale Works.

That change caused a real regression: it made 15 e2e specs fail (all CRO/RO/envelope/override paths) with `Applied` pinned at `ApplyInProgress` and `Available` never reported. `Manifest` embeds `runtime.RawExtension`, and `equality.Semantic` has no custom equality for it, so the comparison was byte-for-byte. Overridden manifests are re-serialized by the JSON patch library, so their bytes never match the API-server-canonicalized bytes read back from the cluster. The short-circuit could therefore never fire, `upsertWork` updated on every reconcile, and the binding's `Applied` condition was continually reset before `setBindingStatus` could propagate real Work status.

It has been reverted so this PR stays scoped to #607. The hash-only short-circuit is sound in practice: manifest content is deterministic given the resource snapshot index and the override snapshot hashes, both of which are already compared.

## Follow-ups (deliberately out of scope)

- #770 — reject envelope wrapper override selectors via webhook, plus a runtime guard.
- #771 — consider hard-failing override selectors that match nothing.

---

Note for reviewers: this repo's `.github/release.yml` expects a single `release-note/*` label, but those labels do not currently exist in the repo. `release-note/fix` matches the title prefix; the wrapper behavior change may warrant `release-note/breaking` instead.