### PR TITLE
feat: [FEP-0001] add accessor interface for placement policy and related APIs

### DIFF
--- a/apis/kubefleet.dev/placement/v1alpha1/interface.go
+++ b/apis/kubefleet.dev/placement/v1alpha1/interface.go
@@ -75,9 +75,6 @@ func (p *ClusterPlacementPolicy) SetStatus(status PlacementPolicyStatus) {
 	p.Status = status
 }
 
-var _ PlacementResourceSnapshotAccessor = &PlacementResourceSnapshot{}
-var _ PlacementResourceSnapshotAccessor = &ClusterPlacementResourceSnapshot{}
-
 // PlacementResourceSnapshotAccessor provides unified access to the spec of placement resource snapshot resources,
 // namespace-scoped and cluster-scoped.
 //
@@ -105,9 +102,6 @@ func (p *ClusterPlacementResourceSnapshot) GetSpec() *PlacementResourceSnapshotS
 func (p *ClusterPlacementResourceSnapshot) SetSpec(spec PlacementResourceSnapshotSpec) {
 	p.Spec = spec
 }
-
-var _ PlacementBindingAccessor = &PlacementBinding{}
-var _ PlacementBindingAccessor = &ClusterPlacementBinding{}
 
 // PlacementBindingAccessor provides unified access to the spec and status of placement binding resources,
 // namespace-scoped and cluster-scoped.

--- a/apis/kubefleet.dev/placement/v1alpha1/interface.go
+++ b/apis/kubefleet.dev/placement/v1alpha1/interface.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2026 The KubeFleet Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Verify the implementation of the accessor interfaces for the placement policy,
+// placement resource snapshot, and placement binding resources.
+var _ PlacementPolicyAccessor = &PlacementPolicy{}
+var _ PlacementPolicyAccessor = &ClusterPlacementPolicy{}
+var _ PlacementResourceSnapshotAccessor = &PlacementResourceSnapshot{}
+var _ PlacementResourceSnapshotAccessor = &ClusterPlacementResourceSnapshot{}
+var _ PlacementBindingAccessor = &PlacementBinding{}
+var _ PlacementBindingAccessor = &ClusterPlacementBinding{}
+
+// PlacementPolicyAccessor provides unified access to the spec and status of placement policy resources,
+// namespace-scoped and cluster-scoped.
+//
+// +kubebuilder:object:generate=false
+type PlacementPolicyAccessor interface {
+	client.Object
+
+	GetSpec() *PlacementPolicySpec
+	GetStatus() *PlacementPolicyStatus
+
+	SetSpec(PlacementPolicySpec)
+	SetStatus(PlacementPolicyStatus)
+}
+
+func (p *PlacementPolicy) GetSpec() *PlacementPolicySpec {
+	return &p.Spec
+}
+
+func (p *PlacementPolicy) GetStatus() *PlacementPolicyStatus {
+	return &p.Status
+}
+
+func (p *PlacementPolicy) SetSpec(spec PlacementPolicySpec) {
+	p.Spec = spec
+}
+
+func (p *PlacementPolicy) SetStatus(status PlacementPolicyStatus) {
+	p.Status = status
+}
+
+func (p *ClusterPlacementPolicy) GetSpec() *PlacementPolicySpec {
+	return &p.Spec
+}
+
+func (p *ClusterPlacementPolicy) GetStatus() *PlacementPolicyStatus {
+	return &p.Status
+}
+
+func (p *ClusterPlacementPolicy) SetSpec(spec PlacementPolicySpec) {
+	p.Spec = spec
+}
+
+func (p *ClusterPlacementPolicy) SetStatus(status PlacementPolicyStatus) {
+	p.Status = status
+}
+
+var _ PlacementResourceSnapshotAccessor = &PlacementResourceSnapshot{}
+var _ PlacementResourceSnapshotAccessor = &ClusterPlacementResourceSnapshot{}
+
+// PlacementResourceSnapshotAccessor provides unified access to the spec of placement resource snapshot resources,
+// namespace-scoped and cluster-scoped.
+//
+// +kubebuilder:object:generate=false
+type PlacementResourceSnapshotAccessor interface {
+	client.Object
+
+	GetSpec() *PlacementResourceSnapshotSpec
+
+	SetSpec(PlacementResourceSnapshotSpec)
+}
+
+func (p *PlacementResourceSnapshot) GetSpec() *PlacementResourceSnapshotSpec {
+	return &p.Spec
+}
+
+func (p *PlacementResourceSnapshot) SetSpec(spec PlacementResourceSnapshotSpec) {
+	p.Spec = spec
+}
+
+func (p *ClusterPlacementResourceSnapshot) GetSpec() *PlacementResourceSnapshotSpec {
+	return &p.Spec
+}
+
+func (p *ClusterPlacementResourceSnapshot) SetSpec(spec PlacementResourceSnapshotSpec) {
+	p.Spec = spec
+}
+
+var _ PlacementBindingAccessor = &PlacementBinding{}
+var _ PlacementBindingAccessor = &ClusterPlacementBinding{}
+
+// PlacementBindingAccessor provides unified access to the spec and status of placement binding resources,
+// namespace-scoped and cluster-scoped.
+//
+// +kubebuilder:object:generate=false
+type PlacementBindingAccessor interface {
+	client.Object
+
+	GetSpec() *PlacementBindingSpec
+	GetStatus() *PlacementBindingStatus
+
+	SetSpec(PlacementBindingSpec)
+	SetStatus(PlacementBindingStatus)
+}
+
+func (p *PlacementBinding) GetSpec() *PlacementBindingSpec {
+	return &p.Spec
+}
+
+func (p *PlacementBinding) GetStatus() *PlacementBindingStatus {
+	return &p.Status
+}
+
+func (p *PlacementBinding) SetSpec(spec PlacementBindingSpec) {
+	p.Spec = spec
+}
+
+func (p *PlacementBinding) SetStatus(status PlacementBindingStatus) {
+	p.Status = status
+}
+
+func (p *ClusterPlacementBinding) GetSpec() *PlacementBindingSpec {
+	return &p.Spec
+}
+
+func (p *ClusterPlacementBinding) GetStatus() *PlacementBindingStatus {
+	return &p.Status
+}
+
+func (p *ClusterPlacementBinding) SetSpec(spec PlacementBindingSpec) {
+	p.Spec = spec
+}
+
+func (p *ClusterPlacementBinding) SetStatus(status PlacementBindingStatus) {
+	p.Status = status
+}


### PR DESCRIPTION
### Description of your changes

This PR adds accessor interfaces for the placement policy and related APIs, which enables controllers to process namespace-scoped and cluster-scoped variants of the same API types easier.

I have:

- [NA] Associated this change with a known KubeFleet Issue (Bug, Feature, etc).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

N/A

### Special notes for your reviewer

N/A