### PR TITLE
chore: upgrade GOLANGCI Linter (v1.64.7 -> v2.13.2)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,30 +1,28 @@
+version: "2"
+
 run:
   timeout: 15m
   go: '1.25.12'
 
-linters-settings:
-  stylecheck:
-    checks: [ "all", "-ST1001" ]  # Disables dot-import warnings
-  revive:
-    rules:
-      - name: dot-imports
-        disabled: true
-  gosec:
-    excludes:
-      - G404 #Use of weak random number generator (math/rand or math/rand/v2). It is only used in tests.
-
 linters:
-  disable-all: true
+  default: none
+  settings:
+    staticcheck:
+      checks: [ "all", "-ST1001" ]  # Disables dot-import warnings
+    revive:
+      rules:
+        - name: dot-imports
+          disabled: true
+    gosec:
+      excludes:
+        - G404 #Use of weak random number generator (math/rand or math/rand/v2). It is only used in tests.
   enable:
     - decorder
     - errcheck
     - errorlint
     - goconst
     - gocyclo
-    - gofmt
-    - goimports
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - misspell
@@ -34,9 +32,11 @@ linters:
     - revive
     - staticcheck
     - tparallel
-    - typecheck
     - unconvert
     - unused
     - whitespace
-  # Run with --fast=false for more extensive checks
-  fast: true
+
+formatters:
+  enable:
+    - gofmt
+    - goimports

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ GOIMPORTS_VER := v0.42.0
 GOIMPORTS_BIN := goimports
 GOIMPORTS := $(abspath $(TOOLS_BIN_DIR)/$(GOIMPORTS_BIN)-$(GOIMPORTS_VER))
 
-GOLANGCI_LINT_VER := v1.64.7
+GOLANGCI_LINT_VER := v2.13.2
 GOLANGCI_LINT_BIN := golangci-lint
 GOLANGCI_LINT := $(abspath $(TOOLS_BIN_DIR)/$(GOLANGCI_LINT_BIN)-$(GOLANGCI_LINT_VER))
 
@@ -81,7 +81,7 @@ GO_INSTALL := ./hack/go-install.sh
 ## --------------------------------------
 
 $(GOLANGCI_LINT):
-	GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) github.com/golangci/golangci-lint/cmd/golangci-lint $(GOLANGCI_LINT_BIN) $(GOLANGCI_LINT_VER)
+	GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) github.com/golangci/golangci-lint/v2/cmd/golangci-lint $(GOLANGCI_LINT_BIN) $(GOLANGCI_LINT_VER)
 
 $(CONTROLLER_GEN):
 	GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) sigs.k8s.io/controller-tools/cmd/controller-gen $(CONTROLLER_GEN_BIN) $(CONTROLLER_GEN_VER)
@@ -109,11 +109,11 @@ help: ## Display this help
 
 .PHONY: lint
 lint: $(GOLANGCI_LINT) ## Run fast linting
-	$(GOLANGCI_LINT) run -v
+	$(GOLANGCI_LINT) run -v --fast-only
 
 .PHONY: lint-full
 lint-full: $(GOLANGCI_LINT) ## Run slower linters to detect possible issues
-	$(GOLANGCI_LINT) run -v --fast=false
+	$(GOLANGCI_LINT) run -v
 
 ## --------------------------------------
 ## Development


### PR DESCRIPTION
### Description of your changes

This pull request updates the project's linting configuration to support GolangCI-Lint v2, reorganizes linter and formatter settings, and updates the Makefile accordingly. The main focus is on aligning the configuration with the new version's requirements and improving clarity by separating linters from code formatters.

(GoLang CI Linter v1.16.7 does not support Go 1.25 and newer versions)

I have:

- [x] Associated this change with a known KubeFleet Issue (Bug, Feature, etc).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

NA


### Special notes for your reviewer

 NA
