### PR TITLE
fix: redact namespace-accessible placement values

### DIFF
--- a/.github/.copilot/breadcrumbs/2026-09-08-1511-crps-value-redaction.md
+++ b/.github/.copilot/breadcrumbs/2026-09-08-1511-crps-value-redaction.md
@@ -1,0 +1,30 @@
+# Redact values in namespace-accessible placement status
+
+## Requirements
+
+- Keep this PR independent from the namespace-to-cluster boundary fix in PR #867.
+- Redact non-empty `ValueInMember` and `ValueInHub` fields in namespaced `ClusterResourcePlacementStatus` objects.
+- Preserve drift and diff paths and empty-side semantics.
+- Preserve the full cluster-scoped `ClusterResourcePlacement` status.
+- Address Michael A. Yu's review comment by using an explanatory redaction marker instead of an empty string.
+
+## Plan
+
+- [x] Add focused tests for redacted member/hub values and empty-side preservation.
+- [x] Redact values in the existing CRP-to-CRPS copy path without relying on PR #867.
+- [x] Update shared integration assertions and served API documentation.
+- [x] Regenerate CRDs and run focused validation.
+- [x] Rewrite and push PR #886 as a standalone change based on `cncf/main`.
+
+## Decisions
+
+- Use the repository's established marker, `(redacted for security reasons)`, for consistency with Secret drift redaction.
+- Replace only non-empty values because an empty string indicates that the JSON path does not exist on that side.
+- Do not redact condition messages in this PR; its scope is limited to `ValueInMember` and `ValueInHub`.
+- Keep namespace-boundary filtering in PR #867 so either security change can be reviewed and merged independently.
+
+## Verification
+
+- The direct redaction unit test passes with Go 1.26.6.
+- Focused namespace status tests pass, the shared CRPS helper compiles, and `git diff --check` passes.
+

