### PR TITLE
fix: cross-compile images instead of emulating the builder stage

### DIFF
--- a/docker/hub-agent.Dockerfile
+++ b/docker/hub-agent.Dockerfile
@@ -1,12 +1,14 @@
 # syntax=docker/dockerfile:1
-# Build the hubagent binary
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.6-1 AS builder
-
-# TARGETOS and TARGETARCH are populated automatically by BuildKit for each
-# platform being built, so a single multi-platform `docker buildx build`
-# produces a correctly built binary per architecture.
-ARG TARGETOS
-ARG TARGETARCH
+# Build the hubagent binary.
+#
+# The builder stage always runs on the build host's own platform
+# (--platform=$BUILDPLATFORM) and cross-compiles for each target platform, so
+# the Go toolchain, cgo and gcc never execute under QEMU. Running the builder
+# per target under emulation crashed gcc's cc1 ("internal compiler error:
+# Segmentation fault" / "cgo: gcc produced no output" in runtime/cgo and net)
+# and, when it did not crash, took over an hour per image. Only the final
+# distroless stage is per-target, and it runs no commands.
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.26.6-1 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -16,16 +18,45 @@ COPY go.sum go.sum
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
 
+# The module download above is declared before the target-specific ARGs so
+# that BuildKit shares its layer across every target platform of one build.
+# TARGETOS and TARGETARCH are populated automatically by BuildKit for each
+# platform being built, so a single multi-platform `docker buildx build`
+# produces a correctly built binary per architecture.
+ARG TARGETOS
+ARG TARGETARCH
+ARG BUILDARCH
+
+# GOEXPERIMENT=systemcrypto requires CGO_ENABLED=1. Its OpenSSL backend
+# dlopen()s libcrypto at run time, so no OpenSSL headers are needed to build -
+# only a C compiler and libc headers for the target architecture. When the
+# target differs from the architecture this stage runs on, install Debian's
+# cross toolchain for it. Either way /usr/local/bin/target-gcc ends up pointing
+# at the right compiler. BUILDARCH is this stage's own architecture because the
+# stage is pinned to --platform=$BUILDPLATFORM above.
+RUN set -eu; \
+    if [ "${TARGETARCH}" = "${BUILDARCH}" ]; then \
+        ln -s /usr/bin/gcc /usr/local/bin/target-gcc; \
+    else \
+        case "${TARGETARCH}" in \
+            arm64) pkg=gcc-aarch64-linux-gnu; triple=aarch64-linux-gnu ;; \
+            amd64) pkg=gcc-x86-64-linux-gnu; triple=x86_64-linux-gnu ;; \
+            *) echo "unsupported TARGETARCH ${TARGETARCH}" >&2; exit 1 ;; \
+        esac; \
+        apt-get update; \
+        apt-get install -y --no-install-recommends "${pkg}" "libc6-dev-${TARGETARCH}-cross"; \
+        rm -rf /var/lib/apt/lists/*; \
+        ln -s "/usr/bin/${triple}-gcc" /usr/local/bin/target-gcc; \
+    fi
+
 # Copy the go source
 COPY cmd/hubagent/ cmd/hubagent/
 COPY apis/ apis/
 COPY pkg/ pkg/
 
-# Build. CGO + systemcrypto compiles against the target architecture's OpenSSL,
-# which is why the builder runs per-target under emulation (see the Makefile's
-# docker-buildx-builder / setup-qemu targets) rather than cross-compiling.
-RUN echo "Building hubagent with GOOS=${TARGETOS} GOARCH=${TARGETARCH}" && \
-    CGO_ENABLED=1 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOEXPERIMENT=systemcrypto go build -o hubagent ./cmd/hubagent/
+# Build for the target platform with the compiler selected above.
+RUN echo "Building hubagent with GOOS=${TARGETOS} GOARCH=${TARGETARCH} CC=$(readlink -f /usr/local/bin/target-gcc)" && \
+    CGO_ENABLED=1 CC=target-gcc GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOEXPERIMENT=systemcrypto go build -o hubagent ./cmd/hubagent/
 
 # Use distroless as minimal base image to package the hubagent binary.
 # The pinned digest must reference a multi-arch image index so BuildKit can

--- a/docker/member-agent.Dockerfile
+++ b/docker/member-agent.Dockerfile
@@ -1,12 +1,14 @@
 # syntax=docker/dockerfile:1
-# Build the memberagent binary
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.6-1 AS builder
-
-# TARGETOS and TARGETARCH are populated automatically by BuildKit for each
-# platform being built, so a single multi-platform `docker buildx build`
-# produces a correctly built binary per architecture.
-ARG TARGETOS
-ARG TARGETARCH
+# Build the memberagent binary.
+#
+# The builder stage always runs on the build host's own platform
+# (--platform=$BUILDPLATFORM) and cross-compiles for each target platform, so
+# the Go toolchain, cgo and gcc never execute under QEMU. Running the builder
+# per target under emulation crashed gcc's cc1 ("internal compiler error:
+# Segmentation fault" / "cgo: gcc produced no output" in runtime/cgo and net)
+# and, when it did not crash, took over an hour per image. Only the final
+# distroless stage is per-target, and it runs no commands.
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.26.6-1 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -16,16 +18,45 @@ COPY go.sum go.sum
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
 
+# The module download above is declared before the target-specific ARGs so
+# that BuildKit shares its layer across every target platform of one build.
+# TARGETOS and TARGETARCH are populated automatically by BuildKit for each
+# platform being built, so a single multi-platform `docker buildx build`
+# produces a correctly built binary per architecture.
+ARG TARGETOS
+ARG TARGETARCH
+ARG BUILDARCH
+
+# GOEXPERIMENT=systemcrypto requires CGO_ENABLED=1. Its OpenSSL backend
+# dlopen()s libcrypto at run time, so no OpenSSL headers are needed to build -
+# only a C compiler and libc headers for the target architecture. When the
+# target differs from the architecture this stage runs on, install Debian's
+# cross toolchain for it. Either way /usr/local/bin/target-gcc ends up pointing
+# at the right compiler. BUILDARCH is this stage's own architecture because the
+# stage is pinned to --platform=$BUILDPLATFORM above.
+RUN set -eu; \
+    if [ "${TARGETARCH}" = "${BUILDARCH}" ]; then \
+        ln -s /usr/bin/gcc /usr/local/bin/target-gcc; \
+    else \
+        case "${TARGETARCH}" in \
+            arm64) pkg=gcc-aarch64-linux-gnu; triple=aarch64-linux-gnu ;; \
+            amd64) pkg=gcc-x86-64-linux-gnu; triple=x86_64-linux-gnu ;; \
+            *) echo "unsupported TARGETARCH ${TARGETARCH}" >&2; exit 1 ;; \
+        esac; \
+        apt-get update; \
+        apt-get install -y --no-install-recommends "${pkg}" "libc6-dev-${TARGETARCH}-cross"; \
+        rm -rf /var/lib/apt/lists/*; \
+        ln -s "/usr/bin/${triple}-gcc" /usr/local/bin/target-gcc; \
+    fi
+
 # Copy the go source
 COPY cmd/memberagent cmd/memberagent/
 COPY apis/ apis/
 COPY pkg/ pkg/
 
-# Build. CGO + systemcrypto compiles against the target architecture's OpenSSL,
-# which is why the builder runs per-target under emulation (see the Makefile's
-# docker-buildx-builder / setup-qemu targets) rather than cross-compiling.
-RUN echo "Building memberagent with GOOS=${TARGETOS} GOARCH=${TARGETARCH}" && \
-    CGO_ENABLED=1 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOEXPERIMENT=systemcrypto go build -o memberagent ./cmd/memberagent/
+# Build for the target platform with the compiler selected above.
+RUN echo "Building memberagent with GOOS=${TARGETOS} GOARCH=${TARGETARCH} CC=$(readlink -f /usr/local/bin/target-gcc)" && \
+    CGO_ENABLED=1 CC=target-gcc GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOEXPERIMENT=systemcrypto go build -o memberagent ./cmd/memberagent/
 
 # Use distroless as minimal base image to package the memberagent binary.
 # The pinned digest must reference a multi-arch image index so BuildKit can

--- a/docker/refresh-token.Dockerfile
+++ b/docker/refresh-token.Dockerfile
@@ -1,12 +1,14 @@
 # syntax=docker/dockerfile:1
-# Build the refreshtoken binary
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.6-1 AS builder
-
-# TARGETOS and TARGETARCH are populated automatically by BuildKit for each
-# platform being built, so a single multi-platform `docker buildx build`
-# produces a correctly built binary per architecture.
-ARG TARGETOS
-ARG TARGETARCH
+# Build the refreshtoken binary.
+#
+# The builder stage always runs on the build host's own platform
+# (--platform=$BUILDPLATFORM) and cross-compiles for each target platform, so
+# the Go toolchain, cgo and gcc never execute under QEMU. Running the builder
+# per target under emulation crashed gcc's cc1 ("internal compiler error:
+# Segmentation fault" / "cgo: gcc produced no output" in runtime/cgo and net)
+# and, when it did not crash, took over an hour per image. Only the final
+# distroless stage is per-target, and it runs no commands.
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.26.6-1 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -16,17 +18,46 @@ COPY go.sum go.sum
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
 
+# The module download above is declared before the target-specific ARGs so
+# that BuildKit shares its layer across every target platform of one build.
+# TARGETOS and TARGETARCH are populated automatically by BuildKit for each
+# platform being built, so a single multi-platform `docker buildx build`
+# produces a correctly built binary per architecture.
+ARG TARGETOS
+ARG TARGETARCH
+ARG BUILDARCH
+
+# GOEXPERIMENT=systemcrypto requires CGO_ENABLED=1. Its OpenSSL backend
+# dlopen()s libcrypto at run time, so no OpenSSL headers are needed to build -
+# only a C compiler and libc headers for the target architecture. When the
+# target differs from the architecture this stage runs on, install Debian's
+# cross toolchain for it. Either way /usr/local/bin/target-gcc ends up pointing
+# at the right compiler. BUILDARCH is this stage's own architecture because the
+# stage is pinned to --platform=$BUILDPLATFORM above.
+RUN set -eu; \
+    if [ "${TARGETARCH}" = "${BUILDARCH}" ]; then \
+        ln -s /usr/bin/gcc /usr/local/bin/target-gcc; \
+    else \
+        case "${TARGETARCH}" in \
+            arm64) pkg=gcc-aarch64-linux-gnu; triple=aarch64-linux-gnu ;; \
+            amd64) pkg=gcc-x86-64-linux-gnu; triple=x86_64-linux-gnu ;; \
+            *) echo "unsupported TARGETARCH ${TARGETARCH}" >&2; exit 1 ;; \
+        esac; \
+        apt-get update; \
+        apt-get install -y --no-install-recommends "${pkg}" "libc6-dev-${TARGETARCH}-cross"; \
+        rm -rf /var/lib/apt/lists/*; \
+        ln -s "/usr/bin/${triple}-gcc" /usr/local/bin/target-gcc; \
+    fi
+
 # Copy the go source
 COPY cmd/authtoken/main.go main.go
 COPY pkg/authtoken pkg/authtoken
 # writefile is a dependency of pkg/authtoken for secure file creation (0600 permissions)
 COPY pkg/utils/writefile pkg/utils/writefile
 
-# Build. CGO + systemcrypto compiles against the target architecture's OpenSSL,
-# which is why the builder runs per-target under emulation (see the Makefile's
-# docker-buildx-builder / setup-qemu targets) rather than cross-compiling.
-RUN echo "Building refreshtoken with GOOS=${TARGETOS} GOARCH=${TARGETARCH}" && \
-    CGO_ENABLED=1 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOEXPERIMENT=systemcrypto go build -o refreshtoken .
+# Build for the target platform with the compiler selected above.
+RUN echo "Building refreshtoken with GOOS=${TARGETOS} GOARCH=${TARGETARCH} CC=$(readlink -f /usr/local/bin/target-gcc)" && \
+    CGO_ENABLED=1 CC=target-gcc GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOEXPERIMENT=systemcrypto go build -o refreshtoken .
 
 # Use distroless as minimal base image to package the refreshtoken binary.
 # The pinned digest must reference a multi-arch image index so BuildKit can


### PR DESCRIPTION
### Description of your changes

Since #745 `make push` builds the three images for `linux/amd64,linux/arm64` in one buildx invocation, but the Dockerfiles ran the whole builder stage per target platform. On the amd64 runner the arm64 half therefore ran the Go toolchain, cgo and gcc under `qemu-user-static`, and gcc does not survive that. Since #851 unblocked `setup-qemu`, the Trivy runs on `main` have mostly failed in the arm64 builder:

```
#30 [linux/arm64 builder 9/9] ... go build
#30 145.9 # runtime/cgo
#30 145.9 gcc: internal compiler error: Segmentation fault signal terminated program cc1     (898e0bbb)
#30 182.5 # net
#30 182.5 cgo: gcc produced no output                                                       (431ba73f)
```

when `cc1` hangs instead of crashing the step sits until the 6-hour job timeout (9bcf5b23), and on the one run where the emulated build did complete (e5f16f29) the step took 53 minutes. Before #745 the whole three-image step took 4m43s.

This pins the builder stage to `$BUILDPLATFORM` and cross-compiles:

- When the target architecture differs from the one the stage runs on, install Debian's cross toolchain (`gcc-<triple>` + `libc6-dev-<arch>-cross`) and point `CC` at it through a `/usr/local/bin/target-gcc` symlink; otherwise the symlink is the native `gcc`. Nothing runs under QEMU any more except the final distroless stage, which runs no commands.
- `BUILDARCH` is the stage's own architecture because the stage is pinned to `--platform=$BUILDPLATFORM`, so it drives the native-vs-cross decision directly.
- `GOEXPERIMENT=systemcrypto` needs `CGO_ENABLED=1` but **no** OpenSSL headers — its backend `dlopen()`s libcrypto at run time, and the builder image ships no `libssl-dev`. The previous Dockerfile comment claiming the build had to compile "against the target architecture's OpenSSL" was wrong; the cross libc headers are all the compile needs.
- `go mod download` now precedes the target-specific `ARG`s so BuildKit shares that layer across both platforms of a build.

`setup-qemu` in the Makefile is left as is; it is no longer needed by these Dockerfiles but is harmless.

Fixes the `main` Trivy workflow failures following #745 / #851.

I have:

- [ ] Associated this change with a known KubeFleet Issue (Bug, Feature, etc).
- [ ] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

Reproduced and fixed on an amd64 Ubuntu 24.04 VM (`Standard_D4as_v5`, Docker 29.7.2) mirroring `ubuntu-latest`, running the real Makefile target — `setup-qemu` registers `qemu-user-static` 7.2.0-1, the `img-builder` builder uses buildkit v0.18.1 — with an OCI-archive output instead of a registry push:

```
make docker-build-hub-agent PLATFORMS=linux/amd64,linux/arm64 OUTPUT_TYPE=type=oci,dest=/tmp/hub.tar
```

| tree | result |
| --- | --- |
| `main` @ 431ba73f | exit 2 after 426s — `runtime/cgo: gcc: signal: segmentation fault (core dumped)` in `[linux/arm64 builder]` (the amd64 half took 157.0s, the same as CI's 157.2s) |
| this branch | exit 0 after 189s — `[linux/amd64->arm64 builder]` with `CC=/usr/bin/aarch64-linux-gnu-gcc-12`; archive holds an x86-64 ELF and an aarch64 ELF; the amd64 binary runs natively and the arm64 image runs as a container under qemu |

On the same VM the other two images build the same way (`make docker-build-member-agent docker-build-refresh-token`, both platforms): exit 0 in 322s, every arm64 build line showing `CC=/usr/bin/aarch64-linux-gnu-gcc-12`. The arm64 hub-agent image also runs as a container there under qemu (`docker run --platform linux/arm64 ... --help` prints the usage), so the loader, libc and libcrypto the binary needs are all present in the distroless base.

The final revision of this branch (1d461afc) was re-verified the same way on a fresh amd64 VM: `make docker-build-hub-agent docker-build-member-agent docker-build-refresh-token PLATFORMS=linux/amd64,linux/arm64` completes with zero build errors, all six image/arch combinations cross-compiled with the expected `CC`, and the arm64 hub-agent image runs as a container under qemu.

The opposite direction (arm64 builder → amd64 target via `gcc-x86-64-linux-gnu`, what a developer on Apple Silicon hits) was built to completion on an arm64 host with the same buildkit: hub-agent for both platforms in 158s, `CC=/usr/bin/x86_64-linux-gnu-gcc-12` for the amd64 half, both ELFs the expected architecture.

### Special notes for your reviewer

- The cross toolchain comes from Debian's apt repos at build time and is not pinned; the base image's own gcc already comes from the same repos.
- The PR checks cannot exercise this: `ci.yml` builds single-platform. The only workflow that runs the multi-arch build is `trivy.yml`, which has no `pull_request` trigger. It can be `workflow_dispatch`ed on this branch; it will still fail later at the pre-existing libssl3t64 CVE gate (CVE-2026-14456), so the thing to check is that the build-and-push step completes.



