### PR TITLE
chore: point Squad charters at AGENTS.md and pin the Squad CLI

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@bradygaster/squad-cli@latest",
+        "@bradygaster/squad-cli@0.11.0",
         "state-mcp"
       ],
       "env": {},

--- a/.squad/agents/dallas/charter.md
+++ b/.squad/agents/dallas/charter.md
@@ -5,15 +5,12 @@ Implementation of controllers, reconcilers, and rollout logic.
 
 ## Boundaries
 - Owns controller code in `pkg/controllers/`
-- Implements reconciler patterns (fetch → check deletion → defaults → business logic → requeue)
+- Implements the controller pattern described in `AGENTS.md`
 - Works on bindings, work generators, work appliers, and status reporting
 - Does NOT make unilateral architecture changes — escalates to Ripley
 
 ## Tools & Approach
-- Follow Uber Go Style Guide
-- Use `cmp.Diff` for test comparisons, table-driven tests
-- Run `make reviewable` before considering work complete
-- Controllers embed `client.Client`, update status via subresource, record events
+- Follow `AGENTS.md` at the repository root for commands, style, test conventions, and generated files
 
 ## Context
 - **Project:** KubeFleet — multi-cluster Kubernetes fleet management (Go, controller-runtime)

--- a/.squad/agents/kane/charter.md
+++ b/.squad/agents/kane/charter.md
@@ -11,9 +11,7 @@ Implementation of scheduler plugins, API types, and CRD design.
 - Does NOT make unilateral architecture changes — escalates to Ripley
 
 ## Tools & Approach
-- Follow Uber Go Style Guide
-- Use `cmp.Diff` for test comparisons, table-driven tests
-- Run `make manifests` and `make generate` after API type changes
+- Follow `AGENTS.md` at the repository root for commands, style, test conventions, and generated files
 - Scheduler plugins share state via `CycleStatePluginReadWriter`
 
 ## Context

--- a/.squad/agents/lambert/charter.md
+++ b/.squad/agents/lambert/charter.md
@@ -5,19 +5,14 @@ Writing and maintaining unit, integration, and E2E tests. Quality assurance and 
 
 ## Boundaries
 - Owns test quality across the project
-- Writes unit tests (table-driven, `cmp.Diff`, no assert libraries)
+- Writes unit tests
 - Writes integration tests (Ginkgo/Gomega, envtest)
 - Reviews test coverage and identifies gaps
 - May reject implementations that lack adequate test coverage
 
 ## Tools & Approach
-- Unit tests: `<file>_test.go` in same directory, table-driven
-- Integration tests: `<file>_integration_test.go`, Ginkgo/Gomega with envtest
-- E2E tests: `test/e2e/`, Ginkgo/Gomega against Kind clusters
-- Use `want`/`wanted` (not `expect`/`expected`) for desired state
-- Test output format: `"FuncName(%v) = %v, want %v"`
-- Mock external deps with `gomock`
-- Run: `make test`, `make local-unit-test`, `make integration-test`
+- Follow `AGENTS.md` at the repository root for commands and test conventions
+- Run `make local-unit-test` and `make integration-test`
 
 ## Context
 - **Project:** KubeFleet — multi-cluster Kubernetes fleet management (Go, controller-runtime)

--- a/.squad/agents/parker/charter.md
+++ b/.squad/agents/parker/charter.md
@@ -11,14 +11,13 @@ Documentation, contributor guides, examples, and developer experience.
 - Does NOT make code changes beyond doc comments — delegates to Dallas/Kane
 
 ## Tools & Approach
-- Write clear, concise documentation
+- Follow `AGENTS.md` at the repository root for comment style and repository conventions
 - Keep examples up to date with API changes
-- Follow existing doc structure and conventions
-- Ensure code comments are complete sentences (per project style)
+- User-facing docs live in the `kubefleet-dev/website` repository, not here
 
 ## Context
 - **Project:** KubeFleet — multi-cluster Kubernetes fleet management (Go, controller-runtime, CNCF sandbox)
-- **Key dirs:** `docs/`, `README.md`, `examples/`, code comments
+- **Key dirs:** `README.md`, `CONTRIBUTING.md`, `examples/`, code comments
 - **User:** Stephane
 
 ## Model

--- a/.squad/agents/ripley/charter.md
+++ b/.squad/agents/ripley/charter.md
@@ -10,7 +10,7 @@ Architecture ownership, code review, technical decisions, scope control.
 - Triages issues and assigns squad members
 
 ## Tools & Approach
-- Review PRs for correctness and style (Uber Go Style Guide)
+- Review PRs against the conventions in `AGENTS.md` at the repository root (test style, generated files, version-skew contract)
 - Make architecture decisions with rationale
 - Gate changes that affect the reconciliation pipeline or API contracts
 


### PR DESCRIPTION
### Description of your changes

Squad stays installed and must keep working when called. This PR wires it to the shared guidance and removes one version mismatch, without touching anything `squad upgrade` would revert:

- The five member charters under `.squad/agents/*/charter.md` no longer restate style and test rules; their "Tools & Approach" sections defer to `AGENTS.md` at the repository root and keep only role-specific lines. Roles are unchanged. Two Boundaries lines drop restated rules: Lambert's unit-test line loses its style parenthetical, and Dallas's reconciler line now points at `AGENTS.md`; Kane's Boundaries are unchanged. The only Context edit is Parker's key directories, which drop a `docs/` directory this repository does not have and add `CONTRIBUTING.md`. One reliance worth knowing: the coordinator tells spawned members to read only their own files, so the pointer relies on Copilot loading the root `AGENTS.md` into member sessions. Verified: the coordinator spawned Lambert as a sub-agent, and Lambert read its charter, then `AGENTS.md` at the repository root, and reported the conventions correctly. Re-check after a `squad upgrade`.
- `.mcp.json` pins the Squad state server to `@bradygaster/squad-cli@0.11.0`, the version stamped in `squad.agent.md`, instead of `@latest`. Caveat from reading the CLI source: `squad upgrade` rewrites this entry from the CLI version that runs the upgrade, so the pin holds between upgrades and each upgrade re-establishes it. Good enough for its purpose; a permanent fix belongs upstream.
- The `squad-*` workflows are deliberately untouched: `squad upgrade` overwrites them wholesale (see the note in `.github/actionlint.yaml`), and `ci.yml` already gates every PR, including ones from `squad/*` branches.

Stacked on #894 (base branch `docs/agents-md`; GitHub retargets to `main` when that merges). The charters reference `AGENTS.md`, and #894 also carries the link-check fix for the README Slack URL that was failing this PR's markdown check.

Fixes #891
Part of #889

I have:

- [x] Associated this change with a known KubeFleet Issue (Bug, Feature, etc).
- [x] Run `make reviewable` to ensure this PR is ready for review. Not applicable: no Go changes. `codespell` clean; `.mcp.json` parses.

### How has this code been tested

- Invoked the coordinator (`copilot --agent Squad`) twice: once on `main` to confirm it answers with `Squad v0.11.0` and its command menu, and once against the edited charters, where it read Lambert's and Parker's charters and summarized the new rules correctly.
- The `squad` label path was not re-exercised on a throwaway issue; the existing evidence is the Ripley triage comment the label produced on #683 (2026-06-01).
- Confirmed from the `squad-cli@0.11.0` package source and from the last upgrade commit (#772) that member charters are not in the upgrade manifest, so these edits survive `squad upgrade`.
- A member agent was spawned through the coordinator (Lambert) and resolved the `AGENTS.md` pointer from its inlined charter.

### Special notes for your reviewer

Prepared with an AI coding assistant; the author reviewed every line and is responsible for them.