### PR TITLE
fix: parse resource property names containing dashes in cluster affinity

### DIFF
--- a/pkg/scheduler/framework/plugins/clusteraffinity/types.go
+++ b/pkg/scheduler/framework/plugins/clusteraffinity/types.go
@@ -50,11 +50,13 @@ func retrieveResourceUsageFrom(cluster *clusterv1beta1.MemberCluster, name strin
 	// `[PREFIX]/[CAPACITY_TYPE]-[RESOURCE_NAME]`; for example, the allocatable CPU capacity of a
 	// a cluster has the label name, `resources.kubernetes-fleet.io/allocatable-cpu`. Note that at
 	// this point of process, the prefix has been removed.
-	segs := strings.Split(name, "-")
-	if len(segs) != 2 || len(segs[0]) == 0 || len(segs[1]) == 0 {
+	//
+	// Only the first dash separates the capacity type; the resource name may itself contain
+	// dashes (e.g., `allocatable-ephemeral-storage`).
+	cn, tn, ok := strings.Cut(name, "-")
+	if !ok || len(cn) == 0 || len(tn) == 0 {
 		return nil, fmt.Errorf("invalid resource property name: %s", name)
 	}
-	cn, tn := segs[0], segs[1]
 
 	// Query the resource usage data.
 	var q resource.Quantity

--- a/pkg/scheduler/framework/plugins/clusteraffinity/types_test.go
+++ b/pkg/scheduler/framework/plugins/clusteraffinity/types_test.go
@@ -50,8 +50,9 @@ func TestRetrieveResourceUsageFrom(t *testing.T) {
 					corev1.ResourceMemory: resource.MustParse("40Gi"),
 				},
 				Allocatable: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("8"),
-					corev1.ResourceMemory: resource.MustParse("36Gi"),
+					corev1.ResourceCPU:              resource.MustParse("8"),
+					corev1.ResourceMemory:           resource.MustParse("36Gi"),
+					corev1.ResourceEphemeralStorage: resource.MustParse("100Gi"),
 				},
 				Available: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("2"),
@@ -69,7 +70,7 @@ func TestRetrieveResourceUsageFrom(t *testing.T) {
 		expectedToFail bool
 	}{
 		{
-			name:           "invalid property name (multiple segments)",
+			name:           "invalid property name (prefix not trimmed)",
 			propertyName:   "resources.kubernetes-fleet.io/allocatable-cpu",
 			expectedToFail: true,
 		},
@@ -110,6 +111,12 @@ func TestRetrieveResourceUsageFrom(t *testing.T) {
 			propertyName: "available-cpu",
 			cluster:      cluster,
 			wantQuantity: ptr.To(resource.MustParse("2")),
+		},
+		{
+			name:         "resource name containing dashes",
+			propertyName: "allocatable-ephemeral-storage",
+			cluster:      cluster,
+			wantQuantity: ptr.To(resource.MustParse("100Gi")),
 		},
 	}
 


### PR DESCRIPTION
### Description of your changes

`retrieveResourceUsageFrom` split a resource property name on every dash and required exactly two segments, so `allocatable-ephemeral-storage` (and any resource whose name contains a dash) was rejected as invalid. Only the first dash separates the capacity type; `strings.Cut` on it.

Split out of #820.

I have:

- [x] Associated this change with a known KubeFleet Issue (Bug, Feature, etc).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

New case in `types_test.go` for `allocatable-ephemeral-storage`; the untrimmed-prefix case still fails as before.