--- a/apis/placement/v1/clusterresourceplacement_types.go
+++ b/apis/placement/v1/clusterresourceplacement_types.go
@@ -1688,6 +1688,8 @@ func (rpl *ResourcePlacementList) GetPlacementObjs() []PlacementObj {
 
 // ClusterResourcePlacementStatus is a namespaced resource that mirrors the PlacementStatus of a corresponding
 // ClusterResourcePlacement object. This allows namespace-scoped access to cluster-scoped placement status.
+// Non-empty ValueInMember and ValueInHub fields in drift and diff details are replaced with
+// "(redacted for security reasons)" in the namespaced copy.
 // The LastUpdatedTime field is updated whenever the object is updated.
 //
 // This object will be created within the target namespace that contains resources being managed by the CRP.
@@ -1700,7 +1702,8 @@ type ClusterResourcePlacementStatus struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	// Source status copied from the corresponding ClusterResourcePlacement.
+	// Source status copied from the corresponding ClusterResourcePlacement, with non-empty member and hub values
+	// in drift and diff details redacted for security reasons.
 	// +kubebuilder:validation:Required
 	PlacementStatus `json:"sourceStatus,omitempty"`
 

--- a/apis/placement/v1beta1/clusterresourceplacement_types.go
+++ b/apis/placement/v1beta1/clusterresourceplacement_types.go
@@ -1796,6 +1796,8 @@ func (rpl *ResourcePlacementList) GetPlacementObjs() []PlacementObj {
 
 // ClusterResourcePlacementStatus is a namespaced resource that mirrors the PlacementStatus of a corresponding
 // ClusterResourcePlacement object. This allows namespace-scoped access to cluster-scoped placement status.
+// Non-empty ValueInMember and ValueInHub fields in drift and diff details are replaced with
+// "(redacted for security reasons)" in the namespaced copy.
 // The LastUpdatedTime field is updated whenever the CRPS object is updated.
 //
 // This object will be created within the target namespace that contains resources being managed by the CRP.
@@ -1808,7 +1810,8 @@ type ClusterResourcePlacementStatus struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	// Source status copied from the corresponding ClusterResourcePlacement.
+	// Source status copied from the corresponding ClusterResourcePlacement, with non-empty member and hub values
+	// in drift and diff details redacted for security reasons.
 	// +kubebuilder:validation:Required
 	PlacementStatus `json:"sourceStatus,omitempty"`
 

--- a/config/crd/bases/placement.kubernetes-fleet.io_clusterresourceplacementstatuses.yaml
+++ b/config/crd/bases/placement.kubernetes-fleet.io_clusterresourceplacementstatuses.yaml
@@ -35,6 +35,8 @@ spec:
         description: |-
           ClusterResourcePlacementStatus is a namespaced resource that mirrors the PlacementStatus of a corresponding
           ClusterResourcePlacement object. This allows namespace-scoped access to cluster-scoped placement status.
+          Non-empty ValueInMember and ValueInHub fields in drift and diff details are replaced with
+          "(redacted for security reasons)" in the namespaced copy.
           The LastUpdatedTime field is updated whenever the object is updated.
 
           This object will be created within the target namespace that contains resources being managed by the CRP.
@@ -68,7 +70,9 @@ spec:
           metadata:
             type: object
           sourceStatus:
-            description: Source status copied from the corresponding ClusterResourcePlacement.
+            description: |-
+              Source status copied from the corresponding ClusterResourcePlacement, with non-empty member and hub values
+              in drift and diff details redacted for security reasons.
             properties:
               conditions:
                 description: |-
@@ -682,6 +686,8 @@ spec:
         description: |-
           ClusterResourcePlacementStatus is a namespaced resource that mirrors the PlacementStatus of a corresponding
           ClusterResourcePlacement object. This allows namespace-scoped access to cluster-scoped placement status.
+          Non-empty ValueInMember and ValueInHub fields in drift and diff details are replaced with
+          "(redacted for security reasons)" in the namespaced copy.
           The LastUpdatedTime field is updated whenever the CRPS object is updated.
 
           This object will be created within the target namespace that contains resources being managed by the CRP.
@@ -715,7 +721,9 @@ spec:
           metadata:
             type: object
           sourceStatus:
-            description: Source status copied from the corresponding ClusterResourcePlacement.
+            description: |-
+              Source status copied from the corresponding ClusterResourcePlacement, with non-empty member and hub values
+              in drift and diff details redacted for security reasons.
             properties:
               conditions:
                 description: |-

--- a/pkg/controllers/placement/namespace_status_sync.go
+++ b/pkg/controllers/placement/namespace_status_sync.go
@@ -33,6 +33,7 @@ import (
 
 const (
 	noNamespaceResourceSelectorMsg = "NamespaceAccessible ClusterResourcePlacement doesn't specify a resource selector which selects a namespace"
+	redactedPatchValue             = "(redacted for security reasons)"
 
 	failedCRPSMessageFmt           = "Failed to create or update ClusterResourcePlacementStatus: %v"
 	successfulCRPSMessageFmt       = "Successfully created or updated ClusterResourcePlacementStatus in namespace '%s'"
@@ -86,6 +87,15 @@ func isNamespaceAccessibleCRP(placementObj placementv1beta1.PlacementObj) bool {
 // Returns a filtered copy of the status with all conditions except StatusSynced.
 func filterStatusSyncedCondition(status *placementv1beta1.PlacementStatus) *placementv1beta1.PlacementStatus {
 	filteredStatus := status.DeepCopy()
+	for idx := range filteredStatus.PerClusterPlacementStatuses {
+		clusterStatus := &filteredStatus.PerClusterPlacementStatuses[idx]
+		for placementIdx := range clusterStatus.DriftedPlacements {
+			redactPatchDetailValues(clusterStatus.DriftedPlacements[placementIdx].ObservedDrifts)
+		}
+		for placementIdx := range clusterStatus.DiffedPlacements {
+			redactPatchDetailValues(clusterStatus.DiffedPlacements[placementIdx].ObservedDiffs)
+		}
+	}
 
 	// Filter out the ClusterResourcePlacementStatusSynced condition.
 	filteredConditions := make([]metav1.Condition, 0, len(filteredStatus.Conditions))
@@ -97,6 +107,17 @@ func filterStatusSyncedCondition(status *placementv1beta1.PlacementStatus) *plac
 	filteredStatus.Conditions = filteredConditions
 
 	return filteredStatus
+}
+
+func redactPatchDetailValues(details []placementv1beta1.PatchDetail) {
+	for idx := range details {
+		if details[idx].ValueInMember != "" {
+			details[idx].ValueInMember = redactedPatchValue
+		}
+		if details[idx].ValueInHub != "" {
+			details[idx].ValueInHub = redactedPatchValue
+		}
+	}
 }
 
 // buildStatusSyncedCondition creates a StatusSynced condition based on the sync result.

--- a/pkg/controllers/placement/namespace_status_sync_test.go
+++ b/pkg/controllers/placement/namespace_status_sync_test.go
@@ -45,6 +45,67 @@ var (
 	}
 )
 
+func TestFilterStatusSyncedConditionRedactsPatchValues(t *testing.T) {
+	status := &placementv1beta1.PlacementStatus{
+		PerClusterPlacementStatuses: []placementv1beta1.PerClusterPlacementStatus{
+			{
+				DriftedPlacements: []placementv1beta1.DriftedResourcePlacement{
+					{
+						ObservedDrifts: []placementv1beta1.PatchDetail{
+							{Path: "/both", ValueInMember: "member-value", ValueInHub: "hub-value"},
+							{Path: "/hub-only", ValueInHub: "hub-value"},
+						},
+					},
+				},
+				DiffedPlacements: []placementv1beta1.DiffedResourcePlacement{
+					{
+						ObservedDiffs: []placementv1beta1.PatchDetail{
+							{Path: "/member-only", ValueInMember: "member-value"},
+						},
+					},
+				},
+			},
+		},
+		Conditions: []metav1.Condition{
+			{Type: string(placementv1beta1.ClusterResourcePlacementScheduledConditionType), Message: "preserved message"},
+			{Type: string(placementv1beta1.ClusterResourcePlacementStatusSyncedConditionType)},
+		},
+	}
+	originalStatus := status.DeepCopy()
+	want := &placementv1beta1.PlacementStatus{
+		PerClusterPlacementStatuses: []placementv1beta1.PerClusterPlacementStatus{
+			{
+				DriftedPlacements: []placementv1beta1.DriftedResourcePlacement{
+					{
+						ObservedDrifts: []placementv1beta1.PatchDetail{
+							{Path: "/both", ValueInMember: redactedPatchValue, ValueInHub: redactedPatchValue},
+							{Path: "/hub-only", ValueInHub: redactedPatchValue},
+						},
+					},
+				},
+				DiffedPlacements: []placementv1beta1.DiffedResourcePlacement{
+					{
+						ObservedDiffs: []placementv1beta1.PatchDetail{
+							{Path: "/member-only", ValueInMember: redactedPatchValue},
+						},
+					},
+				},
+			},
+		},
+		Conditions: []metav1.Condition{
+			{Type: string(placementv1beta1.ClusterResourcePlacementScheduledConditionType), Message: "preserved message"},
+		},
+	}
+
+	got := filterStatusSyncedCondition(status)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("filterStatusSyncedCondition() mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(originalStatus, status); diff != "" {
+		t.Errorf("filterStatusSyncedCondition() mutated source status (-want +got):\n%s", diff)
+	}
+}
+
 func TestHandleNamespaceAccessibleCRP(t *testing.T) {
 	testCases := []struct {
 		name              string

--- a/test/utils/crpstatussync/crp_status_sync.go
+++ b/test/utils/crpstatussync/crp_status_sync.go
@@ -14,6 +14,8 @@ import (
 	placementv1beta1 "github.com/kubefleet-dev/kubefleet/apis/placement/v1beta1"
 )
 
+const redactedPatchValue = "(redacted for security reasons)"
+
 var (
 	// Define comparison options for ignoring auto-generated and time-dependent fields.
 	crpsCmpOpts = []cmp.Option{
@@ -51,6 +53,7 @@ func CRPSStatusMatchesCRPActual(ctx context.Context, client client.Client, crpNa
 			}
 		}
 		expectedStatus.Conditions = filteredConditions
+		redactPlacementStatusPatchValues(expectedStatus)
 
 		wantCRPS := &placementv1beta1.ClusterResourcePlacementStatus{
 			ObjectMeta: metav1.ObjectMeta{
@@ -76,5 +79,28 @@ func CRPSStatusMatchesCRPActual(ctx context.Context, client client.Client, crpNa
 		}
 
 		return nil
+	}
+}
+
+func redactPlacementStatusPatchValues(status *placementv1beta1.PlacementStatus) {
+	for clusterIdx := range status.PerClusterPlacementStatuses {
+		clusterStatus := &status.PerClusterPlacementStatuses[clusterIdx]
+		for placementIdx := range clusterStatus.DriftedPlacements {
+			redactPatchDetails(clusterStatus.DriftedPlacements[placementIdx].ObservedDrifts)
+		}
+		for placementIdx := range clusterStatus.DiffedPlacements {
+			redactPatchDetails(clusterStatus.DiffedPlacements[placementIdx].ObservedDiffs)
+		}
+	}
+}
+
+func redactPatchDetails(details []placementv1beta1.PatchDetail) {
+	for idx := range details {
+		if details[idx].ValueInMember != "" {
+			details[idx].ValueInMember = redactedPatchValue
+		}
+		if details[idx].ValueInHub != "" {
+			details[idx].ValueInHub = redactedPatchValue
+		}
 	}
 }


### PR DESCRIPTION
### Description of your changes

This standalone change redacts drift and diff values copied into namespaced `ClusterResourcePlacementStatus` objects.

It:
- replaces non-empty `ValueInMember` and `ValueInHub` values with `(redacted for security reasons)`
- preserves empty fields so callers can still distinguish JSON paths that are absent on one side
- preserves drift and diff paths
- leaves condition messages unchanged
- leaves the full cluster-scoped `ClusterResourcePlacement` status unchanged
- updates the served API documentation and generated CRD descriptions

The explanatory marker addresses Michael A. Yu’s review comment on #867. This PR is independent from #867 and can be reviewed and merged in either order. If #867 merges first, a small conflict in the CRP-to-CRPS status helper may need resolution.

### How has this code been tested

- `go test ./pkg/controllers/placement -run TestFilterStatusSyncedConditionRedactsPatchValues -count=1`
- `go test ./pkg/controllers/placement -run TestHandleNamespaceAccessibleCRP -count=1`
- `go test ./pkg/controllers/placement -run TestValidateNamespaceSelectorConsistency -count=1`
- `go test ./test/utils/crpstatussync -count=1`
- `make manifests`
- `git diff --check`

Tests used the Go 1.26.6 toolchain required by `go.mod`.