### PR TITLE
fix: repin qemu-user-static to a content-addressable digest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,8 +253,29 @@ BUILDKIT_VERSION ?= v0.18.1
 # and are pinned by digest as well as tag: a floating reference on a privileged
 # release-path container is a supply-chain risk. The binfmt mirror digest is
 # byte-identical to the upstream docker.io/tonistiigi/binfmt tag it mirrors.
+#
+# qemu-user-static has no manifest list - neither upstream nor on the mirror. It
+# is a single linux/amd64 schema-2 manifest, which is all setup-qemu needs: the
+# QEMU_IMAGE branch runs only when TARGET_ARCH is amd64. Obtain its digest with a
+# request that names a schema-2 or OCI media type (substitute QEMU_VERSION for the
+# tag):
+#
+#   curl -sI -H 'Accept: application/vnd.docker.distribution.manifest.v2+json' \
+#     https://mcr.microsoft.com/v2/mirror/docker/multiarch/qemu-user-static/manifests/7.2.0-1 \
+#     | grep -i docker-content-digest
+#
+# `docker manifest inspect -v` and `docker buildx imagetools inspect` also report
+# the correct digest. What does NOT is a bare `curl -sI` sending no Accept header,
+# or one naming only the manifest-list type: MCR then answers with a deprecated
+# schema-1 `v1+prettyjws` view synthesised on demand from the schema-2 manifest.
+# The digest it advertises is stable, but it is never stored as a manifest
+# revision, so fetching by it returns "manifest unknown" and every pull of a pin
+# taken that way fails - most likely how the previous pin here was produced.
+#
+# Both mirrors carry exactly one tag today, so bumping either version below needs
+# MCR to onboard the new tag first.
 QEMU_VERSION ?= 7.2.0-1
-QEMU_IMAGE ?= mcr.microsoft.com/mirror/docker/multiarch/qemu-user-static:$(QEMU_VERSION)@sha256:cb0dff994856c640b6080bfbd5983352e7856221a989625ea3e232cb7eff4507
+QEMU_IMAGE ?= mcr.microsoft.com/mirror/docker/multiarch/qemu-user-static:$(QEMU_VERSION)@sha256:fe60359c92e86a43cc87b3d906006245f77bfc0565676b80004cc666e4feb9f0
 BINFMT_VERSION ?= qemu-v9.2.2-52
 BINFMT_IMAGE ?= mcr.microsoft.com/mirror/docker/tonistiigi/binfmt:$(BINFMT_VERSION)@sha256:1b804311fe87047a4c96d38b4b3ef6f62fca8cd125265917a9e3dc3c996c39e6
 


### PR DESCRIPTION
### Description of your changes

`main` is red: the `Trivy Vulnerability Scanner` workflow fails in ~17s on every
push, and the release path is broken the same way.

#745 added the `setup-qemu` target and pinned the MCR `qemu-user-static` mirror to
a digest that no registry can serve:

```
docker: Error response from daemon: manifest for mcr.microsoft.com/mirror/docker/
multiarch/qemu-user-static@sha256:cb0dff99... not found: manifest unknown
make[1]: *** [Makefile:335: setup-qemu] Error 125
make: *** [Makefile:270: push] Error 2
```

The image has **no manifest list**, upstream or mirrored. When a request carries
no `Accept` header — or names only the manifest-list media type — MCR answers with
a deprecated schema-1 `application/vnd.docker.distribution.manifest.v1+prettyjws`
view, synthesised on demand from the schema-2 manifest. The digest that view
advertises is stable, but it is never stored as a manifest revision, so fetching
by it 404s:

| Request | Result |
| --- | --- |
| `GET /manifests/7.2.0-1` &nbsp;`Accept: manifest.list.v2` | `cb0dff99…`, served as `v1+prettyjws` |
| `GET /manifests/sha256:cb0dff99…` | **HTTP 404** |
| `GET /manifests/7.2.0-1` &nbsp;`Accept: manifest.v2` | `fe60359c…`, schema 2 |
| `GET /manifests/sha256:fe60359c…` | **HTTP 200** |

This repins to the real schema-2 manifest and documents how to obtain the digest,
so the next `QEMU_VERSION` bump does not walk back into the same trap. Note that
`docker manifest inspect -v` and `docker buildx imagetools inspect` both report the
correct digest — a bare `curl -sI` with no `Accept` header is what yields the bad
one, which is most likely how the original pin was produced.

