### PR TITLE
fix: scope namespace-accessible placement status

### DIFF
--- a/.github/.copilot/breadcrumbs/2026-09-01-1947-crps-status-disclosure.md
+++ b/.github/.copilot/breadcrumbs/2026-09-01-1947-crps-status-disclosure.md
@@ -1,0 +1,92 @@
+# Prevent namespace-accessible placement status disclosure
+
+## Requirements
+
+- Build the fix from `cncf/main` on an isolated branch.
+- Restrict the namespaced `ClusterResourcePlacementStatus` projection to the selected Namespace and resources contained in that namespace.
+- Exclude unrelated cluster-scoped resources, such as `ClusterRole` objects.
+- Preserve diff and drift details, including `ValueInMember` and `ValueInHub`, for retained in-namespace resources.
+- Preserve the full cluster-scoped `ClusterResourcePlacement` status for authorized cluster-scoped readers.
+
+## Additional comments from user
+
+- The requested mitigation targets the namespace authorization boundary rather than changing member-side diff calculation globally.
+- Redacting `ValueInMember` and `ValueInHub` is deferred to a separate PR stacked on this namespace-boundary change.
+
+## Plan
+
+### Phase 1: Tests first
+
+- [x] **Task 1.1:** Add unit tests for the namespace-safe status projection.
+  - Verify in-namespace resources remain visible.
+  - Verify the selected Namespace resource remains visible.
+  - Verify unrelated cluster-scoped and cross-namespace resources are removed.
+  - Verify diff and drift details remain unchanged for retained resources.
+  - **Success criterion:** Tests fail against the current verbatim-copy behavior.
+- [x] **Task 1.2:** Add synchronization coverage proving the namespaced object is sanitized without mutating the source CRP status.
+  - **Success criterion:** The test demonstrates separate privileged and namespace-safe views.
+
+### Phase 2: Implement the safe projection
+
+- [x] **Task 2.1:** Replace the current condition-only filter with a namespace-aware projection helper.
+  - Deep-copy status before modification.
+  - Filter resource-bearing status fields to the selected namespace boundary.
+  - **Success criterion:** No out-of-scope resource or reference is copied into CRPS.
+- [x] **Task 2.2:** Preserve non-resource status data for retained namespace-scoped entries.
+  - Keep condition messages and drift/diff values unchanged in this PR.
+  - **Success criterion:** This PR changes only the namespace-to-cluster authorization boundary.
+
+### Phase 3: Verification
+
+- [x] **Task 3.1:** Run focused placement controller unit tests.
+  - **Success criterion:** Namespace status synchronization tests pass.
+- [x] **Task 3.2:** Run broader relevant controller tests and formatting/lint checks where practical.
+  - **Success criterion:** No regressions or new diagnostics are introduced.
+- [x] **Task 3.3:** Review the final diff for minimal scope and document results.
+  - **Success criterion:** The change affects only namespace status projection, its tests, and this breadcrumb.
+
+## Decisions
+
+- Sanitize at the CRP-to-CRPS trust boundary so privileged cluster-scoped status remains unchanged.
+- Use an allowlist-style namespace projection for resource-bearing fields.
+- Handle patch-value redaction separately so its API semantics and placeholder are reviewed independently.
+
+## Implementation Details
+
+- Replaced the verbatim CRP status copy with `buildNamespaceAccessiblePlacementStatus`, which deep-copies before sanitizing.
+- Retained only the selected Namespace and resources whose `namespace` equals the CRPS namespace.
+- Retained only same-namespace `ResourceOverride` references and omitted all cluster-scoped override references.
+- Removed cluster-scoped envelope references while preserving same-namespace envelope metadata.
+- Preserved drift/diff details and free-form condition messages for retained namespace-scoped entries.
+- Updated the shared integration assertion to compare an independently constructed namespace projection, including all retained data.
+- Kept resource indices and cluster names because they are status coordination metadata rather than Kubernetes object contents or out-of-scope object references.
+
+## Changes Made
+
+- Created branch `fix/msrc-crps-status-disclosure` from refreshed `cncf/main` in the isolated worktree `/home/weiweng/kubefleet-cncf`.
+- Added this implementation breadcrumb.
+- Updated `pkg/controllers/placement/namespace_status_sync.go` with the safe projection.
+- Added projection and sync-boundary unit coverage in `pkg/controllers/placement/namespace_status_sync_test.go`.
+- Updated `test/utils/crpstatussync/crp_status_sync.go` for the new CRPS contract.
+- Installed the repository-pinned Kubernetes 1.33.0 envtest assets after the first full package run found no local `etcd` binary.
+
+## Before/After Comparison
+
+- **Before:** Namespaced CRPS receives nearly the complete CRP status, including selected cluster-scoped and cross-namespace resources.
+- **After:** Namespaced CRPS contains only namespace-contained resource status and same-namespace override/envelope references. Retained status details remain unchanged, and cluster-scoped CRP status remains complete.
+
+## References
+
+- `pkg/controllers/placement/namespace_status_sync.go` — current CRP-to-CRPS copy boundary.
+- `pkg/controllers/workapplier/drift_detection_takeover.go` — source of member/hub patch values and Secret-only redaction.
+- `apis/placement/v1beta1/clusterresourceplacement_types.go` — placement status and patch detail API contracts.
+- No applicable placement-specific domain knowledge or specification file exists under `.github/.copilot/domain_knowledge/` or `.github/.copilot/specifications/`.
+- Verification: focused namespace projection tests passed with Go 1.26.6.
+- Verification: the broader package compiled, but its envtest suite requires an `etcd` binary that is not installed at `/usr/local/kubebuilder/bin/etcd` in the current environment.
+
+## Completion criteria
+
+- [x] Namespaced CRPS cannot report unrelated cluster-scoped or cross-namespace resources.
+- [x] Retained namespace-scoped values and condition messages remain unchanged.
+- [x] Cluster-scoped CRP status behavior remains unchanged.
+- [x] Focused tests pass and the final diff is minimal.

