### PR TITLE
fix: block RBAC escalation paths in cluster resource overrides

### DIFF
--- a/.github/.copilot/breadcrumbs/2026-08-31-2128-msrc-rbac-propagation-containment.md
+++ b/.github/.copilot/breadcrumbs/2026-08-31-2128-msrc-rbac-propagation-containment.md
@@ -1,0 +1,79 @@
+# MSRC RBAC override containment
+
+## Requirements
+
+- Reject CRO JSON patches targeting `/subjects`, `/roleRef`, `/rules`, or `/aggregationRule` on `Role`, `RoleBinding`, `ClusterRole`, or `ClusterRoleBinding` resources.
+- Add validation regression coverage for the reported Cluster Writer to member `cluster-admin` escalation path.
+
+## Additional comments from user
+
+- This is immediate containment for Incident 31000000704764.
+- The requested scope is containment only; delegated source/member authorization is a later permanent fix.
+- Scope was narrowed after plan approval: only CRO JSON-patch modification of RBAC binding privilege fields on member clusters is in scope. CRP/RP propagation, RO behavior, delete overrides, and other CRO patches must remain unchanged.
+
+## Plan
+
+### Phase 1: Tests first
+
+- [x] **Task 1.1:** Add CRO validator cases reproducing `/subjects`, `/roleRef`, `/rules`, and `/aggregationRule` patches on Kubernetes RBAC kinds.
+  - Success: both whole-field and descendant JSON-pointer paths are denied with an actionable member-cluster privilege-escalation message.
+- [x] **Task 1.2:** Preserve positive cases.
+  - Success: non-RBAC resources may use the same field names, and RBAC resources may still receive unrelated patches.
+
+### Phase 2: CRO containment
+
+- [x] **Task 2.1:** Add a focused helper identifying Kubernetes RBAC kinds and protected JSON-pointer path prefixes.
+  - Success: the check requires the canonical `rbac.authorization.k8s.io` group and one of the four RBAC kinds.
+- [x] **Task 2.2:** Make CRO policy validation target-kind aware and reject protected paths.
+  - Success: each protected root and its descendants cannot be patched on selected RBAC resources.
+
+### Phase 3: Verification
+
+- [x] **Task 3.1:** Run formatting and required generation only if source/API changes require it.
+  - Success: generated artifacts are synchronized and unrelated generated changes are absent.
+- [x] **Task 3.2:** Run focused validator tests.
+  - Success: all focused tests pass.
+- [x] **Task 3.3:** Run the repository-required review checks practical for this change.
+  - Success: failures are fixed or clearly documented with their cause.
+
+## Decisions
+
+- Apply the tactical path denylist requested by the user instead of rejecting RBAC CRO targets wholesale.
+- Recognize all four Kubernetes RBAC kinds for completeness, although CRO normally selects cluster-scoped `ClusterRole` and `ClusterRoleBinding` objects.
+- Match both the whole field and descendants so array-element or nested-field patches cannot bypass the mitigation.
+- Leave CRP/RP propagation and namespaced RO behavior unchanged per the narrowed request.
+- Do not add delegated SAR or Guard behavior in this containment branch.
+
+## Implementation Details
+
+- CRO policy validation will combine the selected GroupKinds with each JSON patch path and deny protected RBAC binding fields.
+- Existing public API types remain unchanged; only admission behavior is tightened.
+
+## Changes Made
+
+- Branch renamed to `fix/msrc-rbac-cro-path-containment` to reflect the final scope.
+- Plan approved, then narrowed to CRO-only RBAC override containment.
+- Added target-aware CRO validation for all four escalation path roots and descendants.
+- Added table-driven regression tests covering the exploit paths and allowed non-RBAC/unrelated patches.
+- Validation passed: full `pkg/utils/validator` tests, focused `go vet`, fast repository lint, and `git diff --check`.
+- No API or generated-file changes were required.
+
+## Before/After Comparison
+
+- **Before:** A caller able to write CRO objects can cause privileged Fleet controllers to rewrite RBAC grants on selected member clusters.
+- **After:** CROs cannot rewrite RBAC subjects, role references, rules, or aggregation rules; propagation and unrelated override behavior remain unchanged.
+
+## References
+
+- Incident 31000000704764, supplied by the user.
+- `.github/.copilot/domain_knowledge/cluster vs namespace scoped resources`: scope semantics for CRP/RP handling.
+- `pkg/utils/validator/clusterresourceoverride.go`: CRO selector and policy validation used by the validating webhook.
+- No applicable feature specification exists under `.github/.copilot/specifications/`.
+
+## Completion criteria
+
+- [x] CRO JSON patches to all four escalation paths on Kubernetes RBAC kinds are denied.
+- [x] CRP/RP propagation, RO behavior, delete overrides, and unrelated CRO patches are unchanged.
+- [x] The reported subject-rewrite exploit has validation regression coverage.
+- [x] Focused tests and applicable repository checks pass.
+- [x] This breadcrumb records completed tasks, test results, and any course corrections.

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - '**.md'
       - "docs/**"
