### PR TITLE
fix: hide diff values before takeover

### DIFF
--- a/.github/.copilot/breadcrumbs/2026-09-02-1846-report-diff-owned-values.md
+++ b/.github/.copilot/breadcrumbs/2026-09-02-1846-report-diff-owned-values.md
@@ -42,12 +42,14 @@
 - `hideDiffValuesUnlessOwned` preserves values only when the live object has the exact expected AppliedWork owner reference.
 - Focused tests cover the ownership matrix and exercise unmanaged ReportDiff and takeover-refusal paths through complete manifest processing.
 - Integration expectations retain all changed paths while omitting values for missing, takeover-disabled, and takeover-refused resources.
+- E2E expectations apply the same ownership rule without weakening positive coverage: owned-resource diffs and all drift details still retain values.
 
 ## Changes Made
 
 - Added the ReportDiff post-processing policy in `pkg/controllers/workapplier/process.go`.
 - Added focused policy and behavioral tests in `pkg/controllers/workapplier/process_test.go`.
 - Updated work-applier integration expectations for resources Fleet does not own.
+- Updated CRP, ResourcePlacement, API progression, apply-strategy transition, staged rollout, and backoff expectations for unowned resources.
 
 ## Validation
 
@@ -56,6 +58,9 @@
 - Apply-mode partial/full comparison takeover-refusal and strategy-switch integration contexts pass.
 - `go vet ./pkg/controllers/workapplier`, editor diagnostics, and `git diff --check` pass.
 - The unfiltered package run reached the existing 10-minute Go test timeout while starting a later integration case; no assertion failure was reported. The changed contexts were rerun directly and passed.
+- The E2E package compiles after updating all 14 ownership-related CI failures.
+- The focused ownership-policy unit tests pass.
+- The full ordered `slow backoff and fast backoff` envtest context passes after correcting its stale takeover-refusal fixture.
 - Published for review as https://github.com/kubefleet-dev/kubefleet/pull/872.
 
 ## Before/After Comparison

--- a/.github/.copilot/breadcrumbs/2026-09-02-1846-report-diff-owned-values.md
+++ b/.github/.copilot/breadcrumbs/2026-09-02-1846-report-diff-owned-values.md
@@ -1,0 +1,76 @@
+# ReportDiff values after takeover
+
+## Requirements
+
+- Report raw member and hub values only when the live resource is owned by the expected AppliedWork.
+- Report only changed paths before takeover, including when takeover is disabled or blocked by differences.
+- Keep this change independent of the namespace status projection fix in PR #867.
+
+## Additional comments from user
+
+- Implement this policy in a separate pull request.
+
+## Plan
+
+### Phase 1: Specify the disclosure policy
+
+- [x] Task 1.1: Add focused unit tests for owned, unowned, differently owned, and missing resources.
+  Success: The tests distinguish exact AppliedWork ownership and fail before the implementation.
+
+### Phase 2: Implement the policy
+
+- [x] Task 2.1: Apply one ReportDiff value-redaction policy after manifest processing.
+  Success: Every ReportDiff result contains values only when exact ownership is established.
+
+### Phase 3: Validate and publish
+
+- [x] Task 3.1: Run focused and package-level tests, formatting, vet, and diff checks.
+  Success: All applicable checks pass.
+- [x] Task 3.2: Commit with DCO sign-off, push the branch, and open an upstream PR.
+  Success: A separate PR against `kubefleet-dev/kubefleet:main` is available for review.
+
+## Decisions
+
+- Evaluate ownership after takeover so a successful takeover may expose values while a refused takeover cannot.
+- Require an owner reference equal to the expected AppliedWork; another Fleet owner is not sufficient.
+- Treat a missing live resource as unowned, so its root diff contains only `/` and no whole-object placeholder.
+- Keep the namespace projection sanitization from PR #867 as a separate authorization-boundary defense.
+
+## Implementation Details
+
+- `processOneManifest` defers a ReportDiff-specific disclosure check until lookup, takeover, and diff calculation finish.
+- `hideDiffValuesUnlessOwned` preserves values only when the live object has the exact expected AppliedWork owner reference.
+- Focused tests cover the ownership matrix and exercise unmanaged ReportDiff and takeover-refusal paths through complete manifest processing.
+- Integration expectations retain all changed paths while omitting values for missing, takeover-disabled, and takeover-refused resources.
+
+## Changes Made
+
+- Added the ReportDiff post-processing policy in `pkg/controllers/workapplier/process.go`.
+- Added focused policy and behavioral tests in `pkg/controllers/workapplier/process_test.go`.
+- Updated work-applier integration expectations for resources Fleet does not own.
+
+## Validation
+
+- Focused ownership-policy tests pass.
+- All ReportDiff integration contexts pass.
+- Apply-mode partial/full comparison takeover-refusal and strategy-switch integration contexts pass.
+- `go vet ./pkg/controllers/workapplier`, editor diagnostics, and `git diff --check` pass.
+- The unfiltered package run reached the existing 10-minute Go test timeout while starting a later integration case; no assertion failure was reported. The changed contexts were rerun directly and passed.
+- Published for review as https://github.com/kubefleet-dev/kubefleet/pull/872.
+
+## Before/After Comparison
+
+- Before: ReportDiff can include raw values for resources Fleet has not taken over.
+- After: Unowned ReportDiff results identify changed paths without disclosing values.
+
+## References
+
+- `pkg/controllers/workapplier/process.go`: manifest processing, takeover, ReportDiff, and ownership checks.
+- `pkg/controllers/workapplier/process_test.go`: focused work-applier policy tests.
+- Related defense in depth: kubefleet-dev/kubefleet#867.
+
+## Success Criteria
+
+- Exact AppliedWork ownership is the only condition that preserves ReportDiff values.
+- All unowned ReportDiff paths omit both member and hub values.
+- Tests and repository checks pass, and the change is published as an independent PR.

