### PR TITLE
fix: harden release tag handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,7 +127,13 @@ jobs:
             prerelease=""
             case "${TAG}" in *-*) prerelease="--prerelease" ;; esac
             # Create as a draft first so a partially uploaded release is never public.
-            gh release create "${TAG}" --title "${TAG}" --generate-notes --draft ${prerelease}
+            # --verify-tag: `gh release create` creates the tag itself when it is
+            # missing, pointing at the default branch's head. A tag that does not
+            # exist at all already fails earlier, at build-and-publish's checkout,
+            # so this guards the narrower case where the ref resolved to something
+            # that is not the tag - the release would then point at a different
+            # commit than the images were built from.
+            gh release create "${TAG}" --title "${TAG}" --generate-notes --draft --verify-tag ${prerelease}
             created_draft="true"
           fi
           gh release upload "${TAG}" \

--- a/.github/workflows/setup-release.yml
+++ b/.github/workflows/setup-release.yml
@@ -24,14 +24,30 @@ env:
 jobs:
     export:
         runs-on: ubuntu-latest
+        # Validates an input and writes step outputs; it touches no GitHub API,
+        # so it needs no token. Without this it inherits the caller's
+        # permissions, and chart.yml calls it with contents/packages write.
+        permissions: {}
         outputs:
             registry: ${{ steps.setup.outputs.registry }}
             tag: ${{ steps.setup.outputs.tag }}
             version: ${{ steps.setup.outputs.version }}
         steps:
             - id: setup
+              # The tag arrives as an environment variable rather than being
+              # interpolated into the script body: `TAG="${{ inputs.tag }}"`
+              # expands the value in the shell before the validation below can
+              # reject it. Both callers are affected, not just the
+              # workflow_dispatch input - backticks and $(...) are legal in git
+              # ref names and still match the v*.*.* push filter. Reaching
+              # either needs repository write access, so this is defence in
+              # depth, but the outputs below are interpolated into shell by
+              # every downstream job, which makes the regex the trust boundary
+              # for all of them.
+              env:
+                  RELEASE_TAG: ${{ inputs.tag }}
               run: |
-                  TAG="${{ inputs.tag }}"
+                  TAG="${RELEASE_TAG}"
                   if [[ ! "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$ ]]; then
                     echo "Error: Invalid release tag '${TAG}'. Expected format: vMAJOR.MINOR.PATCH or vMAJOR.MINOR.PATCH-rc.N"
                     exit 1


### PR DESCRIPTION
The release tag reaches the workflows in a way that is worth tightening. All three changes need repository write access to reach, so this is defence in depth rather than an externally reachable flaw.

- `setup-release.yml` interpolated `${{ inputs.tag }}` into its script body, expanding the value in the shell before the tag regex could reject it. Both trigger paths were affected, not just `workflow_dispatch` — backticks and `$(...)` are legal in git ref names and still match the `v*.*.*` push filter. The tag now arrives via step `env:`, so validation runs first. That regex is the single trust boundary for the outputs every downstream job interpolates into its own shell, in `release.yml` and `chart.yml` alike.
- The `export` job declared no `permissions:`, so it inherited the caller’s — `contents: write` and `packages: write` from `chart.yml`. It validates an input and writes step outputs, so it needs no token.
- `gh release create` gains `--verify-tag`. A missing tag already fails earlier at `build-and-publish`’s checkout; this covers the narrower case where the ref resolves to something that is not the tag, after which `gh` would create the tag at the default branch’s head and the release would point at a different commit than the images.

Reviewed for shell-injection reachability and for regressions to the RC, `workflow_dispatch`, and re-run paths. `actionlint` clean. Independently backportable.

Part of #693.