--- a/apis/placement/v1/clusterresourceplacement_types.go
+++ b/apis/placement/v1/clusterresourceplacement_types.go
@@ -1686,8 +1686,9 @@ func (rpl *ResourcePlacementList) GetPlacementObjs() []PlacementObj {
 // +kubebuilder:printcolumn:JSONPath=`.metadata.creationTimestamp`,name="Age",type=date
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// ClusterResourcePlacementStatus is a namespaced resource that mirrors the PlacementStatus of a corresponding
-// ClusterResourcePlacement object. This allows namespace-scoped access to cluster-scoped placement status.
+// ClusterResourcePlacementStatus is a namespaced resource that projects the PlacementStatus of a corresponding
+// ClusterResourcePlacement object. The projection includes only the target Namespace and resources and references
+// within it, allowing namespace-scoped access without exposing other cluster-scoped or namespaced resources.
 // The LastUpdatedTime field is updated whenever the object is updated.
 //
 // This object will be created within the target namespace that contains resources being managed by the CRP.
@@ -1700,7 +1701,7 @@ type ClusterResourcePlacementStatus struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	// Source status copied from the corresponding ClusterResourcePlacement.
+	// Source status projected from the corresponding ClusterResourcePlacement for the target namespace.
 	// +kubebuilder:validation:Required
 	PlacementStatus `json:"sourceStatus,omitempty"`
 

--- a/apis/placement/v1beta1/clusterresourceplacement_types.go
+++ b/apis/placement/v1beta1/clusterresourceplacement_types.go
@@ -1794,8 +1794,9 @@ func (rpl *ResourcePlacementList) GetPlacementObjs() []PlacementObj {
 // +kubebuilder:printcolumn:JSONPath=`.metadata.creationTimestamp`,name="Age",type=date
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// ClusterResourcePlacementStatus is a namespaced resource that mirrors the PlacementStatus of a corresponding
-// ClusterResourcePlacement object. This allows namespace-scoped access to cluster-scoped placement status.
+// ClusterResourcePlacementStatus is a namespaced resource that projects the PlacementStatus of a corresponding
+// ClusterResourcePlacement object. The projection includes only the target Namespace and resources and references
+// within it, allowing namespace-scoped access without exposing other cluster-scoped or namespaced resources.
 // The LastUpdatedTime field is updated whenever the CRPS object is updated.
 //
 // This object will be created within the target namespace that contains resources being managed by the CRP.
@@ -1808,7 +1809,7 @@ type ClusterResourcePlacementStatus struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	// Source status copied from the corresponding ClusterResourcePlacement.
+	// Source status projected from the corresponding ClusterResourcePlacement for the target namespace.
 	// +kubebuilder:validation:Required
 	PlacementStatus `json:"sourceStatus,omitempty"`
 

--- a/config/crd/bases/placement.kubernetes-fleet.io_clusterresourceplacementstatuses.yaml
+++ b/config/crd/bases/placement.kubernetes-fleet.io_clusterresourceplacementstatuses.yaml
@@ -33,8 +33,9 @@ spec:
     schema:
       openAPIV3Schema:
         description: |-
-          ClusterResourcePlacementStatus is a namespaced resource that mirrors the PlacementStatus of a corresponding
-          ClusterResourcePlacement object. This allows namespace-scoped access to cluster-scoped placement status.
+          ClusterResourcePlacementStatus is a namespaced resource that projects the PlacementStatus of a corresponding
+          ClusterResourcePlacement object. The projection includes only the target Namespace and resources and references
+          within it, allowing namespace-scoped access without exposing other cluster-scoped or namespaced resources.
           The LastUpdatedTime field is updated whenever the object is updated.
 
           This object will be created within the target namespace that contains resources being managed by the CRP.
@@ -68,7 +69,8 @@ spec:
           metadata:
             type: object
           sourceStatus:
-            description: Source status copied from the corresponding ClusterResourcePlacement.
+            description: Source status projected from the corresponding ClusterResourcePlacement
+              for the target namespace.
             properties:
               conditions:
                 description: |-
@@ -680,8 +682,9 @@ spec:
     schema:
       openAPIV3Schema:
         description: |-
-          ClusterResourcePlacementStatus is a namespaced resource that mirrors the PlacementStatus of a corresponding
-          ClusterResourcePlacement object. This allows namespace-scoped access to cluster-scoped placement status.
+          ClusterResourcePlacementStatus is a namespaced resource that projects the PlacementStatus of a corresponding
+          ClusterResourcePlacement object. The projection includes only the target Namespace and resources and references
+          within it, allowing namespace-scoped access without exposing other cluster-scoped or namespaced resources.
           The LastUpdatedTime field is updated whenever the CRPS object is updated.
 
           This object will be created within the target namespace that contains resources being managed by the CRP.
@@ -715,7 +718,8 @@ spec:
           metadata:
             type: object
           sourceStatus:
-            description: Source status copied from the corresponding ClusterResourcePlacement.
+            description: Source status projected from the corresponding ClusterResourcePlacement
+              for the target namespace.
             properties:
               conditions:
                 description: |-

--- a/pkg/controllers/placement/namespace_status_sync.go
+++ b/pkg/controllers/placement/namespace_status_sync.go
@@ -79,13 +79,38 @@ func isNamespaceAccessibleCRP(placementObj placementv1beta1.PlacementObj) bool {
 	return true
 }
 
-// filterStatusSyncedCondition creates a copy of the placement status with the
-// ClusterResourcePlacementStatusSynced condition removed. This is used when
-// creating ClusterResourcePlacementStatus objects because the StatusSynced
-// condition is only relevant for the main CRP object, not the CRPS object.
-// Returns a filtered copy of the status with all conditions except StatusSynced.
-func filterStatusSyncedCondition(status *placementv1beta1.PlacementStatus) *placementv1beta1.PlacementStatus {
+// buildNamespaceAccessiblePlacementStatus creates a namespace-scoped copy of the placement status.
+// It excludes resources and references outside the target namespace.
+func buildNamespaceAccessiblePlacementStatus(status *placementv1beta1.PlacementStatus, targetNamespace string) *placementv1beta1.PlacementStatus {
 	filteredStatus := status.DeepCopy()
+
+	filteredStatus.SelectedResources = filterResourceIdentifiersByNamespace(filteredStatus.SelectedResources, targetNamespace)
+	for idx := range filteredStatus.PerClusterPlacementStatuses {
+		clusterStatus := &filteredStatus.PerClusterPlacementStatuses[idx]
+		clusterStatus.ApplicableResourceOverrides = filterNamespacedNamesByNamespace(clusterStatus.ApplicableResourceOverrides, targetNamespace)
+		clusterStatus.ApplicableClusterResourceOverrides = nil
+		clusterStatus.FailedPlacements = filterPlacementsByNamespace(
+			clusterStatus.FailedPlacements,
+			targetNamespace,
+			func(placement *placementv1beta1.FailedResourcePlacement) *placementv1beta1.ResourceIdentifier {
+				return &placement.ResourceIdentifier
+			},
+		)
+		clusterStatus.DriftedPlacements = filterPlacementsByNamespace(
+			clusterStatus.DriftedPlacements,
+			targetNamespace,
+			func(placement *placementv1beta1.DriftedResourcePlacement) *placementv1beta1.ResourceIdentifier {
+				return &placement.ResourceIdentifier
+			},
+		)
+		clusterStatus.DiffedPlacements = filterPlacementsByNamespace(
+			clusterStatus.DiffedPlacements,
+			targetNamespace,
+			func(placement *placementv1beta1.DiffedResourcePlacement) *placementv1beta1.ResourceIdentifier {
+				return &placement.ResourceIdentifier
+			},
+		)
+	}
 
 	// Filter out the ClusterResourcePlacementStatusSynced condition.
 	filteredConditions := make([]metav1.Condition, 0, len(filteredStatus.Conditions))
@@ -97,6 +122,78 @@ func filterStatusSyncedCondition(status *placementv1beta1.PlacementStatus) *plac
 	filteredStatus.Conditions = filteredConditions
 
 	return filteredStatus
+}
+
+// isResourceInNamespaceScope reports whether a resource can be included in status published to
+// targetNamespace. The namespace itself is included together with resources contained within it.
+func isResourceInNamespaceScope(identifier placementv1beta1.ResourceIdentifier, targetNamespace string) bool {
+	if identifier.Namespace == targetNamespace {
+		return true
+	}
+
+	return identifier.Namespace == "" &&
+		identifier.Group == utils.NamespaceGVK.Group &&
+		identifier.Version == utils.NamespaceGVK.Version &&
+		identifier.Kind == utils.NamespaceGVK.Kind &&
+		identifier.Name == targetNamespace
+}
+
+// sanitizeResourceIdentifier removes references to cluster-scoped envelope objects from an
+// otherwise namespace-scoped resource identifier.
+func sanitizeResourceIdentifier(identifier placementv1beta1.ResourceIdentifier, targetNamespace string) placementv1beta1.ResourceIdentifier {
+	if identifier.Envelope != nil &&
+		(identifier.Envelope.Type == placementv1beta1.ClusterResourceEnvelopeType || identifier.Envelope.Namespace != targetNamespace) {
+		identifier.Envelope = nil
+	}
+	return identifier
+}
+
+func filterResourceIdentifiersByNamespace(identifiers []placementv1beta1.ResourceIdentifier, targetNamespace string) []placementv1beta1.ResourceIdentifier {
+	if identifiers == nil {
+		return nil
+	}
+
+	filtered := make([]placementv1beta1.ResourceIdentifier, 0, len(identifiers))
+	for _, identifier := range identifiers {
+		if isResourceInNamespaceScope(identifier, targetNamespace) {
+			filtered = append(filtered, sanitizeResourceIdentifier(identifier, targetNamespace))
+		}
+	}
+	return filtered
+}
+
+func filterNamespacedNamesByNamespace(names []placementv1beta1.NamespacedName, targetNamespace string) []placementv1beta1.NamespacedName {
+	if names == nil {
+		return nil
+	}
+
+	filtered := make([]placementv1beta1.NamespacedName, 0, len(names))
+	for _, name := range names {
+		if name.Namespace == targetNamespace {
+			filtered = append(filtered, name)
+		}
+	}
+	return filtered
+}
+
+func filterPlacementsByNamespace[T any](
+	placements []T,
+	targetNamespace string,
+	resourceIdentifier func(*T) *placementv1beta1.ResourceIdentifier,
+) []T {
+	if placements == nil {
+		return nil
+	}
+
+	filtered := make([]T, 0, len(placements))
+	for _, placement := range placements {
+		identifier := resourceIdentifier(&placement)
+		if isResourceInNamespaceScope(*identifier, targetNamespace) {
+			*identifier = sanitizeResourceIdentifier(*identifier, targetNamespace)
+			filtered = append(filtered, placement)
+		}
+	}
+	return filtered
 }
 
 // buildStatusSyncedCondition creates a StatusSynced condition based on the sync result.
@@ -169,8 +266,8 @@ func (r *Reconciler) syncClusterResourcePlacementStatus(ctx context.Context, crp
 	}
 	// Use CreateOrUpdate to handle both creation and update cases.
 	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, crpStatus, func() error {
-		// Set the placement status (excluding StatusSynced condition) and update time.
-		crpStatus.PlacementStatus = *filterStatusSyncedCondition(&crp.Status)
+		// Set the namespace-safe placement status and update time.
+		crpStatus.PlacementStatus = *buildNamespaceAccessiblePlacementStatus(&crp.Status, targetNamespace)
 		crpStatus.LastUpdatedTime = metav1.Now()
 
 		// Set CRP as owner - this ensures automatic cleanup when CRP is deleted.

--- a/pkg/controllers/placement/namespace_status_sync_test.go
+++ b/pkg/controllers/placement/namespace_status_sync_test.go
@@ -45,6 +45,167 @@ var (
 	}
 )
 
+func TestBuildNamespaceAccessiblePlacementStatus(t *testing.T) {
+	targetNamespace := "test-namespace"
+	status := &placementv1beta1.PlacementStatus{
+		SelectedResources: []placementv1beta1.ResourceIdentifier{
+			{Version: "v1", Kind: "Namespace", Name: targetNamespace},
+			{Group: "apps", Version: "v1", Kind: "Deployment", Namespace: targetNamespace, Name: "api", Envelope: &placementv1beta1.EnvelopeIdentifier{Name: "cluster-envelope", Namespace: targetNamespace, Type: placementv1beta1.ClusterResourceEnvelopeType}},
+			{Version: "v1", Kind: "ConfigMap", Namespace: targetNamespace, Name: "config", Envelope: &placementv1beta1.EnvelopeIdentifier{Name: "resource-envelope", Namespace: targetNamespace, Type: placementv1beta1.ResourceEnvelopeType}},
+			{Version: "v1", Kind: "ConfigMap", Namespace: "other-namespace", Name: "other"},
+			{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRole", Name: "cluster-reader"},
+		},
+		ObservedResourceIndex: "1",
+		PerClusterPlacementStatuses: []placementv1beta1.PerClusterPlacementStatus{
+			{
+				ClusterName: "member-1",
+				ApplicableResourceOverrides: []placementv1beta1.NamespacedName{
+					{Name: "same-namespace-override", Namespace: targetNamespace},
+					{Name: "other-namespace-override", Namespace: "other-namespace"},
+				},
+				ApplicableClusterResourceOverrides: []string{"cluster-override"},
+				FailedPlacements: []placementv1beta1.FailedResourcePlacement{
+					{
+						ResourceIdentifier: placementv1beta1.ResourceIdentifier{Group: "apps", Version: "v1", Kind: "Deployment", Namespace: targetNamespace, Name: "api"},
+						Condition:          metav1.Condition{Type: "Applied", Status: metav1.ConditionFalse, Reason: "ApplyFailed", Message: "apply failed"},
+					},
+					{
+						ResourceIdentifier: placementv1beta1.ResourceIdentifier{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRole", Name: "cluster-reader"},
+						Condition:          metav1.Condition{Type: "Applied", Status: metav1.ConditionFalse, Reason: "ApplyFailed", Message: "apply failed"},
+					},
+				},
+				DriftedPlacements: []placementv1beta1.DriftedResourcePlacement{
+					{
+						ResourceIdentifier: placementv1beta1.ResourceIdentifier{Group: "apps", Version: "v1", Kind: "Deployment", Namespace: targetNamespace, Name: "api"},
+						ObservedDrifts: []placementv1beta1.PatchDetail{
+							{Path: "/spec/template/spec/containers/0/env/0/value", ValueInMember: "member-secret", ValueInHub: "hub-secret"},
+						},
+					},
+					{
+						ResourceIdentifier: placementv1beta1.ResourceIdentifier{Version: "v1", Kind: "ConfigMap", Namespace: "other-namespace", Name: "other"},
+						ObservedDrifts:     []placementv1beta1.PatchDetail{{Path: "/data/token", ValueInMember: "other-secret"}},
+					},
+				},
+				DiffedPlacements: []placementv1beta1.DiffedResourcePlacement{
+					{
+						ResourceIdentifier: placementv1beta1.ResourceIdentifier{Version: "v1", Kind: "Namespace", Name: targetNamespace},
+						ObservedDiffs:      []placementv1beta1.PatchDetail{{Path: "/metadata/labels/team", ValueInMember: "member-value", ValueInHub: "hub-value"}},
+					},
+					{
+						ResourceIdentifier: placementv1beta1.ResourceIdentifier{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRole", Name: "cluster-reader"},
+						ObservedDiffs:      []placementv1beta1.PatchDetail{{Path: "/metadata/annotations/token", ValueInMember: "cluster-secret"}},
+					},
+				},
+				Conditions: []metav1.Condition{{Type: "Applied", Status: metav1.ConditionFalse, Reason: "ApplyFailed", Message: "member object contained rejected value secret"}},
+			},
+		},
+		Conditions: []metav1.Condition{
+			{Type: string(placementv1beta1.ClusterResourcePlacementScheduledConditionType), Status: metav1.ConditionTrue, Message: "aggregate message"},
+			{Type: string(placementv1beta1.ClusterResourcePlacementStatusSyncedConditionType), Status: metav1.ConditionTrue},
+		},
+	}
+	originalStatus := status.DeepCopy()
+
+	want := &placementv1beta1.PlacementStatus{
+		SelectedResources: []placementv1beta1.ResourceIdentifier{
+			{Version: "v1", Kind: "Namespace", Name: targetNamespace},
+			{Group: "apps", Version: "v1", Kind: "Deployment", Namespace: targetNamespace, Name: "api"},
+			{Version: "v1", Kind: "ConfigMap", Namespace: targetNamespace, Name: "config", Envelope: &placementv1beta1.EnvelopeIdentifier{Name: "resource-envelope", Namespace: targetNamespace, Type: placementv1beta1.ResourceEnvelopeType}},
+		},
+		ObservedResourceIndex: "1",
+		PerClusterPlacementStatuses: []placementv1beta1.PerClusterPlacementStatus{
+			{
+				ClusterName: "member-1",
+				ApplicableResourceOverrides: []placementv1beta1.NamespacedName{
+					{Name: "same-namespace-override", Namespace: targetNamespace},
+				},
+				FailedPlacements: []placementv1beta1.FailedResourcePlacement{
+					{
+						ResourceIdentifier: placementv1beta1.ResourceIdentifier{Group: "apps", Version: "v1", Kind: "Deployment", Namespace: targetNamespace, Name: "api"},
+						Condition:          metav1.Condition{Type: "Applied", Status: metav1.ConditionFalse, Reason: "ApplyFailed", Message: "apply failed"},
+					},
+				},
+				DriftedPlacements: []placementv1beta1.DriftedResourcePlacement{
+					{
+						ResourceIdentifier: placementv1beta1.ResourceIdentifier{Group: "apps", Version: "v1", Kind: "Deployment", Namespace: targetNamespace, Name: "api"},
+						ObservedDrifts:     []placementv1beta1.PatchDetail{{Path: "/spec/template/spec/containers/0/env/0/value", ValueInMember: "member-secret", ValueInHub: "hub-secret"}},
+					},
+				},
+				DiffedPlacements: []placementv1beta1.DiffedResourcePlacement{
+					{
+						ResourceIdentifier: placementv1beta1.ResourceIdentifier{Version: "v1", Kind: "Namespace", Name: targetNamespace},
+						ObservedDiffs:      []placementv1beta1.PatchDetail{{Path: "/metadata/labels/team", ValueInMember: "member-value", ValueInHub: "hub-value"}},
+					},
+				},
+				Conditions: []metav1.Condition{{Type: "Applied", Status: metav1.ConditionFalse, Reason: "ApplyFailed", Message: "member object contained rejected value secret"}},
+			},
+		},
+		Conditions: []metav1.Condition{
+			{Type: string(placementv1beta1.ClusterResourcePlacementScheduledConditionType), Status: metav1.ConditionTrue, Message: "aggregate message"},
+		},
+	}
+
+	got := buildNamespaceAccessiblePlacementStatus(status, targetNamespace)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("buildNamespaceAccessiblePlacementStatus() mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(originalStatus, status); diff != "" {
+		t.Errorf("buildNamespaceAccessiblePlacementStatus() mutated source status (-want +got):\n%s", diff)
+	}
+}
+
+func TestSyncClusterResourcePlacementStatusSanitizesNamespaceView(t *testing.T) {
+	targetNamespace := "test-namespace"
+	crp := &placementv1beta1.ClusterResourcePlacement{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-crp"},
+		Status: placementv1beta1.PlacementStatus{
+			PerClusterPlacementStatuses: []placementv1beta1.PerClusterPlacementStatus{
+				{
+					ClusterName: "member-1",
+					DiffedPlacements: []placementv1beta1.DiffedResourcePlacement{
+						{
+							ResourceIdentifier: placementv1beta1.ResourceIdentifier{Group: "apps", Version: "v1", Kind: "Deployment", Namespace: targetNamespace, Name: "api"},
+							ObservedDiffs:      []placementv1beta1.PatchDetail{{Path: "/spec/template/spec/containers/0/env", ValueInMember: "member-secret", ValueInHub: "hub-secret"}},
+						},
+						{
+							ResourceIdentifier: placementv1beta1.ResourceIdentifier{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRole", Name: "cluster-reader"},
+							ObservedDiffs:      []placementv1beta1.PatchDetail{{Path: "/metadata/annotations/token", ValueInMember: "cluster-secret"}},
+						},
+					},
+				},
+			},
+		},
+	}
+	originalStatus := crp.Status.DeepCopy()
+	scheme := statusSyncServiceScheme(t)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		crp,
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: targetNamespace}},
+	).Build()
+	reconciler := &Reconciler{Client: fakeClient, Scheme: scheme}
+
+	if err := reconciler.syncClusterResourcePlacementStatus(context.Background(), crp, targetNamespace); err != nil {
+		t.Fatalf("syncClusterResourcePlacementStatus() failed: %v", err)
+	}
+
+	got := &placementv1beta1.ClusterResourcePlacementStatus{}
+	if err := fakeClient.Get(context.Background(), types.NamespacedName{Name: crp.Name, Namespace: targetNamespace}, got); err != nil {
+		t.Fatalf("Failed to get ClusterResourcePlacementStatus: %v", err)
+	}
+	wantDiffedPlacements := []placementv1beta1.DiffedResourcePlacement{
+		{
+			ResourceIdentifier: placementv1beta1.ResourceIdentifier{Group: "apps", Version: "v1", Kind: "Deployment", Namespace: targetNamespace, Name: "api"},
+			ObservedDiffs:      []placementv1beta1.PatchDetail{{Path: "/spec/template/spec/containers/0/env", ValueInMember: "member-secret", ValueInHub: "hub-secret"}},
+		},
+	}
+	if diff := cmp.Diff(wantDiffedPlacements, got.PlacementStatus.PerClusterPlacementStatuses[0].DiffedPlacements); diff != "" {
+		t.Errorf("synced DiffedPlacements mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(originalStatus, &crp.Status); diff != "" {
+		t.Errorf("syncClusterResourcePlacementStatus() mutated source status (-want +got):\n%s", diff)
+	}
+}
+
 func TestHandleNamespaceAccessibleCRP(t *testing.T) {
 	testCases := []struct {
 		name              string

--- a/test/utils/crpstatussync/crp_status_sync.go
+++ b/test/utils/crpstatussync/crp_status_sync.go
@@ -12,6 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	placementv1beta1 "github.com/kubefleet-dev/kubefleet/apis/placement/v1beta1"
+	"github.com/kubefleet-dev/kubefleet/pkg/utils"
 )
 
 var (
@@ -41,16 +42,7 @@ func CRPSStatusMatchesCRPActual(ctx context.Context, client client.Client, crpNa
 			return fmt.Errorf("failed to get CRP: %w", err)
 		}
 
-		// Construct expected CRPS.
-		// Filter out StatusSynced condition as it's specific to CRP status sync process
-		expectedStatus := crp.Status.DeepCopy()
-		var filteredConditions []metav1.Condition
-		for _, condition := range expectedStatus.Conditions {
-			if condition.Type != string(placementv1beta1.ClusterResourcePlacementStatusSyncedConditionType) {
-				filteredConditions = append(filteredConditions, condition)
-			}
-		}
-		expectedStatus.Conditions = filteredConditions
+		expectedStatus := namespaceProjectedStatus(&crp.Status, targetNamespace)
 
 		wantCRPS := &placementv1beta1.ClusterResourcePlacementStatus{
 			ObjectMeta: metav1.ObjectMeta{
@@ -70,11 +62,166 @@ func CRPSStatusMatchesCRPActual(ctx context.Context, client client.Client, crpNa
 			PlacementStatus: *expectedStatus,
 		}
 
-		// Compare CRPS with expected, ignoring fields that vary.
+		if err := validateNamespaceProjection(&crpStatus.PlacementStatus, targetNamespace); err != nil {
+			return err
+		}
+
 		if diff := cmp.Diff(wantCRPS, crpStatus, crpsCmpOpts...); diff != "" {
 			return fmt.Errorf("CRPS does not match expected (-want, +got): %s", diff)
 		}
 
 		return nil
 	}
+}
+
+func namespaceProjectedStatus(status *placementv1beta1.PlacementStatus, targetNamespace string) *placementv1beta1.PlacementStatus {
+	projectedStatus := status.DeepCopy()
+	projectedStatus.SelectedResources = projectResourceIdentifiers(projectedStatus.SelectedResources, targetNamespace)
+	for idx := range projectedStatus.PerClusterPlacementStatuses {
+		clusterStatus := &projectedStatus.PerClusterPlacementStatuses[idx]
+		clusterStatus.ApplicableResourceOverrides = projectResourceOverrides(clusterStatus.ApplicableResourceOverrides, targetNamespace)
+		clusterStatus.ApplicableClusterResourceOverrides = nil
+		clusterStatus.FailedPlacements = projectFailedPlacements(clusterStatus.FailedPlacements, targetNamespace)
+		clusterStatus.DriftedPlacements = projectDriftedPlacements(clusterStatus.DriftedPlacements, targetNamespace)
+		clusterStatus.DiffedPlacements = projectDiffedPlacements(clusterStatus.DiffedPlacements, targetNamespace)
+	}
+
+	conditions := make([]metav1.Condition, 0, len(projectedStatus.Conditions))
+	for _, condition := range projectedStatus.Conditions {
+		if condition.Type != string(placementv1beta1.ClusterResourcePlacementStatusSyncedConditionType) {
+			conditions = append(conditions, condition)
+		}
+	}
+	projectedStatus.Conditions = conditions
+	return projectedStatus
+}
+
+func projectResourceIdentifier(identifier placementv1beta1.ResourceIdentifier, targetNamespace string) (placementv1beta1.ResourceIdentifier, bool) {
+	inScope := identifier.Namespace == targetNamespace ||
+		(identifier.Namespace == "" && identifier.Group == utils.NamespaceGVK.Group && identifier.Version == utils.NamespaceGVK.Version &&
+			identifier.Kind == utils.NamespaceGVK.Kind && identifier.Name == targetNamespace)
+	if !inScope {
+		return placementv1beta1.ResourceIdentifier{}, false
+	}
+	if identifier.Envelope != nil &&
+		(identifier.Envelope.Type == placementv1beta1.ClusterResourceEnvelopeType || identifier.Envelope.Namespace != targetNamespace) {
+		identifier.Envelope = nil
+	}
+	return identifier, true
+}
+
+func projectResourceIdentifiers(identifiers []placementv1beta1.ResourceIdentifier, targetNamespace string) []placementv1beta1.ResourceIdentifier {
+	if identifiers == nil {
+		return nil
+	}
+	projected := make([]placementv1beta1.ResourceIdentifier, 0, len(identifiers))
+	for _, identifier := range identifiers {
+		if projectedIdentifier, ok := projectResourceIdentifier(identifier, targetNamespace); ok {
+			projected = append(projected, projectedIdentifier)
+		}
+	}
+	return projected
+}
+
+func projectResourceOverrides(overrides []placementv1beta1.NamespacedName, targetNamespace string) []placementv1beta1.NamespacedName {
+	if overrides == nil {
+		return nil
+	}
+	projected := make([]placementv1beta1.NamespacedName, 0, len(overrides))
+	for _, override := range overrides {
+		if override.Namespace == targetNamespace {
+			projected = append(projected, override)
+		}
+	}
+	return projected
+}
+
+func projectFailedPlacements(placements []placementv1beta1.FailedResourcePlacement, targetNamespace string) []placementv1beta1.FailedResourcePlacement {
+	if placements == nil {
+		return nil
+	}
+	projected := make([]placementv1beta1.FailedResourcePlacement, 0, len(placements))
+	for _, placement := range placements {
+		if identifier, ok := projectResourceIdentifier(placement.ResourceIdentifier, targetNamespace); ok {
+			placement.ResourceIdentifier = identifier
+			projected = append(projected, placement)
+		}
+	}
+	return projected
+}
+
+func projectDriftedPlacements(placements []placementv1beta1.DriftedResourcePlacement, targetNamespace string) []placementv1beta1.DriftedResourcePlacement {
+	if placements == nil {
+		return nil
+	}
+	projected := make([]placementv1beta1.DriftedResourcePlacement, 0, len(placements))
+	for _, placement := range placements {
+		if identifier, ok := projectResourceIdentifier(placement.ResourceIdentifier, targetNamespace); ok {
+			placement.ResourceIdentifier = identifier
+			projected = append(projected, placement)
+		}
+	}
+	return projected
+}
+
+func projectDiffedPlacements(placements []placementv1beta1.DiffedResourcePlacement, targetNamespace string) []placementv1beta1.DiffedResourcePlacement {
+	if placements == nil {
+		return nil
+	}
+	projected := make([]placementv1beta1.DiffedResourcePlacement, 0, len(placements))
+	for _, placement := range placements {
+		if identifier, ok := projectResourceIdentifier(placement.ResourceIdentifier, targetNamespace); ok {
+			placement.ResourceIdentifier = identifier
+			projected = append(projected, placement)
+		}
+	}
+	return projected
+}
+
+func validateNamespaceProjection(status *placementv1beta1.PlacementStatus, targetNamespace string) error {
+	validateIdentifier := func(identifier placementv1beta1.ResourceIdentifier) error {
+		inScope := identifier.Namespace == targetNamespace ||
+			(identifier.Namespace == "" && identifier.Group == utils.NamespaceGVK.Group && identifier.Version == utils.NamespaceGVK.Version &&
+				identifier.Kind == utils.NamespaceGVK.Kind && identifier.Name == targetNamespace)
+		if !inScope {
+			return fmt.Errorf("CRPS reports out-of-scope resource %s/%s %s/%s", identifier.Group, identifier.Kind, identifier.Namespace, identifier.Name)
+		}
+		if identifier.Envelope != nil &&
+			(identifier.Envelope.Type == placementv1beta1.ClusterResourceEnvelopeType || identifier.Envelope.Namespace != targetNamespace) {
+			return fmt.Errorf("CRPS reports out-of-scope envelope %s/%s", identifier.Envelope.Namespace, identifier.Envelope.Name)
+		}
+		return nil
+	}
+
+	for _, identifier := range status.SelectedResources {
+		if err := validateIdentifier(identifier); err != nil {
+			return err
+		}
+	}
+	for _, clusterStatus := range status.PerClusterPlacementStatuses {
+		for _, override := range clusterStatus.ApplicableResourceOverrides {
+			if override.Namespace != targetNamespace {
+				return fmt.Errorf("CRPS reports out-of-scope ResourceOverride %s/%s", override.Namespace, override.Name)
+			}
+		}
+		if len(clusterStatus.ApplicableClusterResourceOverrides) != 0 {
+			return fmt.Errorf("CRPS reports cluster-scoped ResourceOverrides: %v", clusterStatus.ApplicableClusterResourceOverrides)
+		}
+		for _, placement := range clusterStatus.FailedPlacements {
+			if err := validateIdentifier(placement.ResourceIdentifier); err != nil {
+				return err
+			}
+		}
+		for _, placement := range clusterStatus.DriftedPlacements {
+			if err := validateIdentifier(placement.ResourceIdentifier); err != nil {
+				return err
+			}
+		}
+		for _, placement := range clusterStatus.DiffedPlacements {
+			if err := validateIdentifier(placement.ResourceIdentifier); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
### Description of your changes

This change makes the namespaced `ClusterResourcePlacementStatus` a namespace-scoped projection instead of a near-verbatim copy of cluster-scoped placement status.

It:
- includes only the selected Namespace and resources contained in that namespace
- retains only same-namespace ResourceOverride and ResourceEnvelope references
- omits cluster-scoped override and envelope references
- preserves retained drift/diff values and condition messages unchanged
- keeps the full cluster-scoped ClusterResourcePlacement status unchanged
- updates the served API documentation and generated CRD descriptions

Value redaction is intentionally handled separately in independent PR #886.

### How has this code been tested

- `go test ./pkg/controllers/placement -run TestBuildNamespaceAccessiblePlacementStatus -count=1`
- `go test ./pkg/controllers/placement -run TestSyncClusterResourcePlacementStatusSanitizesNamespaceView -count=1`
- `go test ./test/utils/crpstatussync -count=1`
- `make manifests`
- `git diff --check`

Tests used the Go 1.26.6 toolchain required by `go.mod`. The full placement envtest suite was not run because `/usr/local/kubebuilder/bin/etcd` is unavailable in this environment.

### Special notes for your reviewer

The namespace projection is intentionally applied only at the CRP-to-CRPS trust boundary. Privileged cluster-scoped status remains unchanged. The shared integration helper independently constructs and compares the expected projection so retained in-scope data remains covered.