--- a/pkg/controllers/workapplier/backoff_integration_test.go
+++ b/pkg/controllers/workapplier/backoff_integration_test.go
@@ -144,9 +144,7 @@ var _ = Describe("exponential backoff", func() {
 						ObservedInMemberClusterGeneration: ptr.To(int64(0)),
 						ObservedDiffs: []fleetv1beta1.PatchDetail{
 							{
-								Path:          fmt.Sprintf("/metadata/labels/%s", dummyLabelKey),
-								ValueInMember: dummyLabelValue2,
-								ValueInHub:    dummyLabelValue1,
+										Path: fmt.Sprintf("/metadata/labels/%s", dummyLabelKey),
 							},
 						},
 					},

--- a/pkg/controllers/workapplier/controller_integration_test.go
+++ b/pkg/controllers/workapplier/controller_integration_test.go
@@ -3023,9 +3023,7 @@ var _ = Describe("drift detection and takeover", func() {
 						ObservedInMemberClusterGeneration: &regularDeploy.Generation,
 						ObservedDiffs: []fleetv1beta1.PatchDetail{
 							{
-								Path:          "/spec/replicas",
-								ValueInMember: "2",
-								ValueInHub:    "1",
+								Path: "/spec/replicas",
 							},
 						},
 					},
@@ -3255,15 +3253,13 @@ var _ = Describe("drift detection and takeover", func() {
 						ObservedInMemberClusterGeneration: &regularNS.Generation,
 						ObservedDiffs: []fleetv1beta1.PatchDetail{
 							{
-								Path:          "/metadata/labels/foo",
-								ValueInMember: dummyLabelValue1,
+								Path: "/metadata/labels/foo",
 							},
 							// TO-DO (chenyu1): This is a namespace specific field; consider
 							// if this should be added as an exception which allows ignoring
 							// this diff automatically.
 							{
-								Path:          "/spec/finalizers",
-								ValueInMember: "[kubernetes]",
+								Path: "/spec/finalizers",
 							},
 						},
 					},
@@ -3289,36 +3285,20 @@ var _ = Describe("drift detection and takeover", func() {
 					DiffDetails: &fleetv1beta1.DiffDetails{
 						ObservedInMemberClusterGeneration: &regularDeploy.Generation,
 						ObservedDiffs: []fleetv1beta1.PatchDetail{
-							{Path: "/spec/progressDeadlineSeconds", ValueInMember: "600"},
-							{
-								Path:          "/spec/replicas",
-								ValueInMember: "2",
-								ValueInHub:    "1",
-							},
-							{Path: "/spec/revisionHistoryLimit", ValueInMember: "10"},
-							{
-								Path:          "/spec/strategy/rollingUpdate",
-								ValueInMember: "map[maxSurge:25% maxUnavailable:25%]",
-							},
-							{Path: "/spec/strategy/type", ValueInMember: "RollingUpdate"},
-							{
-								Path:          "/spec/template/spec/containers/0/imagePullPolicy",
-								ValueInMember: "Always",
-							},
-							{Path: "/spec/template/spec/containers/0/ports/0/protocol", ValueInMember: "TCP"},
-							{
-								Path:          "/spec/template/spec/containers/0/terminationMessagePath",
-								ValueInMember: "/dev/termination-log",
-							},
-							{
-								Path:          "/spec/template/spec/containers/0/terminationMessagePolicy",
-								ValueInMember: "File",
-							},
-							{Path: "/spec/template/spec/dnsPolicy", ValueInMember: "ClusterFirst"},
-							{Path: "/spec/template/spec/restartPolicy", ValueInMember: "Always"},
-							{Path: "/spec/template/spec/schedulerName", ValueInMember: "default-scheduler"},
-							{Path: "/spec/template/spec/securityContext", ValueInMember: "map[]"},
-							{Path: "/spec/template/spec/terminationGracePeriodSeconds", ValueInMember: "30"},
+							{Path: "/spec/progressDeadlineSeconds"},
+							{Path: "/spec/replicas"},
+							{Path: "/spec/revisionHistoryLimit"},
+							{Path: "/spec/strategy/rollingUpdate"},
+							{Path: "/spec/strategy/type"},
+							{Path: "/spec/template/spec/containers/0/imagePullPolicy"},
+							{Path: "/spec/template/spec/containers/0/ports/0/protocol"},
+							{Path: "/spec/template/spec/containers/0/terminationMessagePath"},
+							{Path: "/spec/template/spec/containers/0/terminationMessagePolicy"},
+							{Path: "/spec/template/spec/dnsPolicy"},
+							{Path: "/spec/template/spec/restartPolicy"},
+							{Path: "/spec/template/spec/schedulerName"},
+							{Path: "/spec/template/spec/securityContext"},
+							{Path: "/spec/template/spec/terminationGracePeriodSeconds"},
 						},
 					},
 				},
@@ -6145,8 +6125,7 @@ var _ = Describe("report diff", func() {
 					DiffDetails: &fleetv1beta1.DiffDetails{
 						ObservedDiffs: []fleetv1beta1.PatchDetail{
 							{
-								Path:       "/",
-								ValueInHub: "(the whole object)",
+								Path: "/",
 							},
 						},
 					},
@@ -6680,9 +6659,7 @@ var _ = Describe("report diff", func() {
 					DiffDetails: &fleetv1beta1.DiffDetails{
 						ObservedDiffs: []fleetv1beta1.PatchDetail{
 							{
-								Path:          "/spec/replicas",
-								ValueInHub:    "1",
-								ValueInMember: "2",
+								Path: "/spec/replicas",
 							},
 						},
 						ObservedInMemberClusterGeneration: ptr.To(int64(1)),
@@ -6808,8 +6785,7 @@ var _ = Describe("report diff", func() {
 					DiffDetails: &fleetv1beta1.DiffDetails{
 						ObservedDiffs: []fleetv1beta1.PatchDetail{
 							{
-								Path:       "/",
-								ValueInHub: "(the whole object)",
+								Path: "/",
 							},
 						},
 					},
@@ -6968,14 +6944,10 @@ var _ = Describe("report diff", func() {
 						ObservedInMemberClusterGeneration: &regularJob.Generation,
 						ObservedDiffs: []fleetv1beta1.PatchDetail{
 							{
-								Path:          "/spec/completions",
-								ValueInMember: "2",
-								ValueInHub:    "3",
+								Path: "/spec/completions",
 							},
 							{
-								Path:          "/spec/template/spec/containers/0/image",
-								ValueInMember: "busybox",
-								ValueInHub:    "busybox:v0.0.1",
+								Path: "/spec/template/spec/containers/0/image",
 							},
 						},
 					},
@@ -7390,9 +7362,7 @@ var _ = Describe("report diff", func() {
 						ObservedInMemberClusterGeneration: &regularCM.Generation,
 						ObservedDiffs: []fleetv1beta1.PatchDetail{
 							{
-								Path:          fmt.Sprintf("/data/%s", dummyLabelKey),
-								ValueInMember: dummyLabelValue2,
-								ValueInHub:    dummyLabelValue1,
+								Path: fmt.Sprintf("/data/%s", dummyLabelKey),
 							},
 						},
 					},
@@ -7419,9 +7389,7 @@ var _ = Describe("report diff", func() {
 						ObservedInMemberClusterGeneration: &regularSecret.Generation,
 						ObservedDiffs: []fleetv1beta1.PatchDetail{
 							{
-								Path:          fmt.Sprintf("/data/%s", dummyLabelKey),
-								ValueInHub:    "(redacted for security reasons)",
-								ValueInMember: "(redacted for security reasons)",
+								Path: fmt.Sprintf("/data/%s", dummyLabelKey),
 							},
 						},
 					},
@@ -7479,8 +7447,7 @@ var _ = Describe("report diff", func() {
 						ObservedInMemberClusterGeneration: &regularNS.Generation,
 						ObservedDiffs: []fleetv1beta1.PatchDetail{
 							{
-								Path:          "/spec/finalizers",
-								ValueInMember: "[kubernetes]",
+								Path: "/spec/finalizers",
 							},
 						},
 					},
@@ -7507,13 +7474,10 @@ var _ = Describe("report diff", func() {
 						ObservedInMemberClusterGeneration: &regularCM.Generation,
 						ObservedDiffs: []fleetv1beta1.PatchDetail{
 							{
-								Path:          fmt.Sprintf("/data/%s", dummyLabelKey),
-								ValueInMember: dummyLabelValue2,
-								ValueInHub:    dummyLabelValue1,
+								Path: fmt.Sprintf("/data/%s", dummyLabelKey),
 							},
 							{
-								Path:          fmt.Sprintf("/metadata/labels/%s", dummyLabelKey),
-								ValueInMember: dummyLabelValue1,
+								Path: fmt.Sprintf("/metadata/labels/%s", dummyLabelKey),
 							},
 						},
 					},
@@ -7540,17 +7504,13 @@ var _ = Describe("report diff", func() {
 						ObservedInMemberClusterGeneration: &regularSecret.Generation,
 						ObservedDiffs: []fleetv1beta1.PatchDetail{
 							{
-								Path:          fmt.Sprintf("/data/%s", dummyLabelKey),
-								ValueInHub:    "(redacted for security reasons)",
-								ValueInMember: "(redacted for security reasons)",
+								Path: fmt.Sprintf("/data/%s", dummyLabelKey),
 							},
 							{
-								Path:          fmt.Sprintf("/data/%s", "fooStr"),
-								ValueInMember: "(redacted for security reasons)",
+								Path: fmt.Sprintf("/data/%s", "fooStr"),
 							},
 							{
-								Path:          "/type",
-								ValueInMember: "Opaque",
+								Path: "/type",
 							},
 						},
 					},
@@ -8540,9 +8500,7 @@ var _ = Describe("handling different apply strategies", func() {
 						ObservedInMemberClusterGeneration: ptr.To(int64(1)),
 						ObservedDiffs: []fleetv1beta1.PatchDetail{
 							{
-								Path:          "/spec/replicas",
-								ValueInMember: "2",
-								ValueInHub:    "1",
+								Path: "/spec/replicas",
 							},
 						},
 					},

--- a/pkg/controllers/workapplier/process.go
+++ b/pkg/controllers/workapplier/process.go
@@ -116,6 +116,7 @@ func (r *Reconciler) processOneManifest(
 ) {
 	workRef := klog.KObj(work)
 	manifestObjRef := klog.KObj(bundle.manifestObj)
+	defer hideDiffValuesUnlessOwned(bundle, expectedAppliedWorkOwnerRef)
 	// Note (chenyu1): Fleet does not track references for objects in the member cluster as
 	// the references should be the same as those of the manifest objects, provided that Fleet
 	// does not support objects with generate names for now.
@@ -199,6 +200,17 @@ func (r *Reconciler) processOneManifest(
 	bundle.applyOrReportDiffResTyp = ApplyOrReportDiffResTypeApplied
 	klog.V(2).InfoS("Manifest processing completed",
 		"manifestObj", manifestObjRef, "GVR", *bundle.gvr, "work", workRef)
+}
+
+func hideDiffValuesUnlessOwned(bundle *manifestProcessingBundle, expectedAppliedWorkOwnerRef *metav1.OwnerReference) {
+	if bundle.inMemberClusterObj != nil && canApplyWithOwnership(bundle.inMemberClusterObj, expectedAppliedWorkOwnerRef) {
+		return
+	}
+
+	for idx := range bundle.diffs {
+		bundle.diffs[idx].ValueInMember = ""
+		bundle.diffs[idx].ValueInHub = ""
+	}
 }
 
 // findInMemberClusterObjectFor attempts to find the corresponding object in the member cluster

--- a/pkg/controllers/workapplier/process_test.go
+++ b/pkg/controllers/workapplier/process_test.go
@@ -3,10 +3,13 @@ package workapplier
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/scheme"
 
 	fleetv1beta1 "github.com/kubefleet-dev/kubefleet/apis/placement/v1beta1"
 )
@@ -93,6 +96,130 @@ func TestShouldInitiateTakeOverAttempt(t *testing.T) {
 			shouldTakeOver := shouldInitiateTakeOverAttempt(tc.inMemberClusterObj, tc.applyStrategy, tc.expectedAppliedWorkOwnerRef)
 			if shouldTakeOver != tc.wantShouldTakeOver {
 				t.Errorf("shouldInitiateTakeOverAttempt() = %v, want %v", shouldTakeOver, tc.wantShouldTakeOver)
+			}
+		})
+	}
+}
+
+func TestHideDiffValuesUnlessOwned(t *testing.T) {
+	ownedObj := &unstructured.Unstructured{}
+	ownedObj.SetOwnerReferences([]metav1.OwnerReference{*appliedWorkOwnerRef})
+
+	ownedByAnotherAppliedWorkObj := &unstructured.Unstructured{}
+	ownedByAnotherAppliedWorkObj.SetOwnerReferences([]metav1.OwnerReference{
+		{
+			APIVersion: appliedWorkOwnerRef.APIVersion,
+			Kind:       appliedWorkOwnerRef.Kind,
+			Name:       "another-work",
+			UID:        "another-uid",
+		},
+	})
+
+	testCases := []struct {
+		name               string
+		inMemberClusterObj *unstructured.Unstructured
+		wantDiffs          []fleetv1beta1.PatchDetail
+	}{
+		{
+			name:               "owned by expected AppliedWork",
+			inMemberClusterObj: ownedObj,
+			wantDiffs: []fleetv1beta1.PatchDetail{
+				{Path: "/spec/replicas", ValueInMember: "1", ValueInHub: "2"},
+			},
+		},
+		{
+			name: "object does not exist",
+			wantDiffs: []fleetv1beta1.PatchDetail{
+				{Path: "/spec/replicas"},
+			},
+		},
+		{
+			name:               "object is not owned",
+			inMemberClusterObj: &unstructured.Unstructured{},
+			wantDiffs: []fleetv1beta1.PatchDetail{
+				{Path: "/spec/replicas"},
+			},
+		},
+		{
+			name:               "object is owned by another AppliedWork",
+			inMemberClusterObj: ownedByAnotherAppliedWorkObj,
+			wantDiffs: []fleetv1beta1.PatchDetail{
+				{Path: "/spec/replicas"},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			bundle := &manifestProcessingBundle{
+				inMemberClusterObj: tc.inMemberClusterObj,
+				diffs: []fleetv1beta1.PatchDetail{
+					{Path: "/spec/replicas", ValueInMember: "1", ValueInHub: "2"},
+				},
+			}
+
+			hideDiffValuesUnlessOwned(bundle, appliedWorkOwnerRef)
+
+			if diff := cmp.Diff(bundle.diffs, tc.wantDiffs); diff != "" {
+				t.Errorf("hideDiffValuesUnlessOwned() diff mismatch (-got, +want):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestProcessOneManifestHidesDiffValuesForUnownedObject(t *testing.T) {
+	testCases := []struct {
+		name       string
+		strategy   *fleetv1beta1.ApplyStrategy
+		wantResult ManifestProcessingApplyOrReportDiffResultType
+	}{
+		{
+			name: "report diff without takeover",
+			strategy: &fleetv1beta1.ApplyStrategy{
+				Type:             fleetv1beta1.ApplyStrategyTypeReportDiff,
+				WhenToTakeOver:   fleetv1beta1.WhenToTakeOverTypeNever,
+				ComparisonOption: fleetv1beta1.ComparisonOptionTypeFullComparison,
+			},
+			wantResult: ApplyOrReportDiffResTypeFoundDiff,
+		},
+		{
+			name: "diff blocks takeover",
+			strategy: &fleetv1beta1.ApplyStrategy{
+				Type:             fleetv1beta1.ApplyStrategyTypeClientSideApply,
+				WhenToTakeOver:   fleetv1beta1.WhenToTakeOverTypeIfNoDiff,
+				ComparisonOption: fleetv1beta1.ComparisonOptionTypeFullComparison,
+			},
+			wantResult: ApplyOrReportDiffResTypeFailedToTakeOver,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			inMemberClusterObj := nsUnstructured.DeepCopy()
+			inMemberClusterObj.SetLabels(map[string]string{"sensitive": "member-value"})
+			r := &Reconciler{
+				spokeDynamicClient: dynamicfake.NewSimpleDynamicClient(scheme.Scheme, inMemberClusterObj),
+			}
+			bundle := &manifestProcessingBundle{
+				manifestObj: nsUnstructured.DeepCopy(),
+				gvr:         &nsGVR,
+			}
+			work := &fleetv1beta1.Work{
+				Spec: fleetv1beta1.WorkSpec{ApplyStrategy: tc.strategy},
+			}
+
+			r.processOneManifest(t.Context(), bundle, work, appliedWorkOwnerRef)
+
+			if bundle.applyOrReportDiffResTyp != tc.wantResult {
+				t.Fatalf("processOneManifest() result = %s, want %s", bundle.applyOrReportDiffResTyp, tc.wantResult)
+			}
+			if len(bundle.diffs) == 0 {
+				t.Fatal("processOneManifest() reported no diffs, want at least one path")
+			}
+			for _, diff := range bundle.diffs {
+				if diff.ValueInMember != "" || diff.ValueInHub != "" {
+					t.Errorf("processOneManifest() diff at path %q contains values: member=%q, hub=%q", diff.Path, diff.ValueInMember, diff.ValueInHub)
+				}
 			}
 		})
 	}

--- a/test/e2e/actuals_test.go
+++ b/test/e2e/actuals_test.go
@@ -1637,8 +1637,7 @@ func buildPerClusterPlacementStatusesAndHasOverrides(
 						},
 						ObservedDiffs: []placementv1beta1.PatchDetail{
 							{
-								Path:       "/",
-								ValueInHub: "(the whole object)",
+								Path: "/",
 							},
 						},
 					},
@@ -1652,8 +1651,7 @@ func buildPerClusterPlacementStatusesAndHasOverrides(
 						},
 						ObservedDiffs: []placementv1beta1.PatchDetail{
 							{
-								Path:       "/",
-								ValueInHub: "(the whole object)",
+								Path: "/",
 							},
 						},
 					})

--- a/test/e2e/api_progression_test.go
+++ b/test/e2e/api_progression_test.go
@@ -174,9 +174,7 @@ var _ = Describe("takeover, drift detection, and reportDiff mode (v1beta1 to v1)
 									TargetClusterObservedGeneration: ptr.To(int64(0)),
 									ObservedDiffs: []placementv1.PatchDetail{
 										{
-											Path:          fmt.Sprintf("/metadata/labels/%s", managedDataFieldKey),
-											ValueInMember: managedDataFieldVal2,
-											ValueInHub:    managedDataFieldVal1,
+											Path: fmt.Sprintf("/metadata/labels/%s", managedDataFieldKey),
 										},
 									},
 								},
@@ -445,9 +443,7 @@ var _ = Describe("takeover, drift detection, and reportDiff mode (v1beta1 to v1)
 									TargetClusterObservedGeneration: ptr.To(int64(0)),
 									ObservedDiffs: []placementv1.PatchDetail{
 										{
-											Path:          fmt.Sprintf("/metadata/labels/%s", managedDataFieldKey),
-											ValueInMember: managedDataFieldVal2,
-											ValueInHub:    managedDataFieldVal1,
+											Path: fmt.Sprintf("/metadata/labels/%s", managedDataFieldKey),
 										},
 									},
 								},

--- a/test/e2e/placement_apply_strategy_test.go
+++ b/test/e2e/placement_apply_strategy_test.go
@@ -1254,8 +1254,7 @@ var _ = Describe("switching apply strategies", func() {
 									TargetClusterObservedGeneration: ptr.To(int64(0)),
 									ObservedDiffs: []placementv1beta1.PatchDetail{
 										{
-											Path:          fmt.Sprintf("/metadata/labels/%s", unmanagedLabelKey),
-											ValueInMember: unmanagedLabelVal1,
+											Path: fmt.Sprintf("/metadata/labels/%s", unmanagedLabelKey),
 										},
 									},
 								},
@@ -1268,8 +1267,7 @@ var _ = Describe("switching apply strategies", func() {
 									},
 									ObservedDiffs: []placementv1beta1.PatchDetail{
 										{
-											Path:       "/",
-											ValueInHub: "(the whole object)",
+											Path: "/",
 										},
 									},
 								},
@@ -1288,8 +1286,7 @@ var _ = Describe("switching apply strategies", func() {
 									},
 									ObservedDiffs: []placementv1beta1.PatchDetail{
 										{
-											Path:       "/",
-											ValueInHub: "(the whole object)",
+											Path: "/",
 										},
 									},
 								},
@@ -1302,8 +1299,7 @@ var _ = Describe("switching apply strategies", func() {
 									},
 									ObservedDiffs: []placementv1beta1.PatchDetail{
 										{
-											Path:       "/",
-											ValueInHub: "(the whole object)",
+											Path: "/",
 										},
 									},
 								},

--- a/test/e2e/placement_drift_diff_test.go
+++ b/test/e2e/placement_drift_diff_test.go
@@ -214,9 +214,7 @@ var _ = Describe("take over existing resources", func() {
 									TargetClusterObservedGeneration: ptr.To(int64(0)),
 									ObservedDiffs: []placementv1beta1.PatchDetail{
 										{
-											Path:          "/data/data",
-											ValueInMember: managedDataFieldVal1,
-											ValueInHub:    "test",
+											Path: "/data/data",
 										},
 									},
 								},
@@ -398,8 +396,7 @@ var _ = Describe("take over existing resources", func() {
 									TargetClusterObservedGeneration: ptr.To(int64(0)),
 									ObservedDiffs: []placementv1beta1.PatchDetail{
 										{
-											Path:          fmt.Sprintf("/metadata/labels/%s", unmanagedLabelKey),
-											ValueInMember: unmanagedLabelVal1,
+											Path: fmt.Sprintf("/metadata/labels/%s", unmanagedLabelKey),
 										},
 									},
 								},
@@ -413,9 +410,7 @@ var _ = Describe("take over existing resources", func() {
 									TargetClusterObservedGeneration: ptr.To(int64(0)),
 									ObservedDiffs: []placementv1beta1.PatchDetail{
 										{
-											Path:          "/data/data",
-											ValueInMember: managedDataFieldVal1,
-											ValueInHub:    "test",
+											Path: "/data/data",
 										},
 									},
 								},
@@ -1107,8 +1102,7 @@ var _ = Describe("report diff mode", func() {
 									TargetClusterObservedGeneration: ptr.To(int64(0)),
 									ObservedDiffs: []placementv1beta1.PatchDetail{
 										{
-											Path:          fmt.Sprintf("/metadata/labels/%s", unmanagedLabelKey),
-											ValueInMember: unmanagedLabelVal1,
+											Path: fmt.Sprintf("/metadata/labels/%s", unmanagedLabelKey),
 										},
 									},
 								},
@@ -1122,9 +1116,7 @@ var _ = Describe("report diff mode", func() {
 									TargetClusterObservedGeneration: ptr.To(int64(0)),
 									ObservedDiffs: []placementv1beta1.PatchDetail{
 										{
-											Path:          "/data/data",
-											ValueInMember: managedDataFieldVal1,
-											ValueInHub:    "test",
+											Path: "/data/data",
 										},
 									},
 								},
@@ -1144,8 +1136,7 @@ var _ = Describe("report diff mode", func() {
 									},
 									ObservedDiffs: []placementv1beta1.PatchDetail{
 										{
-											Path:       "/",
-											ValueInHub: "(the whole object)",
+											Path: "/",
 										},
 									},
 								},
@@ -1158,8 +1149,7 @@ var _ = Describe("report diff mode", func() {
 									},
 									ObservedDiffs: []placementv1beta1.PatchDetail{
 										{
-											Path:       "/",
-											ValueInHub: "(the whole object)",
+											Path: "/",
 										},
 									},
 								},
@@ -1179,8 +1169,7 @@ var _ = Describe("report diff mode", func() {
 									},
 									ObservedDiffs: []placementv1beta1.PatchDetail{
 										{
-											Path:       "/",
-											ValueInHub: "(the whole object)",
+											Path: "/",
 										},
 									},
 								},
@@ -1193,8 +1182,7 @@ var _ = Describe("report diff mode", func() {
 									},
 									ObservedDiffs: []placementv1beta1.PatchDetail{
 										{
-											Path:       "/",
-											ValueInHub: "(the whole object)",
+											Path: "/",
 										},
 									},
 								},
@@ -1555,9 +1543,7 @@ var _ = Describe("mixed diff and drift reportings", Ordered, func() {
 								TargetClusterObservedGeneration: ptr.To(int64(1)),
 								ObservedDiffs: []placementv1beta1.PatchDetail{
 									{
-										Path:          "/spec/replicas",
-										ValueInMember: "2",
-										ValueInHub:    "1",
+										Path: "/spec/replicas",
 									},
 								},
 							},
@@ -1648,9 +1634,7 @@ var _ = Describe("mixed diff and drift reportings", Ordered, func() {
 								TargetClusterObservedGeneration: ptr.To(int64(0)),
 								ObservedDiffs: []placementv1beta1.PatchDetail{
 									{
-										Path:          fmt.Sprintf("/metadata/labels/%s", managedDataFieldKey),
-										ValueInMember: managedDataFieldVal2,
-										ValueInHub:    managedDataFieldVal1,
+										Path: fmt.Sprintf("/metadata/labels/%s", managedDataFieldKey),
 									},
 								},
 							},

--- a/test/e2e/resource_placement_apply_strategy_test.go
+++ b/test/e2e/resource_placement_apply_strategy_test.go
@@ -1287,8 +1287,7 @@ var _ = Describe("validating resource placement using different apply strategies
 										TargetClusterObservedGeneration: ptr.To(int64(0)),
 										ObservedDiffs: []placementv1beta1.PatchDetail{
 											{
-												Path:          fmt.Sprintf("/metadata/labels/%s", unmanagedLabelKey),
-												ValueInMember: unmanagedLabelVal1,
+												Path: fmt.Sprintf("/metadata/labels/%s", unmanagedLabelKey),
 											},
 										},
 									},
@@ -1308,8 +1307,7 @@ var _ = Describe("validating resource placement using different apply strategies
 										},
 										ObservedDiffs: []placementv1beta1.PatchDetail{
 											{
-												Path:       "/",
-												ValueInHub: "(the whole object)",
+												Path: "/",
 											},
 										},
 									},

--- a/test/e2e/resource_placement_drift_diff_test.go
+++ b/test/e2e/resource_placement_drift_diff_test.go
@@ -277,9 +277,7 @@ var _ = Describe("take over existing resources using RP", Label("resourceplaceme
 									TargetClusterObservedGeneration: ptr.To(int64(0)),
 									ObservedDiffs: []placementv1beta1.PatchDetail{
 										{
-											Path:          "/data/data",
-											ValueInMember: managedDataFieldVal1,
-											ValueInHub:    "test",
+											Path: "/data/data",
 										},
 									},
 								},
@@ -467,9 +465,7 @@ var _ = Describe("take over existing resources using RP", Label("resourceplaceme
 									TargetClusterObservedGeneration: ptr.To(int64(0)),
 									ObservedDiffs: []placementv1beta1.PatchDetail{
 										{
-											Path:          "/data/data",
-											ValueInMember: managedDataFieldVal1,
-											ValueInHub:    "test",
+											Path: "/data/data",
 										},
 									},
 								},
@@ -483,8 +479,7 @@ var _ = Describe("take over existing resources using RP", Label("resourceplaceme
 									TargetClusterObservedGeneration: ptr.To(int64(0)),
 									ObservedDiffs: []placementv1beta1.PatchDetail{
 										{
-											Path:          fmt.Sprintf("/metadata/labels/%s", unmanagedLabelKey),
-											ValueInMember: unmanagedLabelVal1,
+											Path: fmt.Sprintf("/metadata/labels/%s", unmanagedLabelKey),
 										},
 									},
 								},
@@ -1306,9 +1301,7 @@ var _ = Describe("report diff mode using RP", Label("resourceplacement"), func()
 									TargetClusterObservedGeneration: ptr.To(int64(0)),
 									ObservedDiffs: []placementv1beta1.PatchDetail{
 										{
-											Path:          "/data/data",
-											ValueInMember: managedDataFieldVal1,
-											ValueInHub:    "test",
+											Path: "/data/data",
 										},
 									},
 								},
@@ -1322,8 +1315,7 @@ var _ = Describe("report diff mode using RP", Label("resourceplacement"), func()
 									TargetClusterObservedGeneration: ptr.To(int64(0)),
 									ObservedDiffs: []placementv1beta1.PatchDetail{
 										{
-											Path:          fmt.Sprintf("/metadata/labels/%s", unmanagedLabelKey),
-											ValueInMember: unmanagedLabelVal1,
+											Path: fmt.Sprintf("/metadata/labels/%s", unmanagedLabelKey),
 										},
 									},
 								},
@@ -1344,8 +1336,7 @@ var _ = Describe("report diff mode using RP", Label("resourceplacement"), func()
 									},
 									ObservedDiffs: []placementv1beta1.PatchDetail{
 										{
-											Path:       "/",
-											ValueInHub: "(the whole object)",
+											Path: "/",
 										},
 									},
 								},
@@ -1358,8 +1349,7 @@ var _ = Describe("report diff mode using RP", Label("resourceplacement"), func()
 									},
 									ObservedDiffs: []placementv1beta1.PatchDetail{
 										{
-											Path:       "/",
-											ValueInHub: "(the whole object)",
+											Path: "/",
 										},
 									},
 								},
@@ -1380,8 +1370,7 @@ var _ = Describe("report diff mode using RP", Label("resourceplacement"), func()
 									},
 									ObservedDiffs: []placementv1beta1.PatchDetail{
 										{
-											Path:       "/",
-											ValueInHub: "(the whole object)",
+											Path: "/",
 										},
 									},
 								},
@@ -1394,8 +1383,7 @@ var _ = Describe("report diff mode using RP", Label("resourceplacement"), func()
 									},
 									ObservedDiffs: []placementv1beta1.PatchDetail{
 										{
-											Path:       "/",
-											ValueInHub: "(the whole object)",
+											Path: "/",
 										},
 									},
 								},
@@ -1805,9 +1793,7 @@ var _ = Describe("mixed diff and drift reportings using RP", Ordered, Label("res
 								TargetClusterObservedGeneration: ptr.To(int64(1)),
 								ObservedDiffs: []placementv1beta1.PatchDetail{
 									{
-										Path:          "/spec/replicas",
-										ValueInMember: "2",
-										ValueInHub:    "1",
+										Path: "/spec/replicas",
 									},
 								},
 							},


### PR DESCRIPTION
### Description of your changes

Configuration-diff results can include member and hub values before Fleet owns the live member-cluster resource. This allows ReportDiff, takeover-disabled, and takeover-refused flows to disclose values from unmanaged resources.

This change reports raw diff values only when the live object has the exact expected AppliedWork owner reference. Before ownership is established, status still reports every changed path and observed generation, but omits both `valueInMember` and `valueInHub`. Successfully taken-over and already-owned resources continue to report values. Drift details are unchanged.

This is an independent defense-in-depth change related to #867. That PR protects the hub-side namespace authorization boundary; AppliedWork ownership alone does not authorize namespace users to read cluster-scoped CRPS values.

Related to #867

I have:

- [ ] Associated this change with a known KubeFleet Issue (Bug, Feature, etc).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- Focused ownership-policy unit tests pass.
- All ReportDiff integration contexts pass.
- Partial/full comparison takeover-refusal and strategy-switch integration contexts pass.
- `go vet ./pkg/controllers/workapplier` and `git diff --check` pass.
- The unfiltered package run reached its existing 10-minute timeout while starting a later integration case; no assertion failure was reported, and all changed contexts were rerun directly and passed.

### Special notes for your reviewer

The ownership check runs after takeover processing, so a successful takeover may expose values in the same reconciliation while a refused takeover cannot.