The new digest is also what Docker Hub serves for
`multiarch/qemu-user-static:7.2.0-1`, so mirror and upstream agree on the bytes.

The pin stays a `linux/amd64` manifest, which is all `setup-qemu` needs: the
`QEMU_IMAGE` branch of the case statement only runs when `TARGET_ARCH` is `amd64`.
Non-amd64 hosts take the `BINFMT_IMAGE` branch, whose pin is a genuine OCI image
index and is unaffected.

Fixes the CI failure introduced by #745. Note this unblocks the workflow but does
not make it green — `main` separately carries `CVE-2026-14456` (`libssl3t64`
`3.5.6-1~deb13u2` → `3.5.7-1~deb13u2`) from the `distroless/base:nonroot` pin.
Bumping that pin does not help yet: the current `nonroot` tag still ships
`libssl3t64 3.5.6` and carries the identical CVE, so it needs an upstream
distroless rebuild and is tracked separately.

I have:

- [ ] Associated this change with a known KubeFleet Issue (Bug, Feature, etc).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- Re-derived both digests directly against MCR with `curl` under each `Accept`
  media type; results are the table above. Confirmed the schema-1 digest is
  stable across repeated fetches — it is the addressing that is broken, not the
  value.
- `docker pull mcr.microsoft.com/mirror/docker/multiarch/qemu-user-static:7.2.0-1@sha256:fe60359c…`
  succeeds and reports the requested digest back.
- Inspected the new manifest's config blob: `linux/amd64`, entrypoint `/register`,
  which matches the `--reset -p yes` arguments `setup-qemu` passes.
- Confirmed the Makefile still parses and that the target resolves the new
  reference: `make -n setup-qemu AUTO_DETECT_ARCH=FALSE TARGET_ARCH=amd64 PLATFORMS="linux/amd64,linux/arm64"`.

`make reviewable` was **not** run: it is a Go pipeline (`fmt`, `vet`,
`golangci-lint`, `staticcheck`) and this change contains no Go — it is one
Makefile variable and a comment block. Happy to run it if a maintainer prefers the
box ticked regardless.

### Special notes for your reviewer

The `make push` path is not exercised by any PR-triggered workflow — `trivy.yml`
runs on push-to-main, tags, schedule and dispatch, and `release.yml` is
tag-triggered — which is why the bad pin merged green and only surfaced on `main`.
Worth deciding separately whether that gap should be closed.

Four items surfaced while reviewing this that are #745's debt rather than this
fix's, but which this fix makes *reachable* — worth tracking before the next tag
is cut rather than discovering mid-release:

1. **The emulated arm64 leg is untimed and uncached.** `make push` now forces
   `PLATFORMS=linux/amd64,linux/arm64`, and the Dockerfiles build with
   `CGO_ENABLED=1 GOEXPERIMENT=systemcrypto` — deliberately not cross-compiled. So
   the arm64 leg runs the full Go toolchain and a cgo/OpenSSL link under QEMU, three
   times over, with no `--cache-from`/`--cache-to` and no `timeout-minutes` on the
   job. Historical baseline for the amd64-only job was ~5m30s. The first green
   `make push` after this fix will also be the first measurement of that path.
2. **The published arm64 images are never scanned.** `trivy-action` is handed a
   manifest list and resolves it to the runner's platform, so CVE coverage is
   amd64-only while the published surface is now both.
3. **`# syntax=docker/dockerfile:1`** is an unpinned Docker Hub frontend fetched at
   build time on the release path, which sits awkwardly beside #745's own rationale
   for digest-pinning privileged release-path images. `COPY --link` needs frontend
   ≥ 1.4 so it cannot simply be dropped, but it could be pinned by digest.
4. **`QEMU_VERSION` and `BINFMT_VERSION` are decorative.** Because the references
   are `repo:tag@digest`, Docker resolves by digest and ignores the tag — bumping
   only the version variable is a silent no-op.

Longer term, `setup-qemu` could drop `QEMU_IMAGE` altogether and use
`BINFMT_IMAGE` on both branches: `tonistiigi/binfmt` is the modern replacement for
`multiarch/qemu-user-static`, is what `docker/setup-qemu-action` uses on every host
architecture, and is a proper multi-platform index — which would remove this
failure mode from the repo instead of documenting it. It would also move the amd64
path off qemu 7.2.0 (image built 2023-01-17; the upstream repo is dormant and the
mirror carries a single tag) and onto the qemu 9.2.2 the arm64 path already uses.
Kept out of this PR to keep the fix minimal while `main` is red.
