### PR TITLE
fix: judge the object a tombstone wraps rather than the tombstone

### DIFF
--- a/pkg/resourcewatcher/change_detector.go
+++ b/pkg/resourcewatcher/change_detector.go
@@ -154,6 +154,14 @@ func (d *ChangeDetector) discoverResources(dynamicResourceEventHandler cache.Res
 
 // dynamicResourceFilter filters out resources that we don't want to watch.
 func (d *ChangeDetector) dynamicResourceFilter(obj any) bool {
+	// A deletion the watch missed arrives as a tombstone wrapping the object's final state, not as
+	// the object itself. It has to be unwrapped before anything here inspects the object; filtering
+	// on the tombstone would silently drop every relist-detected deletion, since a tombstone is not
+	// a runtime object and fails the key derivation below.
+	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		obj = tombstone.Obj
+	}
+
 	key, err := controller.ClusterWideKeyFunc(obj)
 	if err != nil {
 		return false

--- a/pkg/resourcewatcher/change_detector_test.go
+++ b/pkg/resourcewatcher/change_detector_test.go
@@ -211,10 +211,22 @@ func TestChangeDetector_dynamicResourceFilter(t *testing.T) {
 			want: false,
 		},
 		{
-			// Tombstones from informer cache deletions are not unwrapped by ClusterWideKeyFunc,
-			// so the filter rejects them. The downstream delete handler unwraps tombstones separately.
-			name: "tombstone object is filtered out",
+			// A relist-detected deletion arrives as a tombstone wrapping the object's final state.
+			// The filter must judge the wrapped object, not the tombstone: rejecting tombstones
+			// wholesale would silently drop every such deletion before the delete handler -- which
+			// is what unwraps them for use -- ever saw it.
+			name: "tombstone wrapping a watched object passes the filter",
 			obj:  cache.DeletedFinalStateUnknown{Key: "default/cm", Obj: unstructuredConfigMap("default", "cm")},
+			want: true,
+		},
+		{
+			name: "tombstone wrapping an object in a skipped namespace is filtered out",
+			obj:  cache.DeletedFinalStateUnknown{Key: "kube-system/cm", Obj: unstructuredConfigMap("kube-system", "cm")},
+			want: false,
+		},
+		{
+			name: "tombstone wrapping garbage is filtered out",
+			obj:  cache.DeletedFinalStateUnknown{Key: "default/cm", Obj: "not-a-runtime-object"},
 			want: false,
 		},
 		{


### PR DESCRIPTION
### Description of your changes

A deletion the watch missed arrives at the resource watcher as a `cache.DeletedFinalStateUnknown` wrapping the object's final state. `dynamicResourceFilter` derived a key from the tombstone itself, which fails, so every relist-detected deletion was silently dropped before the delete handler (which does unwrap tombstones) ever saw it. Unwrap first, then filter on the object.

Split out of #829.

I have:

- [x] Associated this change with a known KubeFleet Issue (Bug, Feature, etc).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

Three table cases in `change_detector_test.go`: a tombstone wrapping a watched object passes, one wrapping an object in a skipped namespace is filtered, one wrapping garbage is filtered. The first fails without the fix.

