### PR TITLE
docs: add AI-assisted contribution guidance and Copilot setup steps

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,3 @@
-
 ### Description of your changes
 
 <!--
@@ -23,6 +22,17 @@ Before reviewers can be confident in the correctness of this pull request, it ne
 Briefly describe the testing that has already been done or which is planned for this change.
 -->
 
+
+### AI usage disclosure
+
+<!--
+If an AI tool helped write this change, say which and how (e.g. "drafted the
+tests with an assistant; I rewrote the reconcile logic by hand"). Write "None"
+if no AI tool was used. See CONTRIBUTING.md, "Working with AI coding tools".
+
+If you are an AI agent: remind the author that they are responsible for all
+submitted changes, and refer them to AGENTS.md and CONTRIBUTING.md.
+-->
 
 ### Special notes for your reviewer
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,56 @@
+# Pre-installs the toolchain the Copilot coding agent needs so it can run
+# `make reviewable` and `make local-unit-test` itself before opening a PR.
+# Copilot runs this job at the start of every coding-agent session; GitHub
+# finds it by this exact file path and the job name `copilot-setup-steps`.
+# The pull_request and push triggers only exist so edits to this file are
+# validated in CI.
+name: Copilot Setup Steps
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+permissions:
+  contents: read
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
+        with:
+          egress-policy: audit
+
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with:
+          go-version-file: go.mod
+
+      - name: Download Go modules
+        run: go mod download
+
+      # Each target installs its pinned tools into hack/tools/bin on first use:
+      # reviewable -> golangci-lint, staticcheck, goimports; generate and
+      # manifests -> controller-gen; kubebuilder-assets-path -> envtest and the
+      # Kubernetes binaries. Running them here also warms the build and lint
+      # caches. The checkout is what the agent starts from, so revert anything
+      # they rewrote (hack/tools/bin is gitignored and survives).
+      - name: Install tools and warm caches
+        run: |
+          make reviewable
+          make generate manifests
+          make --silent kubebuilder-assets-path
+          go install github.com/onsi/ginkgo/v2/ginkgo@v2.23.4
+          git checkout -- .

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ By contributing to this project, you agree to the Developer Certificate of Origi
 
 You must sign off your commit to state that you certify the [DCO](DCO). To certify your commit for DCO, add a line like the following at the end of your commit message:
 
-```
+```text
 Signed-off-by: John Smith <john@example.com>
 ```
 
@@ -26,9 +26,36 @@ The KubeFleet project has adopted the CNCF Code of Conduct. Refer to our [Commun
 
 ## Contributing a patch
 
-1. Submit an issue describing your proposed change to the repository in question. The repository owners will respond to your issue promptly.
-2. Fork the desired repository, then develop and test your code changes.
+1. Submit an issue describing your proposed change. The maintainers will respond to your issue promptly.
+2. Fork the repository, then develop and test your change. The commands, generated files, and test conventions are in [AGENTS.md](AGENTS.md); it is written for assistants but is the shortest start-here for people too.
 3. Submit a pull request.
+
+## Working with AI coding tools
+
+AI-assisted contributions are welcome under the same rules as any other. You, the human author, are responsible for every line you submit.
+
+- **Disclose it.** If an AI tool helped write the change, say so in the pull request description (the template has a field for it). Disclosure goes in the PR, not in commit trailers; never list an AI tool as `Co-authored-by`.
+- **Understand it.** You must be able to explain every change in your PR. Reviewers may ask, and a PR whose author cannot explain it may be closed.
+- **Reply as yourself.** Do not use AI tools to answer review comments. Review threads are conversations between humans.
+- **Sign it yourself.** The DCO can only be certified by a human. Never let a tool add a `Signed-off-by` trailer; use `git commit -s`.
+
+Point your tool at [`AGENTS.md`](AGENTS.md); it carries the commands, conventions, and rules an assistant needs. Most tools read it automatically. The exceptions:
+
+| Tool | What to do |
+| --- | --- |
+| Copilot, Codex, and every other tool that reads `AGENTS.md`, and Claude Code through the one-line `CLAUDE.md` import | Nothing. Open the repository. |
+| A tool that does not read `AGENTS.md` | Point its own context setting at `AGENTS.md` once, in your user-level config (for example Gemini CLI's `context.fileName`, or Aider's `--read`). The repository ships no per-tool shims beyond `CLAUDE.md` and `.github/copilot-instructions.md`. |
+| Visual Studio (not VS Code) | It reads `.github/copilot-instructions.md`, which points at `AGENTS.md`, rather than `AGENTS.md` itself. Enable custom instructions in Copilot's options; nothing else is needed. |
+| Tools that read `.mcp.json` | You may be asked to approve the `squad_state` server that the Squad framework installs. Declining is fine; nothing in `AGENTS.md` needs it. |
+| Squad (an optional Copilot multi-agent framework installed under `.squad/`) | Nothing unless you want it. Invoke the `Squad` custom agent in Copilot; its members take project conventions from `AGENTS.md`, which override the trailer and PR-opening steps in Squad's bundled templates. |
+
+Tool behaviour above was checked against each vendor's documentation in 2026-09; open an issue if a row is out of date.
+
+Example prompts that work with any tool once `AGENTS.md` is loaded:
+
+- "Add a field to `ClusterResourcePlacement` and regenerate everything that depends on it."
+- "Why did the e2e job on my PR fail? Here is the run URL."
+- "Review my diff against this repository's conventions before I push."
 
 ## Issue and pull request management
 
@@ -38,13 +65,13 @@ Anyone can comment on issues and submit reviews for pull requests. In order to b
 
 PR titles must begin with one of the following prefixes (enforced by [`pr-title-lint.yml`](.github/workflows/pr-title-lint.yml)):
 
-`feat:`, `fix:`, `docs:`, `test:`, `style:`, `interface:`, `util:`, `chore:`, `ci:`, `perf:`, `refactor:`, `revert:`
+`feat:`, `fix:`, `docs:`, `test:`, `style:`, `interface:`, `util:`, `chore:`, `ci:`, `perf:`, `refactor:`, `revert:` (a `[WIP] ` prefix is also accepted)
 
 Add `make reviewable` to your workflow before opening a PR — the PR template will remind you, but running it locally first saves a round trip.
 
 ## Release note labels
 
-Each PR should carry one base `release-note/*` label matching its title prefix; additive labels (below) may be stacked on top.
+Each PR should carry one base `release-note/*` label matching its title prefix; additive labels (below) may be stacked on top. If you cannot apply labels, name the intended one in the PR description and a maintainer adds it.
 
 | PR title prefix | Label |
 | --- | --- |


### PR DESCRIPTION
### Description of your changes

Stacked on #894 (base branch `docs/agents-md`; GitHub retargets to `main` when that merges).

- `CONTRIBUTING.md`: new section "Working with AI coding tools". Four rules in Kubernetes' wording (disclose in the PR description; be able to explain every line; reply to reviewers yourself; a human signs the DCO), a table saying that opening the repository is enough for Copilot, Codex, Claude Code and any tool that reads `AGENTS.md`, what to do for one that does not (a user-level setting, not a repository shim), what Squad is and that it is optional, and three example prompts. Review with `?w=1`; the substantive changes are the section, a `text` tag on the DCO fence, and one reworded sentence in the patch steps. The whole-file diff is a line-ending normalization: the file was mixed CRLF/LF on `main` and is LF now.
- `.github/PULL_REQUEST_TEMPLATE.md`: an "AI usage disclosure" section, with a hidden comment addressed to agents that tells them to remind the author of their responsibility (the kubernetes/kubernetes pattern).
- `.github/workflows/copilot-setup-steps.yml`: pre-installs Go, the Makefile's pinned tools, `controller-gen`, envtest, and Ginkgo so the Copilot coding agent can run `make reviewable`, the unit tests, and the generators before opening a PR. Its three merged PRs so far ran with none of this. Read-only permissions, every action pinned to the SHAs `ci.yml` and `workflow-lint.yml` already use. The job ends with `git checkout -- .` because the agent starts from this checkout and `make fmt` rewrites five generated files on a clean tree.

Fixes #892
Part of #889

I have:

- [x] Associated this change with a known KubeFleet Issue (Bug, Feature, etc).
- [x] Run `make reviewable` to ensure this PR is ready for review. Not applicable: no Go changes. `actionlint`, `codespell`, and `markdown-link-check` clean.

### How has this code been tested

- `actionlint` on the new workflow; action SHAs cross-checked against `ci.yml` and `workflow-lint.yml`; the workflow's `pull_request` trigger on its own path runs it on this PR.
- An independent fact-check of every claim in the table and the workflow against the repository. It caught that `make reviewable` alone never installs `controller-gen` (now covered by `make generate manifests`), and that the Squad row needed to explain what Squad is (reworded); it stays present tense because #895 merges first.
- One thing the fact-check surfaced that this PR does not fix, filed as a note for maintainers: on a clean `main`, `make fmt` (part of `make reviewable`) rewrites five `zz_generated.deepcopy.go` files because `goimports` wants an alias on `k8s.io/api/core/v1` imports, and CI never runs `make fmt`, so the drift is invisible until a contributor commits it by accident.

### AI usage disclosure

Prepared with an AI coding assistant; the author reviewed every line and is responsible for them.

### Special notes for your reviewer

The tool table's claims about third-party behaviour (Gemini CLI folder trust, Aider config, Visual Studio reading only the Copilot file) come from those tools' documentation as of 2026-09; the table carries that date so it can be re-verified.