+      - ".github/workflows/markdown-lint.yml"
+      - ".github/workflows/markdown.links.config.json"
 
 jobs:
   markdown-link-check:

--- a/.github/workflows/markdown.links.config.json
+++ b/.github/workflows/markdown.links.config.json
@@ -11,6 +11,9 @@
     "ignorePatterns": [
         {
             "pattern": "^mailto:"
+        },
+        {
+            "pattern": "^https://cloud-native\\.slack\\.com/archives/C08KR7589R8$"
         }
     ]
 }

--- a/pkg/utils/validator/clusterresourceoverride.go
+++ b/pkg/utils/validator/clusterresourceoverride.go
@@ -19,11 +19,28 @@ package validator
 
 import (
 	"fmt"
+	"strings"
 
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/errors"
 
 	placementv1beta1 "github.com/kubefleet-dev/kubefleet/apis/placement/v1beta1"
 )
+
+var kubernetesRBACResourceKinds = map[string]bool{
+	"Role":               true,
+	"RoleBinding":        true,
+	"ClusterRole":        true,
+	"ClusterRoleBinding": true,
+}
+
+var rbacEscalationPaths = map[string]struct{}{
+	"subjects":        {},
+	"roleRef":         {},
+	"rules":           {},
+	"aggregationRule": {},
+}
 
 // ValidateClusterResourceOverride validates cluster resource override fields and returns error.
 func ValidateClusterResourceOverride(cro placementv1beta1.ClusterResourceOverride, croList *placementv1beta1.ClusterResourceOverrideList) error {
@@ -42,6 +59,9 @@ func ValidateClusterResourceOverride(cro placementv1beta1.ClusterResourceOverrid
 
 	if cro.Spec.Policy != nil {
 		if err := validateOverridePolicy(cro.Spec.Policy); err != nil {
+			allErr = append(allErr, err)
+		}
+		if err := validateRBACJSONPatchOverrides(cro.Spec.ClusterResourceSelectors, cro.Spec.Policy); err != nil {
 			allErr = append(allErr, err)
 		}
 	}
@@ -70,6 +90,41 @@ func validateClusterResourceSelectors(cro placementv1beta1.ClusterResourceOverri
 		selectorMap[selector] = true
 	}
 	return errors.NewAggregate(allErr)
+}
+
+func isKubernetesRBACResource(gk schema.GroupKind) bool {
+	return gk.Group == rbacv1.GroupName && kubernetesRBACResourceKinds[gk.Kind]
+}
+
+func validateRBACJSONPatchOverrides(selectors []placementv1beta1.ResourceSelectorTerm, policy *placementv1beta1.OverridePolicy) error {
+	allErr := make([]error, 0)
+	for _, selector := range selectors {
+		gk := schema.GroupKind{Group: selector.Group, Kind: selector.Kind}
+		if !isKubernetesRBACResource(gk) {
+			continue
+		}
+
+		for _, rule := range policy.OverrideRules {
+			for _, patch := range rule.JSONPatchOverrides {
+				if isProtectedRBACOverridePath(patch.Path) {
+					allErr = append(allErr, fmt.Errorf("clusterResourceOverride cannot patch path %q on RBAC resource %s because it can escalate privileges on member clusters", patch.Path, gk))
+				}
+			}
+		}
+	}
+	return errors.NewAggregate(allErr)
+}
+
+func isProtectedRBACOverridePath(path string) bool {
+	if !strings.HasPrefix(path, "/") {
+		return false
+	}
+	parts := strings.Split(strings.TrimPrefix(path, "/"), "/")
+	if len(parts) == 0 {
+		return false
+	}
+	_, found := rbacEscalationPaths[parts[0]]
+	return found
 }
 
 // validateClusterResourceOverrideResourceLimit checks if there is only 1 cluster resource override per resource,

--- a/pkg/utils/validator/clusterresourceoverride_test.go
+++ b/pkg/utils/validator/clusterresourceoverride_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apierrors "k8s.io/apimachinery/pkg/util/errors"
@@ -138,6 +139,90 @@ func TestValidateClusterResourceSelectors(t *testing.T) {
 
 			if got != nil && !strings.Contains(got.Error(), tt.wantErrMsg.Error()) {
 				t.Errorf("validateClusterResourceSelectors() = %v, want %v", got, tt.wantErrMsg)
+			}
+		})
+	}
+}
+
+func TestValidateRBACJSONPatchOverrides(t *testing.T) {
+	tests := map[string]struct {
+		group      string
+		kind       string
+		path       string
+		wantErrMsg string
+	}{
+		"deny subjects": {
+			group: rbacv1.GroupName, kind: "ClusterRoleBinding", path: "/subjects",
+			wantErrMsg: `cannot patch path "/subjects" on RBAC resource`,
+		},
+		"deny subjects descendant": {
+			group: rbacv1.GroupName, kind: "RoleBinding", path: "/subjects/0/name",
+			wantErrMsg: `cannot patch path "/subjects/0/name" on RBAC resource`,
+		},
+		"deny roleRef": {
+			group: rbacv1.GroupName, kind: "ClusterRoleBinding", path: "/roleRef",
+			wantErrMsg: `cannot patch path "/roleRef" on RBAC resource`,
+		},
+		"deny roleRef descendant": {
+			group: rbacv1.GroupName, kind: "RoleBinding", path: "/roleRef/name",
+			wantErrMsg: `cannot patch path "/roleRef/name" on RBAC resource`,
+		},
+		"deny rules": {
+			group: rbacv1.GroupName, kind: "ClusterRole", path: "/rules",
+			wantErrMsg: `cannot patch path "/rules" on RBAC resource`,
+		},
+		"deny rules descendant": {
+			group: rbacv1.GroupName, kind: "Role", path: "/rules/0/verbs",
+			wantErrMsg: `cannot patch path "/rules/0/verbs" on RBAC resource`,
+		},
+		"deny aggregationRule": {
+			group: rbacv1.GroupName, kind: "ClusterRole", path: "/aggregationRule",
+			wantErrMsg: `cannot patch path "/aggregationRule" on RBAC resource`,
+		},
+		"deny aggregationRule descendant": {
+			group: rbacv1.GroupName, kind: "ClusterRole", path: "/aggregationRule/clusterRoleSelectors",
+			wantErrMsg: `cannot patch path "/aggregationRule/clusterRoleSelectors" on RBAC resource`,
+		},
+		"allow unrelated RBAC path": {
+			group: rbacv1.GroupName, kind: "ClusterRoleBinding", path: "/metadata/annotations/example.com~1owner",
+		},
+		"allow same path on non-RBAC resource": {
+			group: "example.com", kind: "Example", path: "/rules",
+		},
+		"allow lookalike kind outside RBAC group": {
+			group: "example.com", kind: "ClusterRole", path: "/rules",
+		},
+	}
+
+	for testName, tt := range tests {
+		t.Run(testName, func(t *testing.T) {
+			cro := placementv1beta1.ClusterResourceOverride{
+				Spec: placementv1beta1.ClusterResourceOverrideSpec{
+					ClusterResourceSelectors: []placementv1beta1.ResourceSelectorTerm{{
+						Group: tt.group, Version: "v1", Kind: tt.kind, Name: "target",
+					}},
+					Policy: &placementv1beta1.OverridePolicy{
+						OverrideRules: []placementv1beta1.OverrideRule{{
+							OverrideType: placementv1beta1.JSONPatchOverrideType,
+							JSONPatchOverrides: []placementv1beta1.JSONPatchOverride{{
+								Operator: placementv1beta1.JSONPatchOverrideOpAdd,
+								Path:     tt.path,
+								Value:    apiextensionsv1.JSON{Raw: []byte(`{}`)},
+							}},
+						}},
+					},
+				},
+			}
+
+			got := ValidateClusterResourceOverride(cro, nil)
+			if tt.wantErrMsg == "" {
+				if got != nil {
+					t.Fatalf("ValidateClusterResourceOverride() = %v, want nil", got)
+				}
+				return
+			}
+			if got == nil || !strings.Contains(got.Error(), tt.wantErrMsg) {
+				t.Fatalf("ValidateClusterResourceOverride() = %v, want error containing %q", got, tt.wantErrMsg)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- reject ClusterResourceOverride JSON patches to RBAC `subjects`, `roleRef`, `rules`, and `aggregationRule`
- reject both whole-field and descendant JSON pointer paths on canonical Kubernetes RBAC resources
- preserve unrelated RBAC patches and equivalent paths on non-RBAC resources

## Scope

This is a focused admission-time containment change. CRP/RP propagation, ResourceOverride behavior, delete overrides, and unrelated CRO patches remain unchanged.

## Testing

- `MS_GOTOOLCHAIN_ALLOW_NON_LOCAL=1 GOTOOLCHAIN=auto go test ./pkg/utils/validator -count=1`
- `MS_GOTOOLCHAIN_ALLOW_NON_LOCAL=1 GOTOOLCHAIN=auto go vet ./pkg/utils/validator`
- `make lint`
- `git diff --check`
