### PR TITLE
docs: add repo-specific agent skills including a review rubric

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -1,0 +1,43 @@
+# Skills
+
+Skills are on-demand procedures that AI coding assistants load when a task matches their description. They extend [`AGENTS.md`](../../AGENTS.md), which every assistant loads always, with the multi-step jobs that would bloat it: CVE remediation, e2e failure analysis, API changes, releases, backports, and the maintainers' review rubric.
+
+Tools that implement the [Agent Skills specification](https://agentskills.io) read this directory; `.claude/skills` is a symlink here for the one mainstream tool that looks there instead. That symlink and the one-line `CLAUDE.md` are the only vendor-specific files this directory needs; `.github/copilot-instructions.md` is a pointer to `AGENTS.md` for the same reason. A new shim is added only when a tool that contributors here actually use does not read the standard. The maintainers' review rubric is the `review` skill rather than a per-tool agent, so every tool reads one file. Squad's own skills live separately in `.github/skills/` and are managed by `squad upgrade`.
+
+## When to add a skill
+
+Add one when a procedure is too long for a line in `AGENTS.md`, is only needed for a specific kind of task, and has been explained to a contributor at least twice. Do not add one for a one-line rule (put it in `AGENTS.md`), for something every session needs (same), or for a library's usage (link the docs).
+
+## Layout
+
+```text
+.agents/skills/
+  <name>/
+    SKILL.md        required; frontmatter plus the procedure
+    <other>.md      optional references, linked from SKILL.md, one level deep
+```
+
+Keep the directory flat: some tools do not discover nested skill folders.
+
+## Frontmatter
+
+```yaml
+---
+name: e2e-failure-analysis            # lowercase, hyphens, must equal the directory name
+description: One paragraph. What it does, the concrete triggers ("Use when ..."), and what it is not for if a neighbouring skill is close. This is what the assistant matches on.
+license: Apache-2.0
+metadata:
+  author: The KubeFleet Authors
+---
+```
+
+`name` and `description` are required by the [Agent Skills specification](https://agentskills.io/specification); the rest is optional, and the `skills-ref` validator (below) rejects fields the specification does not list. A skill that only a human may start (the `release` skill) says so in its description and its first paragraph, since there is no portable field for it. Names must not collide with the skills under `.github/skills/`.
+
+## Writing one
+
+- Under 200 lines. Commands copied from the `Makefile` or a workflow, never typed from memory; a wrong command in a skill becomes a wrong action in every future session.
+- Structure as numbered steps. Verification comes before any step that pushes, tags, labels, or opens a PR, and that step starts with a stop for human confirmation.
+- Point at `AGENTS.md` for a rule it already states; restate only the part a reader of this skill acts on differently (the exception, the command, the trap).
+- Say where the source of truth is (a workflow, a Makefile target, a doc) so a reader can check the skill when it ages.
+- Validate before opening a PR: `npx -y skills-ref validate .agents/skills/<name>`. CI does not run it; it is a manual step.
+- A skill change is a `docs:` PR with `release-note/docs`.

--- a/.agents/skills/api-change/SKILL.md
+++ b/.agents/skills/api-change/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: api-change
+description: Add, change, or deprecate a field on a KubeFleet CRD under apis/ (ClusterResourcePlacement, ResourcePlacement, MemberCluster, overrides, staged update run, and the rest) and regenerate everything that depends on it. Use for any edit to a *_types.go file, a kubebuilder marker, or a CRD's validation.
+license: Apache-2.0
+metadata:
+  author: The KubeFleet Authors
+---
+
+# API change
+
+An API edit touches the type, its DeepCopy, the CRD YAML, the chart symlink, and the tests here, plus the website docs and downstream consumers outside. Missing any one fails CI or, worse, ships a hub that older member agents cannot talk to. Read [`AGENTS.md`](../../../AGENTS.md) and the version-skew section of [`VERSIONING.md`](../../../VERSIONING.md) first.
+
+## 1. Decide the version and the bump
+
+- API groups: `placement.kubernetes-fleet.io` (`apis/placement/v1`, `v1beta1`, `v1alpha1`), `cluster.kubernetes-fleet.io` (`apis/cluster/v1`, `v1beta1`), and the newer `placement.kubefleet.dev` (`apis/kubefleet.dev/placement/v1alpha1`; part of FEP-0001, the in-progress enhancement proposal tracked from issue #834). There is no conversion webhook: a field that exists in one served version but not the storage version is silently dropped on write. Check which versions the type has and which is `storage: true` in the generated CRD before editing one.
+- Per `VERSIONING.md`: a new CRD, a new field, or a new enum value is a **minor** bump; a removed or renamed field, tightened validation, or changed default is a **breaking** minor change and needs `release-note/breaking`. Say which in the PR.
+- If the type is exchanged between hub and member (`Work`, `AppliedWork`, `InternalMemberCluster`), the change must be readable by an agent one minor older or newer. New fields must be optional with a safe zero value; never repurpose an existing field.
+
+## 2. Edit the type
+
+- `ClusterResourcePlacement` and `ResourcePlacement` share `PlacementSpec` and `PlacementStatus` in `apis/placement/<version>/clusterresourceplacement_types.go`, so one field added there lands in both CRDs; the same holds for the other cluster/namespace pairs. Check which types embed the struct you edit.
+- Doc comment on every field, complete sentences. Add the kubebuilder markers the neighbours use: `+optional`, `+kubebuilder:default`, `+kubebuilder:validation:Enum`, `+kubebuilder:validation:XValidation` for CEL rules.
+- Immutable fields carry an `XValidation` rule with `self == oldSelf`; look at an existing one in the same file and copy its message style.
+- Every new `.go` file starts with the header in `hack/boilerplate.go.txt`.
+
+## 3. Regenerate
+
+```sh
+make generate      # zz_generated.deepcopy.go
+make manifests     # config/crd/bases/*.yaml
+make crd-verify    # the chart CRD directories must cover every base CRD
+```
+
+A new CRD needs a symlink in `charts/hub-agent/templates/crds/` or `charts/member-agent/templates/crds/` pointing at `../../../../config/crd/bases/<file>`; existing entries are symlinks, so follow the pattern. Exception: CRDs in the `placement.kubefleet.dev` group are deliberately excluded from `crd-verify` and not yet shipped in the charts while FEP-0001 is in progress; do not add symlinks for them unless the issue you are working says to. Commit the regenerated files with the type change. Never hand-edit them.
+
+## 4. Test
+
+- Validation: `test/apis/placement/v1beta1` and `test/apis/cluster/{v1,v1beta1}` run against envtest and exercise CEL rules and defaults (placement has no v1 suite; add cases against the storage version). Add a case for every new rule, including the rejection path.
+- Behaviour: the controller that reads the field gets a table-driven unit test; scheduler-visible fields get a case in `test/scheduler`. Follow the conventions in `AGENTS.md` (`cmp.Diff`, `want`, new Ginkgo `Context`).
+- Run `make reviewable && make local-unit-test && make integration-test`.
+- If the field changes what members see, check the `upgrade.yml` jobs on the PR (`hub-agent-backward-compatibility`, `member-agent-backward-compatibility`, and `full-backward-compatibility`); they run automatically for any PR that touches non-documentation files, and there is no local shortcut.
+
+## 5. Prepare to ship
+
+Stop here; the author opens the PR (`AGENTS.md`, Workflow). What they need:
+
+- PR title `feat:` (new field, label `release-note/feature`) or `interface:` (contract change, label `release-note/chore` per `CONTRIBUTING.md`); add `release-note/breaking` when step 1 said so.
+- PR body: the field, its default, its validation, the version-skew reasoning from step 1, and example YAML.
+- User docs live in the `kubefleet-dev/website` repository (API reference and concept pages); prepare the docs change for the author to open alongside and link.
+
+## Traps
+
+- `make manifests` only regenerates `config/crd/bases`; the charts pick the change up through symlinks, so a copied (not linked) CRD file silently goes stale.
+- Adding a field to `v1beta1` without `v1` (or the reverse) compiles fine and the value is silently dropped whenever the object is stored in the other version.
+- `+kubebuilder:default` on a field that older agents send empty changes behaviour on upgrade; call it out.

--- a/.agents/skills/backport/SKILL.md
+++ b/.agents/skills/backport/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: backport
+description: Backport a fix that is already merged to main onto a supported release-0.Y branch, using the cherry-pick label automation or, when it refuses, a manual cherry-pick that keeps the DCO sign-off. Use when asked to backport, when a cherry-pick/0.Y label produced a failure comment, or when a fix must ship in a patch release.
+license: Apache-2.0
+metadata:
+  author: The KubeFleet Authors
+---
+
+# Backport
+
+Backports are cherry-picks of a commit that is already on `main`, never direct PRs against a release branch. `backport.yml` does the common case; this skill covers using it and the manual path when it declines. Read the rules in [`CONTRIBUTING.md`](../../../CONTRIBUTING.md#backporting-to-release-branches).
+
+## 1. Use the automation
+
+Agree the target minors with the human and ask them to add one `cherry-pick/0.Y` label per target minor to the original PR, before or after it merges; each label makes `backport.yml` push a branch and open a PR on their behalf. On merge, or on labeling an already-merged PR, the workflow cherry-picks the squash commit onto `release-0.Y`, pushes a `cherry-pick/0.Y/pr-<N>` branch, and opens the backport PR.
+
+Which minors are supported is in `SECURITY.md` (`N` and `N-1`). Do not label older branches. If `git ls-remote --heads origin 'release-*'` returns nothing, no release branch has been cut yet and there is nothing to backport to; say so rather than creating a `cherry-pick/0.Y` label.
+
+## 2. Read its failure comment
+
+The workflow comments on the original PR when it cannot proceed; the first and third cases leave the run green, a conflict fails it. Three causes:
+
+| Comment says | Why | What to do |
+| --- | --- | --- |
+| Not a squash merge | It only picks single squash commits | Manual path below, one commit at a time |
+| Cherry-pick did not apply cleanly | Conflict with the release branch | Manual path below; resolve, then push your own branch |
+| Branch `release-0.Y` not found | The minor has no release branch yet | Cut it first (see the `release` skill) or pick a supported minor |
+
+Re-adding the label retries the automation after you fix the cause. The bot's `cherry-pick/0.Y/pr-<N>` branches are force-pushed on retry, so never do manual work on one.
+
+## 3. Manual cherry-pick
+
+```sh
+git fetch origin
+git checkout -b backport-<N>-0.Y origin/release-0.Y
+git cherry-pick -x <squash sha>          # -x adds "(cherry picked from commit ...)"
+# resolve conflicts if any, then:
+GIT_EDITOR=true git cherry-pick --continue   # keeps the original message without opening an editor
+```
+
+Rules that hold on the manual path:
+
+- The cherry-picked commit keeps the original author's `Signed-off-by`. If you had to rewrite the change substantially, the human doing the backport adds their own with `git commit -s --amend`; a tool never adds one.
+- Same PR-title prefix as the original, same `release-note/*` label, and `Fixes #<issue>` so the patch notes link the bug.
+- Only the fix. If the conflict resolution needs code that is not on `release-0.Y`, that is a sign the fix cannot be backported as-is; say so instead of pulling in extra commits.
+
+## 4. Verify
+
+`make reviewable` and `make local-unit-test` on the release branch; the tool versions pinned there may differ from `main`, so run them from the checkout, not from memory.
+
+## 5. Hand the branch to the author
+
+Stop here and show the human the resolved diff; pushing and opening the PR are theirs (`AGENTS.md`, Workflow). What they run:
+
+```sh
+git push -u origin backport-<N>-0.Y
+gh pr create --base release-0.Y --title "<original title> [backport release-0.Y]" \
+  --label "release-note/<same as original>" --body "Backport of #<N>. Fixes #<issue>."
+```
+
+Confirm the PR's base is `release-0.Y` and CI runs there before asking for review.

--- a/.agents/skills/cve-remediation/SKILL.md
+++ b/.agents/skills/cve-remediation/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: cve-remediation
+description: Fix the HIGH/CRITICAL CVEs reported by the weekly Trivy scan issue (one per ISO week, labels security and trivy). Use when assigned or pointed at that issue, or when asked to remediate a container-image or Go-module vulnerability in hub-agent, member-agent, or refresh-token.
+license: Apache-2.0
+metadata:
+  author: The KubeFleet Authors
+---
+
+# CVE remediation
+
+`trivy.yml` scans the three published images every day at 06:00 UTC and keeps one open issue per ISO week with a table of findings: CVE, severity, package, installed version, fixed version, image. This skill turns that table into one PR. Read [`AGENTS.md`](../../../AGENTS.md) first; its rules apply.
+
+## 1. Classify every row
+
+Each finding is one of three kinds, and each kind has exactly one fix site:
+
+| Package looks like | Kind | Fix |
+| --- | --- | --- |
+| `libssl3t64`, `libc6`, `zlib1g`, any Debian package | OS package in the runtime base image | Bump the `gcr.io/distroless/base:nonroot@sha256:...` digest in all three `docker/*.Dockerfile` |
+| `golang.org/x/...`, `github.com/...`, `k8s.io/...` | Go module | `go get <module>@<fixed version>` then `go mod tidy` |
+| `stdlib`, `go` | Go standard library | Bump the builder image tag `mcr.microsoft.com/oss/go/microsoft/golang:<ver>` in all three Dockerfiles, and the `go` directive in `go.mod` if the patch is newer |
+
+The scan runs with `ignore-unfixed`, so every row it reports has a fix available.
+
+## 2. Apply the fix
+
+Runtime base image: Dependabot's `docker` ecosystem bumps this digest on its weekly schedule. Check first with `gh pr list --repo kubefleet-dev/kubefleet --label docker --state open`; if Dependabot already proposes the digest, merge or rebase that PR instead of duplicating it. Otherwise resolve the current digest and replace it in every Dockerfile. The three files must end up identical on that line.
+
+```sh
+docker buildx imagetools inspect gcr.io/distroless/base:nonroot --format '{{ .Manifest.Digest }}'
+grep -n 'distroless/base:nonroot@' docker/*.Dockerfile
+```
+
+Go module: `go get <module>@<fixed version> && go mod tidy`. Tidy may advance related `golang.org/x/*` modules; that is expected. Do not downgrade anything.
+
+Builder image: the tag is `<go version>-<revision>`; pick the newest revision for the patch the issue names. Dependabot bumps only the Dockerfile tag; the same Go patch is also pinned as `GO_VERSION` in `ci.yml`, `code-lint.yml`, `release.yml`, `upgrade.yml`, and `trivy.yml`, and as the `go` directive in `go.mod`, and those do not move with it (`grep -rn "GO_VERSION:" .github/workflows` lists them). For a stdlib CVE move all of them yourself, as PR #836 did.
+
+## 3. Verify
+
+```sh
+make reviewable
+make local-unit-test
+trivy fs --severity HIGH,CRITICAL --scanners vuln .      # module findings, no image build needed
+```
+
+For image findings, building locally needs Docker, and the target first sets up a buildx builder with two privileged QEMU containers (`setup-qemu`). Pass `OUTPUT_TYPE=type=docker`; without it the target pushes to the registry: `make docker-build-hub-agent OUTPUT_TYPE=type=docker`, then `trivy image --severity HIGH,CRITICAL ghcr.io/hub-agent:$(git rev-parse --short=7 HEAD)`. If you cannot build, say so in the PR; CI rebuilds and the next scheduled scan re-checks.
+
+## 4. Prepare the PR for the human to open
+
+Stop here and hand the branch to the author; opening the PR and applying labels are theirs (`AGENTS.md`, Workflow). What they need:
+
+- Title `fix: address trivy CVEs found in <ISO week>` or `fix: remediate <CVE> in <package>`.
+- Labels `release-note/fix` plus the additive `release-note/security`, and, once a `release-0.Y` branch exists, `cherry-pick/0.Y` for each supported one (support window in `SECURITY.md`; the `backport` skill covers what the label does).
+- Body: one bullet per finding with the version or digest moved from and to, and `Fixes #<issue>`.
+
+## Known shapes
+
+- Two shapes recur: a builder-image bump plus the `GO_VERSION` pins for Go standard-library CVEs (PR #836), and a distroless digest bump (Dependabot's #878 is the precedent) plus one `golang.org/x/*` bump for the rest (PR #887). Check a cited PR's state before treating it as precedent.
+- The scan reports each OS CVE three times, once per image. That is one fix, not three.
+- Trivy issues are superseded weekly; if the issue you were given is closed as superseded, work from the newer one.

--- a/.agents/skills/e2e-failure-analysis/SKILL.md
+++ b/.agents/skills/e2e-failure-analysis/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: e2e-failure-analysis
+description: Find the root cause of a failing or flaky KubeFleet e2e job from a GitHub Actions run, a PR number, or downloaded logs. Use when a CI e2e job fails, a test is suspected flaky, or someone asks why a placement, rollout, or Work never reached the expected state. Also covers inspecting a live hub and member cluster.
+license: Apache-2.0
+metadata:
+  author: The KubeFleet Authors
+---
+
+# E2E failure analysis
+
+Work backwards from the assertion that failed to the log line that explains it. Never stop at the first error message; for each finding ask "what caused this?" until the answer is backed by a timestamped log line. Read [`AGENTS.md`](../../../AGENTS.md) first for the pipeline the objects flow through.
+
+## 1. Find the failing job
+
+`ci.yml` runs four e2e jobs in a matrix named by `customized-settings`: `default`, `resourceplacement`, `joinleave`, `custom`. From a PR:
+
+```sh
+gh pr checks <pr> --repo kubefleet-dev/kubefleet          # failing jobs with their URLs
+gh run list --repo kubefleet-dev/kubefleet --commit <sha> --json databaseId,name,conclusion,url
+```
+
+## 2. Collect the evidence
+
+```sh
+gh api --allow-escape-sequences repos/kubefleet-dev/kubefleet/actions/jobs/<job_id>/logs \
+  | sed 's/\x1b\[[0-9;]*m//g' > job.log     # the Ginkgo output; gh refuses the ANSI colours without the flag
+gh run download <run_id> --repo kubefleet-dev/kubefleet -n e2e-logs-<setting> -D e2e-logs-<setting>   # agent logs from every cluster
+```
+
+The artifact is what `make collect-e2e-logs` (`test/e2e/collect-logs.sh`) produced. Without `-D` a single artifact extracts into the current directory; with it the layout is:
+
+```text
+e2e-logs-<setting>/<timestamp>/
+  hub/nodes/<node>/hub-agent-*.log          hub agent; the failure window is often in a rotated file named hub-agent-*.log.<timestamp>.log, so grep all of them
+  cluster-1/nodes/<node>/member-agent-*.log  one directory per member (cluster-1, cluster-2, cluster-3)
+  hub-debug-info.txt, cluster-N-debug-info.txt   pod status and events in fleet-system
+  summary.txt
+```
+
+Locally, the same layout appears under `test/e2e/logs/<timestamp>/` after `make collect-e2e-logs`.
+
+## 3. Find the failure in the Ginkgo log
+
+```sh
+grep -n '\[FAILED\]\|Summarizing' job.log
+```
+
+For the failing spec, extract the assertion (file:line and the timeout), the `STEP:` timeline with timestamps, and the timeline of the previous spec that shared resources (same placement, namespace, or member cluster). Flakes are usually the previous spec's cleanup racing the current spec's setup. A readiness wait that passes in milliseconds instead of seconds means it read stale state. A `Consistently` that fails well under a second right after a member-cluster change usually means an unrelated scheduling cycle ran; grep the hub log for `Enqueueing placement for scheduler processing` and `Scheduling cycle starts` in that window to find the trigger.
+
+## 4. Trace backwards through the agents
+
+The object that never reached the expected state has one owning controller. Grep that controller's log for the object name and count the hits: one hit and no retry means the controller gave up, so check its requeue logic in `pkg/controllers/<name>` before claiming it "should self-heal".
+
+| Symptom | Owning controller | Log |
+| --- | --- | --- |
+| Placement never scheduled, `Scheduled` false | scheduler (`pkg/scheduler`) | `hub-agent-*.log`, search the placement name and `scheduling cycle` |
+| Binding stuck, rollout never advanced | rollout (`pkg/controllers/rollout`) | hub agent |
+| No `Work` in the member's namespace on the hub | work generator (`pkg/controllers/workgenerator`) | hub agent |
+| `Work` exists but `AppliedWork` or `Applied`/`Available` condition missing | work applier (`pkg/controllers/workapplier`) | `member-agent-*.log` on that member |
+| Member shows unhealthy or heartbeats stop | `internalmembercluster` controller | member agent, then hub `membercluster` controller |
+
+Build a timeline of writes to the state the controller read, with exact timestamps, and compare it with the test's `STEP:` timeline to find the window where the state was stale or wrong. Member agents refresh properties, resource usage, and the namespace list every heartbeat period, and any change re-enqueues every placement; the `Calling property provider` line in the member-agent log gives the exact times.
+
+## 5. Inspect a live cluster
+
+With a kubeconfig for the hub (`kind export kubeconfig --name hub` locally):
+
+```sh
+kubectl get clusterresourceplacement <name> -o yaml | yq .status         # conditions and per-cluster status
+kubectl get clusterresourcesnapshot,clusterschedulingpolicysnapshot \
+  -l kubernetes-fleet.io/parent-CRP=<name>,kubernetes-fleet.io/is-latest-snapshot=true
+kubectl get clusterresourcebinding -l kubernetes-fleet.io/parent-CRP=<name> -o wide
+kubectl get work -A -l kubernetes-fleet.io/parent-CRP=<name>              # one per target cluster, in that member's hub namespace
+kubectl get membercluster -o wide                                          # join state, heartbeat, capacity
+```
+
+On a member (`kind export kubeconfig --name cluster-1`): `kubectl get appliedwork` and `kubectl -n fleet-system logs deploy/member-agent`. Namespace-scoped placements use `resourceplacement`, `resourcebinding`, and the same labels.
+
+## 6. Report
+
+An evidence chain, from the error backwards: the assertion (file:line), what it means, the owning controller's decision with log lines and timestamps, the stale or wrong state it read, the root cause, and why it did not self-heal (checked against the code). Quote log lines verbatim. Then say whether it is a product bug, a test race, or an infrastructure failure, and what the fix is.
+
+## 7. Improve this skill
+
+If you found a failure pattern, log location, or command this file lacks, propose an addition. Keep it generic (the pattern, not this test's names and timestamps), show it to the user, and let them decide whether to commit it.

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: release
+description: Cut a KubeFleet release or release candidate, or check that a release that already ran is complete. Only when a human explicitly asks for a release. Covers the tag grammar, what release.yml and chart.yml produce, the release-notes labels, the release branch, and the notice to downstream consumers.
+license: Apache-2.0
+metadata:
+  author: The KubeFleet Authors
+---
+
+# Release
+
+**Do not start this procedure on your own initiative.** Tags and releases are public and cannot be undone. Only follow it when a human has explicitly asked for a release or a release check, and stop before any `git push` or `gh release` command unless they confirmed the exact tag or branch name.
+
+Two human actions produce a release: push a tag, then review the draft. Everything else is automation whose outputs this skill tells you to verify. Read [`VERSIONING.md`](../../../VERSIONING.md) before starting; it decides whether this is a patch or a minor.
+
+## 1. Before tagging
+
+- Pick the version with the table in `VERSIONING.md`. Any new CRD field or changed placement semantics since the last tag means a minor.
+- Confirm every merged PR since the previous tag carries a `release-note/*` label; unlabeled PRs land under "Other Changes" and breaking changes without `release-note/breaking` are invisible. Check with `gh pr list --repo kubefleet-dev/kubefleet --state merged --limit 200 --search "merged:>YYYY-MM-DD" --json number,title,labels`.
+- CI on `main` is green, including `upgrade.yml` (the version-skew jobs).
+- For the first release candidate of a minor, cut the release branch from the same commit: `git branch release-0.Y <sha> && git push origin release-0.Y`. `backport.yml` and `CONTRIBUTING.md` assume this branch exists; `git ls-remote --heads origin 'release-*'` shows whether any has been cut, and if none has, confirm the convention with the maintainers first.
+
+## 2. Tag
+
+Only two formats are accepted; `setup-release.yml` rejects anything else:
+
+```text
+vMAJOR.MINOR.PATCH          v0.5.0
+vMAJOR.MINOR.PATCH-rc.N     v0.5.0-rc.1
+```
+
+```sh
+git tag -a <tag> <sha> -m <tag> && git push origin <tag>
+```
+
+Signed tags are not required today; if the release-signing work lands, this line changes to `git tag -s`.
+
+`release.yml` also accepts `workflow_dispatch` with the tag as input, for re-running a release whose tag already exists.
+
+## 3. What the tag triggers
+
+| Workflow | Produces | Verify |
+| --- | --- | --- |
+| `release.yml` → `build-and-publish` | `ghcr.io/kubefleet-dev/kubefleet/{hub-agent,member-agent,refresh-token}` for `linux/amd64` and `linux/arm64`, tagged `v0.5.0` and, for GA only, the short alias `0.5.0` | `docker buildx imagetools inspect ghcr.io/kubefleet-dev/kubefleet/hub-agent:v0.5.0` shows both platforms; inspect the short alias too on a GA release |
+| `release.yml` → `publish-crds` | A GitHub release created as a **draft**, with the CRD tarball and its `.sha256` from `make crd-package`, then flipped to published | Release page shows the two assets and is no longer a draft |
+| `chart.yml` (GA tags only, `-rc` tags are filtered out) | The Helm charts in the GitHub Pages index (`publish-github-pages` job) and as OCI artifacts under `ghcr.io/kubefleet-dev/kubefleet/charts` (`publish-oci` job, `make helm-push`) | `helm repo add kubefleet https://kubefleet-dev.github.io/kubefleet/charts && helm repo update && helm search repo kubefleet` lists the new version; `helm show chart oci://ghcr.io/kubefleet-dev/kubefleet/charts/hub-agent --version <ver>` resolves |
+
+Release notes are generated from PR labels by `.github/release.yml`. Read the draft once for wrong categories and for anything that needs a manual upgrade note, then edit the release text; do not edit labels retroactively to fix notes.
+
+## 4. After publishing
+
+- A release candidate stays marked pre-release; a GA release must not be.
+- Update the support window in `SECURITY.md` if a minor dropped out of `N` and `N-1`.
+- Draft the downstream notice and hand it to the human to send; do not post to other repositories yourself. `Azure/fleet` mirrors this repository and publishes it as `go.goms.io/fleet`; `Azure/fleet-networking` and other consumers bump that module.
+- Close the release tracking issue if one exists.
+
+## If something failed
+
+`release.yml` is safe to re-run with `workflow_dispatch` and the same tag: image pushes are idempotent, and a release the run created is only flipped out of draft after every asset uploads. If the draft already existed before the re-run, the run uploads the assets but leaves it a draft and prints a warning; publish it by hand. Never delete and re-push a tag that anyone may have pulled; cut the next patch instead.

--- a/.agents/skills/review/SKILL.md
+++ b/.agents/skills/review/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: review
+description: Review a diff or pull request the way KubeFleet's maintainers do, read-only. Checks test conventions, controller and scheduler patterns, generated-file drift, cluster- versus namespace-scoped CRUD, hub/member version-skew impact, and PR hygiene. Use when asked to review a KubeFleet change, to self-review a branch before pushing (review first, then fix as the author), or when asked what a maintainer would flag.
+license: Apache-2.0
+metadata:
+  author: The KubeFleet Authors
+---
+
+# Review
+
+Review a change the way KubeFleet's maintainers do. This is a read-only procedure: do not edit files, and use the shell only for `git diff`, `git log`, `gh pr diff`, `gh pr view` and `gh issue view` (title, labels, body, linked issue), and the read-only make targets named below. Read [`AGENTS.md`](../../../AGENTS.md) first; every rule there is a review criterion.
+
+For a diff that touches no Go (Markdown, YAML, JSON, workflows), skip the Go-specific checks and say so; hygiene still applies. For a diff under `.squad/`, `.github/skills/`, or the `squad-*` workflows, also check whether `squad upgrade` would revert it (`AGENTS.md`, Gotchas).
+
+Report findings ordered by severity, each with file:line, what is wrong, why it matters here, and the concrete fix. Say "no findings" for a category you checked and found clean; do not pad. Quote the maintainers' convention you are applying so the author can look it up.
+
+## What to check
+
+**Tests**
+
+- New behaviour has a test in the same PR; a bug fix has a test that fails without the fix.
+- Comparisons use `cmp.Equal` / `cmp.Diff`, whole structs in one shot. Flag assertion libraries and field-by-field checks.
+- Expected values are named `want`/`wanted`, the actual value prints first, and diffs are labelled `(-want +got)`.
+- Table-driven unit tests; Ginkgo cases added as a new `Context` that reuses the suite's setup.
+
+**Controllers and scheduler**
+
+- Reconcile shape: fetch, check deletion, defaults, reconcile, requeue. Status written through the status subresource; events recorded for user-visible outcomes.
+- Errors wrapped with `pkg/utils/controller` constructors so retry semantics are right; flag bare `return err` on API-server or user errors.
+- Namespace-scoped objects (`ResourcePlacement`, `ResourceBinding`, `ResourceSnapshot`) carry `Namespace` in every `NamespacedName`; the `Cluster`-prefixed twins never do.
+- Scheduler plugins implement the framework interfaces in `pkg/scheduler/framework/interface.go` and read shared state through `CycleStatePluginReadWriter` (`cyclestate.go` in the same package).
+
+**APIs and generated files**
+
+- Any edit under `apis/` comes with regenerated `zz_generated.deepcopy.go` and `config/crd/bases`, and `make crd-verify` passes (new CRDs are symlinked into the charts).
+- No hand edits to generated files.
+- New fields are optional with safe zero values, documented, and validated with markers or CEL; immutable fields have an `XValidation` rule.
+- Anything exchanged between hub and member (`Work`, `AppliedWork`, `InternalMemberCluster`) stays readable one minor older and newer, per `VERSIONING.md`. Ask for the skew reasoning if the PR does not give it.
+
+**Hygiene**
+
+- Style and boilerplate per `AGENTS.md` (header, trailing newline, comment punctuation).
+- PR title uses an allowed prefix; a `release-note/*` label is set; the PR links an issue; the change is focused, with no unrelated reformatting.
+- No `Signed-off-by` written by a tool and no AI tool listed as `Co-authored-by`; AI assistance, if any, is disclosed in the PR description.
+
+## How to work
+
+1. `git diff --stat` to see the shape, then read the full diff.
+2. For each touched controller or type, open the file and the nearest test file; check the conventions above against both.
+3. If the author has not stated the result, run `make vet lint staticcheck` (these do not modify files; `make reviewable` does, through `fmt` and `go mod tidy`). Never run e2e.
+4. Write the report. Finish with one line: ready to merge, ready after the listed fixes, or needs a design conversation.

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,7 @@ status flows back: AppliedWork → Work → Binding → Placement
 ## Where to look
 
 - [CONTRIBUTING.md](CONTRIBUTING.md): DCO, PR titles, release-note labels, backports.
+- `.agents/skills/`: step-by-step procedures (API change, backport, CVE remediation, e2e failure analysis, release, review) that assistants load on demand and people can read.
 - [VERSIONING.md](VERSIONING.md), [SECURITY.md](SECURITY.md), [ROADMAP.md](ROADMAP.md).
 - User documentation: <https://kubefleet.dev/docs/> (source in `kubefleet-dev/website`). Runnable manifests in `examples/`.
 - `.github/.copilot/`: the maintainers' domain knowledge and breadcrumbs (per-task design notes). The team tracks its non-trivial work there under the protocol in [`.github/copilot-instructions.md`](.github/copilot-instructions.md), whatever tool it uses; external contributors are not expected to write one, and "plan approval" for them is agreement on the issue.


### PR DESCRIPTION
### Description of your changes

Stacked on #894 (base branch `docs/agents-md`).

Six repository-specific skills under `.agents/skills/`, in the [Agent Skills](https://agentskills.io) format, with `.claude/skills` symlinked to the same directory so one copy serves every tool:

| Skill | What it encodes |
| --- | --- |
| `cve-remediation` | The weekly Trivy issue into one PR: classify each row (OS package, Go module, Go stdlib), the fix site for each, the `GO_VERSION` pins that move with the builder image, verification, labels |
| `e2e-failure-analysis` | From a failing CI job to a root cause: `e2e-logs-<setting>` artifacts and their layout, the controller that owns each symptom, the `kubectl` recipes for a live hub and member, an evidence-chain report |
| `api-change` | Type edit → `make generate manifests` → chart symlink → validation tests → version-skew reasoning → labels → docs PR, including the `placement.kubefleet.dev` group that `crd-verify` excludes on purpose |
| `release` | Tag grammar, what `release.yml` and `chart.yml` produce and how to verify each, re-run behaviour, the downstream notice. Human-invoked only, stated in prose because the specification has no field for it |
| `backport` | The `cherry-pick/0.Y` automation, its three failure comments, and the manual path that keeps the DCO sign-off, with a human gate before push |
| `review` | The maintainers' read-only review rubric: test conventions, controller and scheduler patterns, generated-file drift, scoped CRUD, version-skew impact, PR hygiene. A skill rather than a per-tool agent so Claude Code, Copilot, and Codex all read the same file |

Also `.agents/skills/README.md`: when something is a skill versus an `AGENTS.md` line, frontmatter, the flat-directory rule, validation, and the rule that a vendor-specific shim is added only for a tool contributors here use that does not read the standard.

Not included on purpose: generic Go style, generic controller patterns, or a skill for using KubeFleet as a product; those belong to the linter, `AGENTS.md`, and the docs site respectively.

Fixes #893
Part of #889

I have:

- [x] Associated this change with a known KubeFleet Issue (Bug, Feature, etc).
- [x] Run `make reviewable` to ensure this PR is ready for review. Not applicable: no Go changes. `codespell` and `markdown-link-check` clean; all six skills pass `npx -y skills-ref validate`.

### How has this code been tested

- Every command, path, label, workflow name, artifact name, and behavioural claim in the five skills was checked against the `Makefile`, the workflows, and the source by two independent review passes. They caught and I fixed: a "local" image build that would have pushed to the registry (`OUTPUT_TYPE` defaults to `type=registry`), the artifact download path, `interface:` mapping to `release-note/chore`, the missing third API group, tag signing presented as policy, a `gh pr list` that truncates at 30, and ungated pushes in the backport skill.
- Discovery verified live in three tools: Copilot CLI and Codex CLI list the skills from `.agents/skills/`; a tool that reads `.claude/skills` lists them through the symlink.
- Four skills were exercised on real inputs. `api-change`: an optional field added to `PlacementSpec` on a scratch branch went through `make generate manifests crd-verify` cleanly, appeared in both the CRP and RP base CRDs and in the chart through the symlink, and was reverted; that run added the shared-`PlacementSpec` note to the skill. `cve-remediation`: its `trivy fs`, `docker buildx imagetools inspect`, and `gh pr list --label docker` commands all ran and returned the live finding, the current digest, and the open-PR check. And two end to end: `review` on PR #895 (it produced findings and a verdict a maintainer agreed with), and `e2e-failure-analysis` on the failed `e2e-tests (joinleave)` job of run 34282936322, where it traced the failure to a scheduler/watcher semantic conflict with timestamped log lines (filed separately). The run exposed that `gh api .../logs` needs `--allow-escape-sequences`, now in the skill, and contributed three failure patterns to it.
- The review skill is read-only by instruction; its shell use is scoped to `git diff`, `gh pr diff`, and the non-writing `make vet lint staticcheck`.

### AI usage disclosure

Prepared with an AI coding assistant; the author reviewed every line and is responsible for them.

### Special notes for your reviewer

The README's "tools that implement the specification" wording replaces a named tool list on purpose so it does not rot.