### PR TITLE
fix: useCAAuth renders a colliding CA_BUNDLE placeholder by default

### DIFF
--- a/charts/member-agent/templates/deployment.yaml
+++ b/charts/member-agent/templates/deployment.yaml
@@ -103,8 +103,10 @@ spec:
             value:  "{{ .Values.config.identityKey }}"
           - name: IDENTITY_CERT
             value:  "{{ .Values.config.identityCert }}"
+          {{- if .Values.config.CABundle }}
           - name: CA_BUNDLE
             value:  "{{ .Values.config.CABundle }}"
+          {{- end }}
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/member-agent/values.yaml
+++ b/charts/member-agent/values.yaml
@@ -34,7 +34,10 @@ config:
   hubCA: <certificate-authority-data>
   identityKey: "identity-key-path"
   identityCert: "identity-cert-path"
-  CABundle: "ca-bundle-path"
+  # CABundle is a file path to a CA bundle used to verify the hub cluster's TLS certificate.
+  # Optional and mutually exclusive with hubCA: leave empty ("") to trust the hub's CA via
+  # hubCA (or the system trust store) instead.
+  CABundle: ""
   azureCloudConfig:
     cloud: ""
     tenantId: ""


### PR DESCRIPTION
## Summary

- `charts/member-agent`'s `useCAAuth` mode unconditionally rendered `CA_BUNDLE` from `values.yaml`'s non-empty placeholder default (`"ca-bundle-path"`), which collides with `HUB_CERTIFICATE_AUTHORITY` whenever an operator also sets a real `hubCA` (the common case): the member agent's `buildHubConfig` explicitly rejects having both set, since they are mutually exclusive ways of supplying the hub's CA. Setting `CABundle` to `""` didn't help either, since a present-but-empty `CA_BUNDLE` is separately rejected.
- `CA_BUNDLE` is now only rendered when `config.CABundle` is actually set, and its default is empty, so `useCAAuth` + `hubCA` works out of the box.

Found while live-testing all member-agent hub-connectivity auth modes end to end against real AKS clusters; unrelated to #913 (the vendor-neutral hub-kubeconfig PR), which I've kept scoped to just the kubeconfig mechanism.

## Test plan

- [x] `helm lint`
- [x] `helm template` with `useCAAuth=true` + `hubCA` set, no `CABundle` override — confirmed no `CA_BUNDLE` env var and no collision
- [x] `helm template` with `useCAAuth=true` + `CABundle` explicitly set — confirmed `CA_BUNDLE` still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)