### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @kubefleet-maintainers will be requested for review when someone opens a pull request.
+* @kubefleet-dev/kubefleet-maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
-# @kubefleet-maintainers will be requested for review when someone opens a pull request.
+# KubeFleet maintainers will be requested for review when someone opens a pull request.
 * @kubefleet-dev/kubefleet-maintainers


### PR DESCRIPTION
### Description of your changes

This PR adds the CODEOWNERS file so that PR reviews can be requested automatically on GitHub.

I have:

- [NA] Associated this change with a known KubeFleet Issue (Bug, Feature, etc).
- [NA] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

N/A

### Special notes for your reviewer

N/A
