### PR TITLE
ci: ignore authenticated Slack links in the markdown link check

### DIFF
--- a/.github/workflows/markdown.links.config.json
+++ b/.github/workflows/markdown.links.config.json
@@ -11,6 +11,9 @@
     "ignorePatterns": [
         {
             "pattern": "^mailto:"
+        },
+        {
+            "pattern": "^https://cloud-native\\.slack\\.com/archives/"
         }
     ]
 }


### PR DESCRIPTION
The README's Slack channel link (`cloud-native.slack.com/archives/...`) returns 403 to unauthenticated requests, so `markdown-link-check` fails on any PR that touches a markdown file and intermittently on `main`. The link is correct; the checker cannot follow it.

This ignores the `archives/` path the same way `mailto:` links are already ignored. Azure/fleet carries the same ignore (Azure/fleet@dbbe3c9c).

Currently blocking a green check on #822, #823, and #824.