### PR TITLE
test: add scheduled-to-bound coverage for TestPickBindingsToRoll

### DIFF
--- a/pkg/controllers/rollout/controller_test.go
+++ b/pkg/controllers/rollout/controller_test.go
@@ -1236,6 +1236,204 @@ func TestPickBindingsToRoll(t *testing.T) {
 		wantErr                     error
 	}{
 		// TODO: add more tests
+		"test scheduled binding to bound, latest resources and nil overrides - rollout allowed": {
+			allBindingsFunc: func() []*placementv1beta1.ClusterResourceBinding {
+				return []*placementv1beta1.ClusterResourceBinding{
+					generateClusterResourceBinding(placementv1beta1.BindingStateScheduled, "snapshot-1", cluster1),
+				}
+			},
+			latestResourceSnapshotName: "snapshot-1",
+			crp: clusterResourcePlacementForTest("test",
+				createPlacementPolicyForTest(placementv1beta1.PickAllPlacementType, 0),
+				createPlacementRolloutStrategyForTest(placementv1beta1.RollingUpdateRolloutStrategyType, generateDefaultRollingUpdateConfig(), nil)),
+			wantTobeUpdatedBindings: []int{0},
+			wantDesiredBindingsSpec: []placementv1beta1.ResourceBindingSpec{
+				{
+					State:                placementv1beta1.BindingStateBound,
+					TargetCluster:        cluster1,
+					ResourceSnapshotName: "snapshot-1",
+				},
+			},
+			wantNeedRoll: true,
+			wantWaitTime: 0,
+		},
+		"test scheduled binding to bound with PickFixed placement type - rollout allowed": {
+			allBindingsFunc: func() []*placementv1beta1.ClusterResourceBinding {
+				return []*placementv1beta1.ClusterResourceBinding{
+					generateClusterResourceBinding(placementv1beta1.BindingStateScheduled, "snapshot-1", cluster1),
+				}
+			},
+			latestResourceSnapshotName: "snapshot-2",
+			crp: clusterResourcePlacementForTest("test",
+				&placementv1beta1.PlacementPolicy{
+					PlacementType: placementv1beta1.PickFixedPlacementType,
+					ClusterNames:  []string{cluster1},
+				},
+				createPlacementRolloutStrategyForTest(placementv1beta1.RollingUpdateRolloutStrategyType, generateDefaultRollingUpdateConfig(), nil)),
+			wantTobeUpdatedBindings: []int{0},
+			wantDesiredBindingsSpec: []placementv1beta1.ResourceBindingSpec{
+				{
+					State:                placementv1beta1.BindingStateBound,
+					TargetCluster:        cluster1,
+					ResourceSnapshotName: "snapshot-2",
+				},
+			},
+			wantNeedRoll: true,
+			wantWaitTime: 0,
+		},
+		"test multiple scheduled bindings with maxSurge set to zero and no ready bindings - rollout allowed": {
+			allBindingsFunc: func() []*placementv1beta1.ClusterResourceBinding {
+				return []*placementv1beta1.ClusterResourceBinding{
+					generateClusterResourceBinding(placementv1beta1.BindingStateScheduled, "snapshot-1", cluster1),
+					generateClusterResourceBinding(placementv1beta1.BindingStateScheduled, "snapshot-1", cluster2),
+				}
+			},
+			latestResourceSnapshotName: "snapshot-1",
+			crp: clusterResourcePlacementForTest("test",
+				createPlacementPolicyForTest(placementv1beta1.PickNPlacementType, 2),
+				createPlacementRolloutStrategyForTest(placementv1beta1.RollingUpdateRolloutStrategyType, &placementv1beta1.RollingUpdateConfig{
+					MaxUnavailable: &intstr.IntOrString{
+						Type:   intstr.String,
+						StrVal: "20%",
+					},
+					MaxSurge: &intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: 0,
+					},
+					UnavailablePeriodSeconds: ptr.To(1),
+				}, nil)),
+			// maxSurge bounds how far the can-be-ready set may exceed the target. Scheduled bindings
+			// are not counted as can-be-ready, so with nothing ready yet the budget is the full
+			// target number and both bindings are allowed to roll.
+			wantTobeUpdatedBindings: []int{0, 1},
+			wantDesiredBindingsSpec: []placementv1beta1.ResourceBindingSpec{
+				{
+					State:                placementv1beta1.BindingStateBound,
+					TargetCluster:        cluster1,
+					ResourceSnapshotName: "snapshot-1",
+				},
+				{
+					State:                placementv1beta1.BindingStateBound,
+					TargetCluster:        cluster2,
+					ResourceSnapshotName: "snapshot-1",
+				},
+			},
+			wantNeedRoll: true,
+			wantWaitTime: 0,
+		},
+		"test scheduled binding with maxSurge set to zero and target met by ready bound bindings - rollout blocked": {
+			allBindingsFunc: func() []*placementv1beta1.ClusterResourceBinding {
+				return []*placementv1beta1.ClusterResourceBinding{
+					generateReadyClusterResourceBinding(placementv1beta1.BindingStateBound, "snapshot-1", cluster1),
+					generateReadyClusterResourceBinding(placementv1beta1.BindingStateBound, "snapshot-1", cluster2),
+					generateClusterResourceBinding(placementv1beta1.BindingStateScheduled, "snapshot-1", cluster3),
+				}
+			},
+			latestResourceSnapshotName: "snapshot-1",
+			crp: clusterResourcePlacementForTest("test",
+				createPlacementPolicyForTest(placementv1beta1.PickNPlacementType, 2),
+				createPlacementRolloutStrategyForTest(placementv1beta1.RollingUpdateRolloutStrategyType, &placementv1beta1.RollingUpdateConfig{
+					MaxUnavailable: &intstr.IntOrString{
+						Type:   intstr.String,
+						StrVal: "20%",
+					},
+					MaxSurge: &intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: 0,
+					},
+					UnavailablePeriodSeconds: ptr.To(1),
+				}, nil)),
+			// The two ready bound bindings already fill the target, so with maxSurge zero there is
+			// no room to bring the scheduled binding up and it stays unselected this round.
+			wantTobeUpdatedBindings:     []int{},
+			wantStaleUnselectedBindings: []int{2},
+			wantUpToDateBoundBindings:   []int{0, 1},
+			wantDesiredBindingsSpec: []placementv1beta1.ResourceBindingSpec{
+				{
+					State:                placementv1beta1.BindingStateBound,
+					TargetCluster:        cluster1,
+					ResourceSnapshotName: "snapshot-1",
+				},
+				{
+					State:                placementv1beta1.BindingStateBound,
+					TargetCluster:        cluster2,
+					ResourceSnapshotName: "snapshot-1",
+				},
+				{
+					State:                placementv1beta1.BindingStateBound,
+					TargetCluster:        cluster3,
+					ResourceSnapshotName: "snapshot-1",
+				},
+			},
+			wantNeedRoll: true,
+			wantWaitTime: 0,
+		},
+		"test multiple scheduled bindings with percentage maxSurge - surge budget rounds up": {
+			allBindingsFunc: func() []*placementv1beta1.ClusterResourceBinding {
+				return []*placementv1beta1.ClusterResourceBinding{
+					generateReadyClusterResourceBinding(placementv1beta1.BindingStateBound, "snapshot-1", cluster1),
+					generateReadyClusterResourceBinding(placementv1beta1.BindingStateBound, "snapshot-1", cluster2),
+					generateReadyClusterResourceBinding(placementv1beta1.BindingStateBound, "snapshot-1", cluster3),
+					generateClusterResourceBinding(placementv1beta1.BindingStateScheduled, "snapshot-1", cluster4),
+					generateClusterResourceBinding(placementv1beta1.BindingStateScheduled, "snapshot-1", cluster5),
+					generateClusterResourceBinding(placementv1beta1.BindingStateScheduled, "snapshot-1", cluster6),
+				}
+			},
+			latestResourceSnapshotName: "snapshot-1",
+			crp: clusterResourcePlacementForTest("test",
+				createPlacementPolicyForTest(placementv1beta1.PickNPlacementType, 3),
+				createPlacementRolloutStrategyForTest(placementv1beta1.RollingUpdateRolloutStrategyType, &placementv1beta1.RollingUpdateConfig{
+					MaxUnavailable: &intstr.IntOrString{
+						Type:   intstr.String,
+						StrVal: "20%",
+					},
+					MaxSurge: &intstr.IntOrString{
+						Type:   intstr.String,
+						StrVal: "50%",
+					},
+					UnavailablePeriodSeconds: ptr.To(1),
+				}, nil)),
+			// 50% of the target of 3 rounds up to 2, so the can-be-ready ceiling is 5. The three
+			// ready bound bindings already count towards it, leaving room for exactly two of the
+			// three scheduled bindings; the third stays unselected this round.
+			wantTobeUpdatedBindings:     []int{3, 4},
+			wantStaleUnselectedBindings: []int{5},
+			wantUpToDateBoundBindings:   []int{0, 1, 2},
+			wantDesiredBindingsSpec: []placementv1beta1.ResourceBindingSpec{
+				{
+					State:                placementv1beta1.BindingStateBound,
+					TargetCluster:        cluster1,
+					ResourceSnapshotName: "snapshot-1",
+				},
+				{
+					State:                placementv1beta1.BindingStateBound,
+					TargetCluster:        cluster2,
+					ResourceSnapshotName: "snapshot-1",
+				},
+				{
+					State:                placementv1beta1.BindingStateBound,
+					TargetCluster:        cluster3,
+					ResourceSnapshotName: "snapshot-1",
+				},
+				{
+					State:                placementv1beta1.BindingStateBound,
+					TargetCluster:        cluster4,
+					ResourceSnapshotName: "snapshot-1",
+				},
+				{
+					State:                placementv1beta1.BindingStateBound,
+					TargetCluster:        cluster5,
+					ResourceSnapshotName: "snapshot-1",
+				},
+				{
+					State:                placementv1beta1.BindingStateBound,
+					TargetCluster:        cluster6,
+					ResourceSnapshotName: "snapshot-1",
+				},
+			},
+			wantNeedRoll: true,
+			wantWaitTime: 0,
+		},
 		"test scheduled binding to bound, outdated resources and nil overrides - rollout allowed": {
 			allBindingsFunc: func() []*placementv1beta1.ClusterResourceBinding {
 				return []*placementv1beta1.ClusterResourceBinding{


### PR DESCRIPTION
## Description

`TestPickBindingsToRoll` carries a `// TODO: add more tests`. This adds five table-driven cases for the scheduled-to-bound transition, which the existing cases cover only thinly, and which left one branch of `calculateRealTarget` untested entirely.

Cases added:

| Case | What it pins |
|---|---|
| scheduled binding already at the latest snapshot | every existing case starts from an outdated snapshot, so this path was untested |
| **PickFixed placement type** | `PickFixedPlacementType` appeared **zero** times in this package's tests, so the `ClusterNames` branch of `calculateRealTarget` was never taken |
| multiple scheduled bindings, `maxSurge: 0`, nothing ready | rollout is allowed |
| scheduled binding, `maxSurge: 0`, target already met by ready bound bindings | rollout is held back |
| multiple scheduled bindings, percentage `maxSurge` | the surge budget rounds **up** (50% of 3 → 2, not 1) |

The `maxSurge: 0` pair is deliberately split into two cases. Scheduled bindings are not added to `canBeReadyBindings` (`controller.go:421-431`), so `calculateMaxToAdd` returns the full target number when nothing is ready yet — `maxSurge: 0` only holds a rollout back once ready bindings already meet the target. The two cases document that distinction, which I found surprising when reading the code.

## Coverage

```
                        before    after
calculateRealTarget      70.0%    80.0%
```

The PickFixed case is the one that moves the needle. `pickBindingsToRoll` (98.7%), `determineBindingsToUpdate` (100%) and `calculateMaxToAdd` (100%) were already covered, so the remaining four cases add behavioural assertions — particularly the percentage rounding — rather than new lines. I would rather state that plainly than imply more than the numbers support.

Expected values were derived from reading `pickBindingsToRoll`, `determineBindingsToUpdate`, `calculateMaxToAdd` and `calculateRealTarget` before running anything, not adjusted afterwards to match observed output.

## Testing

```
go test ./pkg/controllers/rollout/ -run TestPickBindingsToRoll -count=1 -v
```

All five new cases pass. All other unit tests in the package pass.

**One pre-existing failure, unrelated to this change:**

```
--- FAIL: TestPickBindingsToRoll/test_unscheduled_bindings_with_different_waitTimes_and_check_the_wait_time_is_correct
    pickBindingsToRoll() = waitTime 0s, want 25s
```

This reproduces identically on unmodified `main` (I stashed this change and re-ran to confirm), and the CI run for `e160c1cd`, the commit this branch is based on, is also red. The case builds bindings with `time.Now()`-relative transition times, so it looks timing-sensitive rather than caused by any recent change. Flagging it here so it is not misattributed to this PR — happy to open a separate issue if that would be useful.

`TestAPIs` was not run locally as it needs an envtest control plane.

## Related

Part of #676. That issue also lists a set of untested paths in `pickBindingsToRoll` itself — `IsBindingDiffReported`, deletion timestamps on scheduled bindings, negative `maxNumberToRemove`, and others. Those are a separate concern from the scheduled-to-bound group and are left for follow-up rather than bundled here, so the `// TODO` comment stays in place.
