### PR TITLE
chore: update maintainer details and contacts

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -50,6 +50,7 @@ Examples of unacceptable behavior include but are not limited to:
 * Other conduct which could reasonably be considered inappropriate in a professional setting
 
 The following behaviors are also prohibited:
+
 * Providing knowingly false or misleading information in connection with a Code of Conduct investigation or otherwise intentionally tampering with an investigation.
 * Retaliating against a person because they reported an incident or provided information about an incident as a witness.
 
@@ -65,7 +66,7 @@ permanently removed from the project team.
 ## Reporting
 
 Report abusive, harassing, or otherwise unacceptable behaviors in the KubeFleet community
-to the project team at [kubefleet-maintainers@googlegroups.com](mailto:kubefleet-maintainers@googlegroups.com).
+to the [KubeFleet maintainers](mailto:kubefleet@microsoft.com).
 All reports will be thoroughly reviewed and investigated, and a response will be prepared,
 as appropriate.
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,11 +1,11 @@
 # The KubeFleet Maintainers
 
-| Maintainer       | Organization | GitHub Username                                    |
-|------------------|--------------|----------------------------------------------------|
-| Ryan Zhang       | Microsoft    | [@ryanzhang-oss](https://github.com/ryanzhang-oss) |
-| Zhiying Lin      | Microsoft    | [@zhiying-lin](https://github.com/zhiying-lin)     |
-| Chen Yu          | Microsoft    | [@michaelawyu](https://github.com/michaelawyu)     |
-| Wei Weng         | Microsoft    | [@weng271190436](https://github.com/weng271190436) |
-| Yetkin Timocin   | Microsoft    | [@ytimocin](https://github.com/ytimocin)           |
-| Stéphane Erbrech | Microsoft    | [@serbrech](https://github.com/serbrech)           |
-| Simon Waight     | Microsoft    | [@sjwaight](https://github.com/sjwaight)           |
+| Maintainer               | Organization | GitHub Username                                    |
+|--------------------------|--------------|----------------------------------------------------|
+| Chen Yu                  | Microsoft    | [@michaelawyu](https://github.com/michaelawyu)     |
+| Britania Rodriguez Reyes | Microsoft    | [britaniar](https://github.com/britaniar) |
+| Zhiying Lin              | Microsoft    | [@zhiying-lin](https://github.com/zhiying-lin)     |
+| Wei Weng                 | Microsoft    | [@weng271190436](https://github.com/weng271190436) |
+| Yetkin Timocin           | Microsoft    | [@ytimocin](https://github.com/ytimocin)           |
+| Stéphane Erbrech         | Microsoft    | [@serbrech](https://github.com/serbrech)           |
+| Simon Waight             | Microsoft    | [@sjwaight](https://github.com/sjwaight)           |

--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ You can reach the KubeFleet community and developers via the following channels:
 
 ## Community Meetings
 
-Please refer to the [calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/kubefleet?view=month) for the latest schedule. 
+We aim to hold one meeting per month. Community meetings for US/EU and APAC/India communities happen in alternate months.
 
-We aim to hold one meeting per month for each of our US/EU and APAC/India communities.
+Please refer to the [calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/kubefleet?view=month) for the latest schedule.
 
 For more meeting information please see the [KubeFleet community repository](https://github.com/kubefleet-dev/community#community-meetings).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -67,7 +67,7 @@ This section will be updated as each item is decided.
 ## Reporting Security Issues
 
 **Please do not report security vulnerabilities through public GitHub issues.** Instead, 
-report them to the [KubeFleet maintainers](mailto:kubefleet-maintainers@googlegroups.com).
+report them to the [KubeFleet maintainers](mailto:kubefleet@microsoft.com).
 We prefer all communications to be in English.
 
 You should receive a response as soon as possible. If for some reason you do not, please

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -2,11 +2,8 @@
 
 ## How to file issues and get help  
 
-This project uses GitHub Issues to track bugs and feature requests. Please search the existing issues before filing new issues to avoid duplicates. For new issues, file your bug or feature request as a new Issue.
+This project uses [GitHub Issues](https://github.com/kubefleet-dev/kubefleet/issues/) to track bugs and feature requests. Please search the existing issues before filing new issues to avoid duplicates. For new issues, file your [bug](https://github.com/kubefleet-dev/kubefleet/issues/new?template=bug_report.md) or [feature request](https://github.com/kubefleet-dev/kubefleet/issues/new?template=feature_request.md) as a new Issue.
 
-For help and questions about using this project, please
+For help and questions about using KubeFleet, please use our [GitHub Discussions](https://github.com/kubefleet-dev/kubefleet/discussions/).
 
-* start the conversation in the [GitHub Discussions](https://github.com/kubefleet-dev/kubefleet/discussions/).
-
-We are actively exploring other means for developers, system admins, and anyone who has an interest
-in the multi-cluster domain to engage with us. Please stay tuned.
+We are actively exploring other means for developers, system admins, and anyone who has an interest in the multi-cluster domain to engage with us. Please stay tuned.


### PR DESCRIPTION
This pull request updates project documentation to improve clarity, update contact information, and reflect current project maintainers. The changes focus on updating communication channels, clarifying reporting procedures, and refreshing maintainer information.

**Documentation updates:**

* Updated the `MAINTAINERS.md` file to reflect the current list of maintainers, adding Britania Rodriguez Reyes and correcting the formatting of the table.
* Improved instructions in `SUPPORT.md` by adding direct links for filing bugs and feature requests, and clarified that GitHub Discussions should be used for questions and help.

**Contact and reporting procedures:**

* Updated contact email addresses in `CODE_OF_CONDUCT.md` and `SECURITY.md` for reporting incidents and security issues, changing them from a Google Groups address to a Microsoft address. [[1]](diffhunk://#diff-ffdbe3a1e7ee93cacfc080b6c635ccf3a8f6b0f00f2fb884f78c6b5f9dac8fd2L68-R69) [[2]](diffhunk://#diff-f6ed156e4bf5c791680662464b94ea5d753f219ee816b385f67870e2c0d7d4c7L70-R70)

**Code of Conduct enhancements:**

* Added explicit prohibitions in `CODE_OF_CONDUCT.md` against providing false or misleading information during investigations and against retaliation for reporting incidents.

**Community meeting information:**

* Clarified the schedule for community meetings in `README.md`, specifying that US/EU and APAC/India meetings alternate monthly.